### PR TITLE
Record population size, options, hardware and score milestones in evolve statistics (Issue #3422)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.9.27",
+  "version": "5.9.28",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/api/EVOLUTION.md
+++ b/docs/api/EVOLUTION.md
@@ -10,6 +10,9 @@ presets, and plateau detection.
 ## 📦 Exports documented here
 
 - `Creature.evolveDir()`, `Creature.evolveRL()` (methods on `Creature`)
+- Run-level tuning statistics (Issue #3422): `EvolveResult`,
+  `EvolveRunStatistics`, `HardwareDescriptors`, `OptionsEcho`,
+  `ScoreImprovementMilestone`, `ScoreImprovementMilestones`
 - Reinforcement-learning episode contract: `EpisodeAdapter`, `StepResult`,
   `DEFAULT_MAX_STEPS`, `DEFAULT_WALL_CLOCK_MS`, `EpisodeResult`,
   `TruncationReason`, `EvolveRLOptions`, `EvolveRLMilestone`,
@@ -41,6 +44,12 @@ async evolveDir(
   generation: number;
   phaseTimingTotals: PhaseTimingTotals;
   scorerUtilisation: ScorerUtilisationTotals;
+  // Issue #3422 — run-level tuning statistics:
+  populationSize: number;
+  finalPopulationSize?: number; // only when adaptive sizing is enabled
+  requestedOptions: OptionsEcho;
+  hardware: HardwareDescriptors;
+  scoreImprovement: ScoreImprovementMilestones;
 }>
 ```
 
@@ -59,6 +68,16 @@ async evolveDir(
   (`PhaseTimingTotals`, Issue #3210); see [Run telemetry](#run-telemetry)
 - `scorerUtilisation` — Whole-run scorer-utilisation totals split by backend
   (`ScorerUtilisationTotals`, Issue #3234); see [Run telemetry](#run-telemetry)
+- `populationSize` — Configured population size, always recorded explicitly
+  (Issue #3422); see [Tuning statistics](#tuning-statistics-issue-3422)
+- `finalPopulationSize` — Final effective population size, present **only** when
+  adaptive population sizing is enabled
+- `requestedOptions` — Echo of the caller-requested options (changes from
+  defaults; functions/non-serialisable values recorded by name with a marker)
+- `hardware` — CPU cores, total memory and host identifier for cross-machine
+  comparison
+- `scoreImprovement` — Milestone summary of the score-improvement curve
+  (25/50/75/90%)
 
 ### 📁 Dataset Format
 
@@ -178,6 +197,65 @@ interface ScorerUtilisationTotals {
   readonly creaturesPerCreatureScored: number;
   readonly batchFallbackGenerations: number;
 }
+```
+
+### Tuning statistics (Issue #3422)
+
+Every `evolve*` result also carries the inputs needed to tune throughput across
+machines — the population size, the caller-requested options, the hardware the
+run used, and a milestone summary of the score-improvement curve. Judging
+"optimal" (most variants checked per hour, best rate of score gain) happens
+downstream from these fields; the library only records the data. The signatures
+below mirror `src/creature/EvolveRunStatistics.ts`.
+
+```typescript
+// populationSize — configured population size, always recorded explicitly
+// even when it came from a default (the primary tuning variable).
+// finalPopulationSize — final effective size, present ONLY when adaptive
+// population sizing (AdaptivePopulationConfig) is enabled.
+
+// requestedOptions — echo of just the options the caller requested (changes
+// from defaults). Function/callback options are recorded as "[function]" and
+// non-serialisable values as "[unserialisable]" rather than dropped silently.
+type OptionsEcho = Record<string, unknown>;
+
+// hardware — machine descriptors for cross-machine comparison. The best-effort
+// fields degrade to null (never throw) when --allow-sys is not granted.
+interface HardwareDescriptors {
+  readonly cpuCores: number | null; // navigator.hardwareConcurrency
+  readonly totalMemoryBytes: number | null; // needs --allow-sys=systemMemoryInfo
+  readonly host: string | null; // needs --allow-sys=hostname
+}
+
+// scoreImprovement — when the run reached 25/50/75/90% of its total score
+// improvement. Computed at run end from a compact in-memory best-score
+// trajectory; no per-generation series is kept or persisted.
+interface ScoreImprovementMilestone {
+  readonly fraction: number; // 0.25 | 0.5 | 0.75 | 0.9
+  readonly generation: number;
+  readonly timeMs: number;
+  readonly scoredCount: number; // cumulative creatures scored ("variants checked")
+  readonly score: number;
+}
+interface ScoreImprovementMilestones {
+  readonly initialScore: number; // first champion (baseline)
+  readonly finalScore: number;
+  readonly totalImprovement: number; // finalScore - initialScore; 0 if no gain
+  readonly milestones: ScoreImprovementMilestone[]; // empty when no positive gain
+}
+```
+
+The improvement milestones are derived from a compact trajectory that only grows
+when the best score improves — nothing per-generation is stored:
+
+```mermaid
+flowchart LR
+    Gen[Generation cycle] -->|champion improved?| Rec{best score<br/>strictly up?}
+    Rec -- no --> Gen
+    Rec -- yes --> Point[Append trajectory point<br/>score / generation / time / scoredCount]
+    Point --> Gen
+    Gen -->|run ends| Fin[Finalise: for each of<br/>25/50/75/90% pick first<br/>point reaching the target]
+    Fin --> Out[scoreImprovement on result]
 ```
 
 ### EpisodeAdapter

--- a/docs/archive/pr-summaries/pr-summary-3422.md
+++ b/docs/archive/pr-summaries/pr-summary-3422.md
@@ -1,0 +1,98 @@
+# Record population size and options in evolve statistics (Issue #3422)
+
+## Summary
+
+The run-level result returned by `evolveDir`/`evolveDataSet`/`evolveEnv`/
+`evolveRL` (the shape GRQ-cluster persists as `result.json`) previously reported
+only `error`, `score`, `generation`, `time`, `phaseTimingTotals` and
+`scorerUtilisation` — enough to see a run's outcome but not enough to compare
+configurations across machines or judge which gives the best rate of score
+improvement. This PR adds the missing tuning inputs so each run is
+self-contained. Judging "optimal" (most variants checked per hour, best rate of
+score gain) happens downstream; the library only records the data. **Closes
+#3422.**
+
+New fields on every `evolve*` result:
+
+- **`populationSize`** — configured population size, always recorded explicitly
+  (the primary tuning variable), even when it came from a default.
+- **`finalPopulationSize`** — final effective population size, present **only**
+  when adaptive population sizing (`AdaptivePopulationConfig`) is enabled.
+- **`requestedOptions`** — echo of just the options the caller requested
+  (changes from defaults, not the full resolved config). Function/callback
+  options are recorded as `"[function]"` and non-serialisable values as
+  `"[unserialisable]"` — recorded by name with a marker rather than dropped
+  silently.
+- **`hardware`** — CPU cores, total memory and host identifier for cross-machine
+  comparison. Best-effort fields degrade to `null` (never throw) when
+  `--allow-sys` is not granted.
+- **`scoreImprovement`** — a milestone summary of the score-improvement curve:
+  the time, generation and cumulative scored-count when the run reached
+  25/50/75/90% of its total improvement. Computed at run end from a compact
+  in-memory best-score trajectory that only grows on a champion improvement — no
+  per-generation series is kept or persisted (the issue explicitly does not want
+  a large JSON).
+
+The existing throughput counters (`generation`, `scorerUtilisation` scored
+count, `time`) are unchanged; per-hour rates remain the caller's to derive.
+
+### Design
+
+The additions live in four small, single-responsibility modules so each piece is
+testable in isolation, and a shared `EvolveResult` type replaces the four
+previously-inlined return shapes (DRY):
+
+- `src/creature/EvolveHardwareDescriptors.ts` — `captureHardwareDescriptors()`
+- `src/creature/EvolveOptionsEcho.ts` — `serialiseOptionsEcho()`
+- `src/creature/ScoreImprovementMilestones.ts` — trajectory + milestone
+  finaliser
+- `src/creature/EvolveRunStatistics.ts` — `buildEvolveRunStatistics()` +
+  `EvolveResult`
+
+## Evidence
+
+Backend/library change — no web interface to screenshot. Verified via the unit
+and integration tests below (all pass) and the full `./quality.sh` gate
+(`7754 passed | 0 failed`).
+
+The score-improvement milestones are derived from a compact trajectory that only
+grows when the best score improves — nothing per-generation is stored:
+
+```mermaid
+flowchart LR
+    Gen[Generation cycle] -->|champion improved?| Rec{best score<br/>strictly up?}
+    Rec -- no --> Gen
+    Rec -- yes --> Point[Append trajectory point<br/>score / generation / time / scoredCount]
+    Point --> Gen
+    Gen -->|run ends| Fin[Finalise: for each of<br/>25/50/75/90% pick first<br/>point reaching the target]
+    Fin --> Out[scoreImprovement on result]
+```
+
+### Deno regression avoided
+
+Hardware capture uses native `navigator.hardwareConcurrency`, `Deno.hostname()`
+and `Deno.systemMemoryInfo()` rather than any Node `os` module — no Node tooling
+or dependency was introduced.
+
+## Test Plan
+
+New unit tests (pure helpers):
+
+- `test/creature/EvolveOptionsEcho.ts` — echoes serialisable options, records
+  functions/non-serialisable values by marker, skips `undefined`, deep-clones
+  nested values.
+- `test/creature/ScoreImprovementMilestones.ts` — empty/single-point/no-gain
+  edge cases, first-point-reaching-each-fraction selection, single big jump.
+- `test/creature/EvolveHardwareDescriptors.ts` — descriptor shape; best-effort
+  fields are a typed value or `null` and never throw without `--allow-sys`.
+
+New integration test:
+
+- `test/creature/EvolveRunStatistics.ts` — `evolveDataSet` records
+  `populationSize` and only the requested options; hardware descriptors present;
+  score-improvement milestones ordered and reaching their targets;
+  `finalPopulationSize` recorded when adaptive sizing is enabled.
+
+Regression coverage: existing `EvolvePhaseTimingTotals`,
+`EvolveScorerUtilisation`, `evolveRL_test`, `EvolveEnv` and the full suite
+continue to pass.

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -526,6 +526,8 @@
     "unregularised",
     "unrepresentable",
     "unscored",
+    "unserialisable",
+    "UNSERIALISABLE",
     "unsquash",
     "unsquashed",
     "upgrader",

--- a/mod.ts
+++ b/mod.ts
@@ -83,6 +83,15 @@ export type { EvolveRLOptions } from "@creature/CreatureTraining.ts";
 // Issue #3210: whole-run per-phase timing totals returned by the evolve* fns.
 export type { PhaseTimingTotals } from "@creature/PhaseTimingTotals.ts";
 export type { EvolveRLMilestone } from "@creature/EvolveRLStatistics.ts";
+// Issue #3422: run-level tuning statistics recorded on every evolve* result.
+export type {
+  EvolveResult,
+  EvolveRunStatistics,
+  HardwareDescriptors,
+  OptionsEcho,
+  ScoreImprovementMilestone,
+  ScoreImprovementMilestones,
+} from "@creature/EvolveRunStatistics.ts";
 export type {
   EpisodeTrialsEvent,
   EpisodicOptions,

--- a/src/Creature.ts
+++ b/src/Creature.ts
@@ -1001,16 +1001,7 @@ export class Creature implements CreatureInternal {
   evolveDir(
     dataSetDir: string,
     options: NeatOptions,
-  ): Promise<
-    {
-      error: number;
-      score: number;
-      time: number;
-      generation: number;
-      phaseTimingTotals: training.PhaseTimingTotals;
-      scorerUtilisation: training.ScorerUtilisationTotals;
-    }
-  > {
+  ): Promise<training.EvolveResult> {
     return training.evolveDir(this, dataSetDir, options);
   }
 
@@ -1026,16 +1017,7 @@ export class Creature implements CreatureInternal {
     options:
       & NeatOptions
       & import("./creature/EpisodicFitnessTypes.ts").EpisodicOptions,
-  ): Promise<
-    {
-      error: number;
-      score: number;
-      time: number;
-      generation: number;
-      phaseTimingTotals: training.PhaseTimingTotals;
-      scorerUtilisation: training.ScorerUtilisationTotals;
-    }
-  > {
+  ): Promise<training.EvolveResult> {
     return training.evolveEnv(this, adapter, options);
   }
 
@@ -1051,13 +1033,7 @@ export class Creature implements CreatureInternal {
     adapter: import("./creature/EpisodeAdapter.ts").EpisodeAdapter<S, A>,
     options: training.EvolveRLOptions,
   ): Promise<
-    {
-      error: number;
-      score: number;
-      time: number;
-      generation: number;
-      phaseTimingTotals: training.PhaseTimingTotals;
-      scorerUtilisation: training.ScorerUtilisationTotals;
+    training.EvolveResult & {
       /**
        * Issue #2629: per-milestone payloads collected when
        * `options.statistics === true`. Omitted when statistics are off.
@@ -1072,15 +1048,7 @@ export class Creature implements CreatureInternal {
   evolveDataSet(
     dataSet: DataRecordInterface[],
     options: NeatOptions,
-  ): Promise<
-    {
-      error: number;
-      score: number;
-      time: number;
-      phaseTimingTotals: training.PhaseTimingTotals;
-      scorerUtilisation: training.ScorerUtilisationTotals;
-    }
-  > {
+  ): Promise<training.EvolveResult> {
     return training.evolveDataSet(this, dataSet, options);
   }
 

--- a/src/creature/CreatureTraining.ts
+++ b/src/creature/CreatureTraining.ts
@@ -81,7 +81,6 @@ import {
   accumulatePhaseTiming,
   createPhaseTimingAccumulator,
   finalisePhaseTimingTotals,
-  type PhaseTimingTotals,
 } from "@creature/PhaseTimingTotals.ts";
 // Re-export so `import * as training` consumers (e.g. Creature.ts) can name the
 // run-level phase-timing totals shape (Issue #3210).
@@ -91,7 +90,6 @@ import {
   createScorerUtilisationAccumulator,
   finaliseScorerUtilisationTotals,
   type ScorerUtilisationCounts,
-  type ScorerUtilisationTotals,
 } from "@creature/ScorerUtilisationTotals.ts";
 // Re-export so `import * as training` consumers (e.g. Creature.ts) can name the
 // run-level scorer-utilisation totals shape (Issue #3234).
@@ -100,6 +98,25 @@ import {
   type EvolveRLMilestone,
   isMilestoneGeneration,
 } from "@creature/EvolveRLStatistics.ts";
+import {
+  buildEvolveRunStatistics,
+  type EvolveResult,
+} from "@creature/EvolveRunStatistics.ts";
+// Re-export so `import * as training` consumers (e.g. Creature.ts) can name the
+// run-level result and its tuning-statistics sub-shapes (Issue #3422).
+export type {
+  EvolveResult,
+  EvolveRunStatistics,
+  HardwareDescriptors,
+  OptionsEcho,
+  ScoreImprovementMilestone,
+  ScoreImprovementMilestones,
+} from "@creature/EvolveRunStatistics.ts";
+import {
+  createScoreTrajectory,
+  recordScoreImprovement,
+} from "@creature/ScoreImprovementMilestones.ts";
+import { serialiseOptionsEcho } from "@creature/EvolveOptionsEcho.ts";
 
 /**
  * Snapshot the per-backend scorer-utilisation counts published by `Fitness`
@@ -443,16 +460,7 @@ export async function evolveDir(
   dataSetDir: string,
   options: NeatOptions,
   deps?: EvolveDirDeps,
-): Promise<
-  {
-    error: number;
-    score: number;
-    time: number;
-    generation: number;
-    phaseTimingTotals: PhaseTimingTotals;
-    scorerUtilisation: ScorerUtilisationTotals;
-  }
-> {
+): Promise<EvolveResult> {
   let interrupted = false;
   const signalListener = () => {
     getLogger().info("SIGTERM received, saving progress...");
@@ -570,6 +578,8 @@ export async function evolveDir(
   const phaseTimingAccumulator = createPhaseTimingAccumulator();
   // Issue #3234: sum the per-backend scorer-utilisation counts across the run.
   const scorerUtilisationAccumulator = createScorerUtilisationAccumulator();
+  // Issue #3422: compact best-score trajectory for the improvement milestones.
+  const scoreTrajectory = createScoreTrajectory();
 
   while (true) {
     // deno-lint-ignore no-await-in-loop
@@ -578,6 +588,9 @@ export async function evolveDir(
     const fittest = result.fittest;
     const fittestScore = fittest.score!;
     assert(fittestScore >= bestScore, "Score is less than best score");
+    // Issue #3422: note whether this generation improved the champion so the
+    // trajectory point is recorded once the scored-count is up to date below.
+    let championImproved = false;
     // Issue #2787: route champion comparison through the cost-aware helper.
     // Today this remains a strict `score > bestScore` for every cost
     // (NaN-safe) so existing runs do not regress; the seam is in place for
@@ -602,6 +615,7 @@ export async function evolveDir(
         typeof CreatureClass
       >;
       bestCreature.score = bestScore;
+      championImproved = true;
     }
 
     const now = Date.now();
@@ -635,6 +649,19 @@ export async function evolveDir(
       scorerUtilisationAccumulator,
       readScorerUtilisation(neat.fitness),
     );
+
+    // Issue #3422: on a champion improvement, snapshot the best-score curve with
+    // the now-current cumulative scored-count so the milestone summary can be
+    // derived at run end without persisting a per-generation series.
+    if (championImproved) {
+      recordScoreImprovement(scoreTrajectory, {
+        score: bestScore,
+        generation,
+        timeMs: now - start,
+        scoredCount: scorerUtilisationAccumulator.creaturesBatchScored +
+          scorerUtilisationAccumulator.creaturesPerCreatureScored,
+      });
+    }
 
     const generationElapsedMs = now -
       (generation === 1 ? start : iterationStartMS);
@@ -765,6 +792,15 @@ export async function evolveDir(
     scorerUtilisation: finaliseScorerUtilisationTotals(
       scorerUtilisationAccumulator,
     ),
+    // Issue #3422: run-level tuning statistics — population size, requested
+    // options, hardware and the score-improvement milestones.
+    ...buildEvolveRunStatistics({
+      populationSize: config.populationSize,
+      adaptivePopulationEnabled: config.adaptivePopulation.enabled,
+      finalPopulationSize: neat.effectivePopulationSize,
+      options,
+      trajectory: scoreTrajectory,
+    }),
   };
 }
 
@@ -792,16 +828,7 @@ export async function evolveEnv<S, A>(
   creature: Creature,
   adapter: LegacyEpisodeAdapter<S, A>,
   options: NeatOptions & EpisodicOptions,
-): Promise<
-  {
-    error: number;
-    score: number;
-    time: number;
-    generation: number;
-    phaseTimingTotals: PhaseTimingTotals;
-    scorerUtilisation: ScorerUtilisationTotals;
-  }
-> {
+): Promise<EvolveResult> {
   if (creature.input !== adapter.inputCount) {
     throw new Error(
       `Creature input ${creature.input} does not match adapter inputCount ` +
@@ -910,6 +937,8 @@ export async function evolveEnv<S, A>(
   const phaseTimingAccumulator = createPhaseTimingAccumulator();
   // Issue #3234: sum the per-backend scorer-utilisation counts across the run.
   const scorerUtilisationAccumulator = createScorerUtilisationAccumulator();
+  // Issue #3422: compact best-score trajectory for the improvement milestones.
+  const scoreTrajectory = createScoreTrajectory();
 
   while (true) {
     generation++;
@@ -921,6 +950,9 @@ export async function evolveEnv<S, A>(
     const fittest = result.fittest;
     const fittestScore = fittest.score!;
     assert(fittestScore >= bestScore, "Score is less than best score");
+    // Issue #3422: note whether this generation improved the champion so the
+    // trajectory point is recorded once the scored-count is up to date below.
+    let championImproved = false;
     // Issue #2787: route champion comparison through the cost-aware helper.
     // Today this remains a strict `score > bestScore` for every cost
     // (NaN-safe) so existing runs do not regress; the seam is in place for
@@ -940,6 +972,7 @@ export async function evolveEnv<S, A>(
         typeof CreatureClass
       >;
       bestCreature.score = bestScore;
+      championImproved = true;
     }
 
     const now = Date.now();
@@ -965,6 +998,19 @@ export async function evolveEnv<S, A>(
       scorerUtilisationAccumulator,
       readScorerUtilisation(neat.fitness),
     );
+
+    // Issue #3422: on a champion improvement, snapshot the best-score curve with
+    // the now-current cumulative scored-count so the milestone summary can be
+    // derived at run end without persisting a per-generation series.
+    if (championImproved) {
+      recordScoreImprovement(scoreTrajectory, {
+        score: bestScore,
+        generation,
+        timeMs: now - start,
+        scoredCount: scorerUtilisationAccumulator.creaturesBatchScored +
+          scorerUtilisationAccumulator.creaturesPerCreatureScored,
+      });
+    }
 
     const generationElapsedMs = now -
       (generation === 1 ? start : iterationStartMS);
@@ -1082,6 +1128,15 @@ export async function evolveEnv<S, A>(
     scorerUtilisation: finaliseScorerUtilisationTotals(
       scorerUtilisationAccumulator,
     ),
+    // Issue #3422: run-level tuning statistics — population size, requested
+    // options, hardware and the score-improvement milestones.
+    ...buildEvolveRunStatistics({
+      populationSize: config.populationSize,
+      adaptivePopulationEnabled: config.adaptivePopulation.enabled,
+      finalPopulationSize: neat.effectivePopulationSize,
+      options,
+      trajectory: scoreTrajectory,
+    }),
   };
 }
 
@@ -1186,13 +1241,7 @@ export async function evolveRL<S, A>(
   adapter: EpisodeAdapter<S, A>,
   options: EvolveRLOptions,
 ): Promise<
-  {
-    error: number;
-    score: number;
-    time: number;
-    generation: number;
-    phaseTimingTotals: PhaseTimingTotals;
-    scorerUtilisation: ScorerUtilisationTotals;
+  EvolveResult & {
     /**
      * Issue #2629: per-milestone payloads collected when `statistics === true`.
      * Omitted entirely when statistics are disabled so the return shape stays
@@ -1413,6 +1462,8 @@ export async function evolveRL<S, A>(
   const phaseTimingAccumulator = createPhaseTimingAccumulator();
   // Issue #3234: sum the per-backend scorer-utilisation counts across the run.
   const scorerUtilisationAccumulator = createScorerUtilisationAccumulator();
+  // Issue #3422: compact best-score trajectory for the improvement milestones.
+  const scoreTrajectory = createScoreTrajectory();
 
   while (true) {
     generation++;
@@ -1432,6 +1483,9 @@ export async function evolveRL<S, A>(
     const fittest = result.fittest;
     const fittestScore = fittest.score!;
     assert(fittestScore >= bestScore, "Score is less than best score");
+    // Issue #3422: note whether this generation improved the champion so the
+    // trajectory point is recorded once the scored-count is up to date below.
+    let championImproved = false;
     // Issue #2787: route champion comparison through the cost-aware helper.
     // Today this remains a strict `score > bestScore` for every cost
     // (NaN-safe) so existing runs do not regress; the seam is in place for
@@ -1451,6 +1505,7 @@ export async function evolveRL<S, A>(
         typeof CreatureClass
       >;
       bestCreature.score = bestScore;
+      championImproved = true;
     }
 
     const now = Date.now();
@@ -1476,6 +1531,19 @@ export async function evolveRL<S, A>(
       scorerUtilisationAccumulator,
       readScorerUtilisation(neat.fitness),
     );
+
+    // Issue #3422: on a champion improvement, snapshot the best-score curve with
+    // the now-current cumulative scored-count so the milestone summary can be
+    // derived at run end without persisting a per-generation series.
+    if (championImproved) {
+      recordScoreImprovement(scoreTrajectory, {
+        score: bestScore,
+        generation,
+        timeMs: now - start,
+        scoredCount: scorerUtilisationAccumulator.creaturesBatchScored +
+          scorerUtilisationAccumulator.creaturesPerCreatureScored,
+      });
+    }
 
     const generationElapsedMs = now -
       (generation === 1 ? start : iterationStartMS);
@@ -1661,6 +1729,15 @@ export async function evolveRL<S, A>(
   const scorerUtilisation = finaliseScorerUtilisationTotals(
     scorerUtilisationAccumulator,
   );
+  // Issue #3422: run-level tuning statistics — population size, requested
+  // options, hardware and the score-improvement milestones.
+  const runStatistics = buildEvolveRunStatistics({
+    populationSize: config.populationSize,
+    adaptivePopulationEnabled: config.adaptivePopulation.enabled,
+    finalPopulationSize: neat.effectivePopulationSize,
+    options,
+    trajectory: scoreTrajectory,
+  });
   if (statisticsEnabled) {
     return {
       error,
@@ -1669,6 +1746,7 @@ export async function evolveRL<S, A>(
       time,
       phaseTimingTotals,
       scorerUtilisation,
+      ...runStatistics,
       milestones,
     };
   }
@@ -1679,6 +1757,7 @@ export async function evolveRL<S, A>(
     time,
     phaseTimingTotals,
     scorerUtilisation,
+    ...runStatistics,
   };
 }
 
@@ -1690,15 +1769,7 @@ export async function evolveDataSet(
   creature: Creature,
   dataSet: DataRecordInterface[],
   options: NeatOptions,
-): Promise<
-  {
-    error: number;
-    score: number;
-    time: number;
-    phaseTimingTotals: PhaseTimingTotals;
-    scorerUtilisation: ScorerUtilisationTotals;
-  }
-> {
+): Promise<EvolveResult> {
   const config = createNeatConfig(options);
 
   const dataSetDir = makeDataDir(dataSet, config.dataSetPartitionBreak, {
@@ -1711,7 +1782,10 @@ export async function evolveDataSet(
   // deno-lint-ignore no-sync-fn-in-async-fn -- Cleanup of temporary directory after async evolution.
   Deno.removeSync(dataSetDir, { recursive: true });
 
-  return result;
+  // Issue #3422: evolveDir was handed the fully-resolved `config`, so its
+  // requestedOptions echo would list every default. Overwrite it with the
+  // caller's original request (changes from defaults) to match the contract.
+  return { ...result, requestedOptions: serialiseOptionsEcho(options) };
 }
 
 /**

--- a/src/creature/EvolveHardwareDescriptors.ts
+++ b/src/creature/EvolveHardwareDescriptors.ts
@@ -1,0 +1,82 @@
+/**
+ * Hardware descriptors recorded on the run-level evolve result so a persisted
+ * `result.json` is self-contained enough to compare configurations across
+ * machines (Issue #3422).
+ *
+ * Nigel wants to work out the optimal evolution configuration for various
+ * hardware — most-variants-checked-per-hour is the proxy — so each run must
+ * carry the CPU core count, total physical memory, and a host identifier of the
+ * machine it ran on. Without these, throughput numbers from two machines cannot
+ * be told apart downstream.
+ *
+ * Each descriptor is captured independently and best-effort: reading total
+ * memory and the hostname needs the `--allow-sys` permission, which is not
+ * granted in every context (the test runner deliberately omits it). A denied
+ * permission is not a run failure — it is honestly recorded as `null` rather
+ * than crashing the evolve loop or masking the gap with a fake value.
+ */
+
+/** Machine descriptors captured once at the end of an evolve run. */
+export interface HardwareDescriptors {
+  /**
+   * Logical CPU core count from `navigator.hardwareConcurrency`. `null` only
+   * when the runtime does not expose it.
+   */
+  readonly cpuCores: number | null;
+  /**
+   * Total physical memory in bytes from `Deno.systemMemoryInfo()`. `null` when
+   * the `--allow-sys=systemMemoryInfo` permission is not granted.
+   */
+  readonly totalMemoryBytes: number | null;
+  /**
+   * Host identifier from `Deno.hostname()`. `null` when the
+   * `--allow-sys=hostname` permission is not granted.
+   */
+  readonly host: string | null;
+}
+
+/**
+ * Capture the {@link HardwareDescriptors} of the current machine. Each field is
+ * read independently so a single denied permission does not blank the others.
+ */
+export function captureHardwareDescriptors(): HardwareDescriptors {
+  return {
+    cpuCores: readCpuCores(),
+    totalMemoryBytes: readTotalMemoryBytes(),
+    host: readHost(),
+  };
+}
+
+/** Logical CPU cores; needs no permission. `null` if the runtime hides it. */
+function readCpuCores(): number | null {
+  const cores = navigator.hardwareConcurrency;
+  return typeof cores === "number" && Number.isFinite(cores) && cores > 0
+    ? cores
+    : null;
+}
+
+/**
+ * Total physical memory in bytes. Returns `null` when the permission is denied
+ * (or the platform reports a non-positive total) rather than throwing.
+ */
+function readTotalMemoryBytes(): number | null {
+  try {
+    const total = Deno.systemMemoryInfo().total;
+    return Number.isFinite(total) && total > 0 ? total : null;
+  } catch {
+    // Permission denied (--allow-sys not granted) or unsupported platform.
+    // Best-effort metadata: record the gap as null, do not fail the run.
+    return null;
+  }
+}
+
+/** Host identifier. Returns `null` when the permission is denied. */
+function readHost(): string | null {
+  try {
+    const host = Deno.hostname();
+    return typeof host === "string" && host.length > 0 ? host : null;
+  } catch {
+    // Permission denied (--allow-sys not granted): record the gap as null.
+    return null;
+  }
+}

--- a/src/creature/EvolveOptionsEcho.ts
+++ b/src/creature/EvolveOptionsEcho.ts
@@ -1,0 +1,60 @@
+/**
+ * Echo of the caller-supplied evolve options recorded on the run-level result
+ * (Issue #3422).
+ *
+ * Only the options the calling program actually requested are echoed — the raw
+ * options object passed to `evolveDir`/`evolveDataSet`/`evolveEnv`/`evolveRL`,
+ * i.e. the changes from defaults. The fully-resolved config is deliberately not
+ * recorded because the defaults can be inferred downstream; capturing just the
+ * request keeps the persisted `result.json` small and shows exactly which knobs
+ * a run turned.
+ *
+ * Options are serialised as passed. Non-serialisable entries are recorded by
+ * name with a marker instead of being silently dropped: function/callback
+ * options (e.g. `onTrainingEvent`, `customCost`, `logger`) become
+ * `"[function]"` and anything that cannot round-trip through JSON (e.g. an
+ * `AbortSignal`) becomes `"[unserialisable]"`. Recording the key with a marker
+ * keeps the echo honest about what the caller requested without persisting an
+ * unusable value.
+ */
+
+/** Marker recorded for a function/callback-valued option. */
+export const OPTION_FUNCTION_MARKER = "[function]";
+/** Marker recorded for an option that cannot round-trip through JSON. */
+export const OPTION_UNSERIALISABLE_MARKER = "[unserialisable]";
+
+/** JSON-safe echo of the caller-requested options, keyed by option name. */
+export type OptionsEcho = Record<string, unknown>;
+
+/**
+ * Serialise the caller-supplied options object into a JSON-safe
+ * {@link OptionsEcho}. Only the caller's own enumerable keys are echoed;
+ * `undefined` values are skipped, functions become {@link OPTION_FUNCTION_MARKER},
+ * and non-serialisable values become {@link OPTION_UNSERIALISABLE_MARKER}.
+ */
+export function serialiseOptionsEcho(
+  options: object | undefined,
+): OptionsEcho {
+  const echo: OptionsEcho = {};
+  if (options === undefined || options === null) return echo;
+
+  for (const [key, value] of Object.entries(options)) {
+    if (value === undefined) continue;
+    if (typeof value === "function") {
+      echo[key] = OPTION_FUNCTION_MARKER;
+      continue;
+    }
+    try {
+      const json = JSON.stringify(value);
+      // JSON.stringify returns undefined for values with no JSON
+      // representation (e.g. a bare symbol); treat that as unserialisable.
+      echo[key] = json === undefined
+        ? OPTION_UNSERIALISABLE_MARKER
+        : JSON.parse(json);
+    } catch {
+      // Circular reference or a value whose toJSON throws.
+      echo[key] = OPTION_UNSERIALISABLE_MARKER;
+    }
+  }
+  return echo;
+}

--- a/src/creature/EvolveRunStatistics.ts
+++ b/src/creature/EvolveRunStatistics.ts
@@ -1,0 +1,113 @@
+/**
+ * Run-level tuning statistics recorded on every `evolve*` result (Issue #3422).
+ *
+ * Production evolution runs on a range of hardware and configurations; Nigel
+ * wants each run self-contained enough to compare configurations across
+ * machines and judge which gives the best rate of score improvement. The
+ * existing result already reports `error`, `score`, `generation`, `time`,
+ * `phaseTimingTotals` and `scorerUtilisation`; this group adds the missing
+ * tuning inputs — the population size, the caller-requested options, the
+ * hardware it ran on, and a milestone summary of the score-improvement curve.
+ *
+ * Judging "optimal" (most variants checked per hour, best rate of score gain)
+ * happens downstream from these fields; this module only records the data.
+ */
+
+import type { PhaseTimingTotals } from "@creature/PhaseTimingTotals.ts";
+import type { ScorerUtilisationTotals } from "@creature/ScorerUtilisationTotals.ts";
+import {
+  captureHardwareDescriptors,
+  type HardwareDescriptors,
+} from "@creature/EvolveHardwareDescriptors.ts";
+import {
+  type OptionsEcho,
+  serialiseOptionsEcho,
+} from "@creature/EvolveOptionsEcho.ts";
+import {
+  finaliseScoreImprovementMilestones,
+  type ScoreImprovementMilestones,
+  type ScoreTrajectory,
+} from "@creature/ScoreImprovementMilestones.ts";
+
+export type { HardwareDescriptors } from "@creature/EvolveHardwareDescriptors.ts";
+export type { OptionsEcho } from "@creature/EvolveOptionsEcho.ts";
+export type {
+  ScoreImprovementMilestone,
+  ScoreImprovementMilestones,
+} from "@creature/ScoreImprovementMilestones.ts";
+
+/** The tuning-statistics group added to every `evolve*` result (Issue #3422). */
+export interface EvolveRunStatistics {
+  /**
+   * Configured population size — always recorded explicitly even when it came
+   * from a default, as it is the primary tuning variable.
+   */
+  readonly populationSize: number;
+  /**
+   * Final actual population size, recorded only when adaptive population sizing
+   * (`AdaptivePopulationConfig`, opt-in) is enabled and may differ from the
+   * configured `populationSize`. Omitted otherwise.
+   */
+  readonly finalPopulationSize?: number;
+  /** Echo of the caller-requested options (changes from defaults). */
+  readonly requestedOptions: OptionsEcho;
+  /** Machine descriptors for cross-machine comparison. */
+  readonly hardware: HardwareDescriptors;
+  /** Milestone summary of the score-improvement curve. */
+  readonly scoreImprovement: ScoreImprovementMilestones;
+}
+
+/**
+ * The full run-level result returned by `evolveDir`/`evolveDataSet`/`evolveEnv`
+ * — the existing throughput/score fields plus the Issue #3422 tuning-statistics
+ * group. `evolveRL` extends this with an optional `milestones` array.
+ */
+export interface EvolveResult extends EvolveRunStatistics {
+  /** Best creature's error at run end. */
+  readonly error: number;
+  /** Best score reached during the run. */
+  readonly score: number;
+  /** Total run wall-clock time in ms. */
+  readonly time: number;
+  /** Generations completed during the run. */
+  readonly generation: number;
+  /** Whole-run per-phase timing totals (Issue #3210). */
+  readonly phaseTimingTotals: PhaseTimingTotals;
+  /** Whole-run per-backend scorer-utilisation totals (Issue #3234). */
+  readonly scorerUtilisation: ScorerUtilisationTotals;
+}
+
+/** Inputs needed to assemble the {@link EvolveRunStatistics} group. */
+export interface EvolveRunStatisticsInputs {
+  /** Configured population size (`config.populationSize`). */
+  readonly populationSize: number;
+  /** True when adaptive population sizing is enabled for this run. */
+  readonly adaptivePopulationEnabled: boolean;
+  /** Effective population size at run end (`neat.effectivePopulationSize`). */
+  readonly finalPopulationSize: number;
+  /** The raw options object the caller passed to the `evolve*` function. */
+  readonly options: object | undefined;
+  /** The compact best-score trajectory accumulated during the run. */
+  readonly trajectory: ScoreTrajectory;
+}
+
+/**
+ * Assemble the {@link EvolveRunStatistics} group from the run's inputs. Captures
+ * the hardware descriptors, echoes the caller options, and finalises the
+ * score-improvement milestones. `finalPopulationSize` is included only when
+ * adaptive population sizing was enabled.
+ */
+export function buildEvolveRunStatistics(
+  inputs: EvolveRunStatisticsInputs,
+): EvolveRunStatistics {
+  const base: EvolveRunStatistics = {
+    populationSize: inputs.populationSize,
+    requestedOptions: serialiseOptionsEcho(inputs.options),
+    hardware: captureHardwareDescriptors(),
+    scoreImprovement: finaliseScoreImprovementMilestones(inputs.trajectory),
+  };
+  if (inputs.adaptivePopulationEnabled) {
+    return { ...base, finalPopulationSize: inputs.finalPopulationSize };
+  }
+  return base;
+}

--- a/src/creature/ScoreImprovementMilestones.ts
+++ b/src/creature/ScoreImprovementMilestones.ts
@@ -1,0 +1,133 @@
+/**
+ * Milestone summary of the score-improvement curve recorded on the run-level
+ * evolve result (Issue #3422).
+ *
+ * Final score alone is a poor tuning signal because runs plateau (diminishing
+ * returns), so a configuration that reaches most of its improvement quickly is
+ * more valuable than one that limps to a marginally higher score. To judge that
+ * downstream without persisting a large per-generation series, the run records
+ * *when* it reached 25/50/75/90% of its total score improvement: the time,
+ * generation and cumulative scored-count at each threshold.
+ *
+ * The summary is computed at run end from a compact in-memory trajectory that
+ * only records a point when the best score improves — nothing per-generation is
+ * kept or persisted.
+ */
+
+/** The improvement fractions summarised, in order. */
+export const SCORE_IMPROVEMENT_FRACTIONS: readonly number[] = [
+  0.25,
+  0.5,
+  0.75,
+  0.9,
+];
+
+/** One point on the best-score trajectory, recorded when the best improves. */
+export interface ScoreTrajectoryPoint {
+  /** Best score reached at this point. */
+  readonly score: number;
+  /** Generation number at which the best reached this score. */
+  readonly generation: number;
+  /** Elapsed run time in ms when the best reached this score. */
+  readonly timeMs: number;
+  /** Cumulative creatures scored across the run up to this point. */
+  readonly scoredCount: number;
+}
+
+/** One entry of the finalised improvement-curve summary. */
+export interface ScoreImprovementMilestone {
+  /** Fraction of total improvement this milestone marks (e.g. `0.25`). */
+  readonly fraction: number;
+  /** First generation whose best score reached the milestone. */
+  readonly generation: number;
+  /** Elapsed run time in ms when the milestone was reached. */
+  readonly timeMs: number;
+  /** Cumulative creatures scored when the milestone was reached. */
+  readonly scoredCount: number;
+  /** Best score at the milestone (>= the milestone target). */
+  readonly score: number;
+}
+
+/** Finalised score-improvement summary surfaced on the evolve result. */
+export interface ScoreImprovementMilestones {
+  /** Best score at the first recorded improvement (the run baseline). */
+  readonly initialScore: number;
+  /** Best score at run end. */
+  readonly finalScore: number;
+  /** `finalScore - initialScore`; `0` when the run never improved. */
+  readonly totalImprovement: number;
+  /**
+   * Per-fraction milestones. Empty when there was no positive improvement
+   * (e.g. a zero- or one-generation run, or one that never beat its baseline).
+   */
+  readonly milestones: ScoreImprovementMilestone[];
+}
+
+/**
+ * Mutable, compact best-score trajectory built up during the run. Only points
+ * where the best score improved are appended, so its length is bounded by the
+ * number of champions found, not by the generation count.
+ */
+export interface ScoreTrajectory {
+  readonly points: ScoreTrajectoryPoint[];
+}
+
+/** Create an empty {@link ScoreTrajectory}. */
+export function createScoreTrajectory(): ScoreTrajectory {
+  return { points: [] };
+}
+
+/**
+ * Append a best-score-improvement point. Callers invoke this only when the
+ * best score strictly improved, keeping the trajectory compact.
+ */
+export function recordScoreImprovement(
+  trajectory: ScoreTrajectory,
+  point: ScoreTrajectoryPoint,
+): void {
+  trajectory.points.push(point);
+}
+
+/**
+ * Freeze the trajectory into an immutable {@link ScoreImprovementMilestones}.
+ *
+ * For each fraction in {@link SCORE_IMPROVEMENT_FRACTIONS} the first trajectory
+ * point whose score reached `initialScore + fraction * totalImprovement` is
+ * recorded. Milestones are empty when improvement is not positive.
+ */
+export function finaliseScoreImprovementMilestones(
+  trajectory: ScoreTrajectory,
+): ScoreImprovementMilestones {
+  const points = trajectory.points;
+  if (points.length === 0) {
+    return {
+      initialScore: 0,
+      finalScore: 0,
+      totalImprovement: 0,
+      milestones: [],
+    };
+  }
+
+  const initialScore = points[0].score;
+  const finalScore = points[points.length - 1].score;
+  const totalImprovement = finalScore - initialScore;
+
+  const milestones: ScoreImprovementMilestone[] = [];
+  if (totalImprovement > 0) {
+    for (const fraction of SCORE_IMPROVEMENT_FRACTIONS) {
+      const target = initialScore + fraction * totalImprovement;
+      const hit = points.find((p) => p.score >= target);
+      if (hit) {
+        milestones.push({
+          fraction,
+          generation: hit.generation,
+          timeMs: hit.timeMs,
+          scoredCount: hit.scoredCount,
+          score: hit.score,
+        });
+      }
+    }
+  }
+
+  return { initialScore, finalScore, totalImprovement, milestones };
+}

--- a/test/creature/EvolveHardwareDescriptors.ts
+++ b/test/creature/EvolveHardwareDescriptors.ts
@@ -1,0 +1,47 @@
+/**
+ * Unit tests for {@link captureHardwareDescriptors} (Issue #3422): the machine
+ * descriptors recorded on the run-level result must always be present, with
+ * best-effort fields degrading to `null` rather than throwing when the
+ * `--allow-sys` permission is absent (as it is in the test runner).
+ */
+
+import { assert, assertEquals } from "@std/assert";
+import { captureHardwareDescriptors } from "@creature/EvolveHardwareDescriptors.ts";
+
+Deno.test("captureHardwareDescriptors - returns the expected shape", () => {
+  const hw = captureHardwareDescriptors();
+
+  // Exactly the three descriptor keys.
+  assertEquals(Object.keys(hw).sort(), [
+    "cpuCores",
+    "host",
+    "totalMemoryBytes",
+  ]);
+});
+
+Deno.test("captureHardwareDescriptors - cpuCores is a positive integer or null", () => {
+  const { cpuCores } = captureHardwareDescriptors();
+
+  if (cpuCores !== null) {
+    assertEquals(typeof cpuCores, "number");
+    assert(cpuCores > 0, "cpuCores must be positive when present");
+  }
+});
+
+Deno.test("captureHardwareDescriptors - best-effort fields are typed value or null", () => {
+  const { totalMemoryBytes, host } = captureHardwareDescriptors();
+
+  // Without --allow-sys these degrade to null; when the permission is present
+  // they carry a positive number / non-empty string. Either way, no throw.
+  if (totalMemoryBytes !== null) {
+    assertEquals(typeof totalMemoryBytes, "number");
+    assert(
+      totalMemoryBytes > 0,
+      "totalMemoryBytes must be positive when present",
+    );
+  }
+  if (host !== null) {
+    assertEquals(typeof host, "string");
+    assert(host.length > 0, "host must be non-empty when present");
+  }
+});

--- a/test/creature/EvolveOptionsEcho.ts
+++ b/test/creature/EvolveOptionsEcho.ts
@@ -1,0 +1,78 @@
+/**
+ * Unit tests for {@link serialiseOptionsEcho} (Issue #3422): the caller-supplied
+ * evolve options echoed onto the run-level result must round-trip serialisable
+ * values, skip `undefined`, and record non-serialisable options by name with a
+ * marker rather than dropping them silently.
+ */
+
+import { assertEquals } from "@std/assert";
+import {
+  OPTION_FUNCTION_MARKER,
+  OPTION_UNSERIALISABLE_MARKER,
+  serialiseOptionsEcho,
+} from "@creature/EvolveOptionsEcho.ts";
+
+Deno.test("serialiseOptionsEcho - echoes serialisable options as passed", () => {
+  const echo = serialiseOptionsEcho({
+    populationSize: 100,
+    iterations: 50,
+    targetError: 0,
+    costName: "MSE",
+    outputRanges: [{ min: 0, max: 1 }],
+  });
+
+  assertEquals(echo, {
+    populationSize: 100,
+    iterations: 50,
+    targetError: 0,
+    costName: "MSE",
+    outputRanges: [{ min: 0, max: 1 }],
+  });
+});
+
+Deno.test("serialiseOptionsEcho - records function options by name with marker", () => {
+  const echo = serialiseOptionsEcho({
+    populationSize: 10,
+    onTrainingEvent: () => {},
+    customCost: function cost() {
+      return 0;
+    },
+  });
+
+  assertEquals(echo.populationSize, 10);
+  assertEquals(echo.onTrainingEvent, OPTION_FUNCTION_MARKER);
+  assertEquals(echo.customCost, OPTION_FUNCTION_MARKER);
+});
+
+Deno.test("serialiseOptionsEcho - marks non-serialisable (circular) values", () => {
+  const circular: Record<string, unknown> = { name: "loop" };
+  circular.self = circular;
+
+  const echo = serialiseOptionsEcho({ populationSize: 5, circular });
+
+  assertEquals(echo.populationSize, 5);
+  assertEquals(echo.circular, OPTION_UNSERIALISABLE_MARKER);
+});
+
+Deno.test("serialiseOptionsEcho - skips undefined values", () => {
+  const echo = serialiseOptionsEcho({
+    populationSize: 20,
+    threads: undefined,
+  });
+
+  assertEquals(Object.hasOwn(echo, "threads"), false);
+  assertEquals(echo.populationSize, 20);
+});
+
+Deno.test("serialiseOptionsEcho - empty result for undefined input", () => {
+  assertEquals(serialiseOptionsEcho(undefined), {});
+});
+
+Deno.test("serialiseOptionsEcho - deep-clones nested values (no shared reference)", () => {
+  const source = { nested: { list: [1, 2, 3] } };
+  const echo = serialiseOptionsEcho(source);
+
+  (echo.nested as { list: number[] }).list.push(4);
+  // Mutating the echo must not affect the caller's original options.
+  assertEquals(source.nested.list, [1, 2, 3]);
+});

--- a/test/creature/EvolveRunStatistics.ts
+++ b/test/creature/EvolveRunStatistics.ts
@@ -1,0 +1,137 @@
+/**
+ * Integration test: the evolve* functions record run-level tuning statistics on
+ * their result (Issue #3422) — the configured population size, an echo of the
+ * caller-requested options, hardware descriptors, and a milestone summary of
+ * the score-improvement curve — so a persisted `result.json` is self-contained
+ * enough to compare configurations across machines.
+ */
+
+import { assert, assertEquals } from "@std/assert";
+import { Creature } from "@creature";
+import { SCORE_IMPROVEMENT_FRACTIONS } from "@creature/ScoreImprovementMilestones.ts";
+import { initWasmForTests } from "../_initWasm.ts";
+
+const XOR = [
+  { input: new Float32Array([0, 0]), output: new Float32Array([0]) },
+  { input: new Float32Array([0, 1]), output: new Float32Array([1]) },
+  { input: new Float32Array([1, 0]), output: new Float32Array([1]) },
+  { input: new Float32Array([1, 1]), output: new Float32Array([0]) },
+];
+
+Deno.test("evolveDataSet records populationSize and requested options", async () => {
+  await initWasmForTests();
+
+  const creature = new Creature(2, 1);
+  const result = await creature.evolveDataSet(XOR, {
+    iterations: 5,
+    targetError: 0,
+    populationSize: 12,
+    threads: 1,
+  });
+
+  // Configured population size is always recorded explicitly.
+  assertEquals(result.populationSize, 12);
+  // Adaptive sizing was not enabled, so no final population size is recorded.
+  assertEquals(Object.hasOwn(result, "finalPopulationSize"), false);
+
+  // Only the caller-requested options are echoed (changes from defaults),
+  // not the full resolved config.
+  assertEquals(result.requestedOptions.populationSize, 12);
+  assertEquals(result.requestedOptions.iterations, 5);
+  assertEquals(result.requestedOptions.threads, 1);
+  // A default the caller never set must not appear in the echo.
+  assertEquals(Object.hasOwn(result.requestedOptions, "costName"), false);
+});
+
+Deno.test("evolveDataSet records hardware descriptors", async () => {
+  await initWasmForTests();
+
+  const creature = new Creature(2, 1);
+  const result = await creature.evolveDataSet(XOR, {
+    iterations: 3,
+    populationSize: 10,
+    threads: 1,
+  });
+
+  const hw = result.hardware;
+  assertEquals(Object.keys(hw).sort(), [
+    "cpuCores",
+    "host",
+    "totalMemoryBytes",
+  ]);
+  // cpuCores needs no permission; the best-effort fields may be null under the
+  // test runner's permission set, but the descriptor object is always present.
+  if (hw.cpuCores !== null) {
+    assert(hw.cpuCores > 0, "cpuCores must be positive when present");
+  }
+});
+
+Deno.test("evolveDataSet records score-improvement milestones", async () => {
+  await initWasmForTests();
+
+  const creature = new Creature(2, 1);
+  const result = await creature.evolveDataSet(XOR, {
+    iterations: 12,
+    targetError: 0,
+    populationSize: 20,
+    threads: 1,
+  });
+
+  const summary = result.scoreImprovement;
+  // Baseline and final are the run's first and last champion scores.
+  assert(summary.finalScore >= summary.initialScore);
+  assertEquals(
+    summary.totalImprovement,
+    summary.finalScore - summary.initialScore,
+  );
+
+  // When the run improved, milestones are ordered by fraction and each records
+  // a non-decreasing generation/time/scored-count as the curve progresses.
+  if (summary.totalImprovement > 0) {
+    assert(summary.milestones.length > 0, "expected at least one milestone");
+    assert(
+      summary.milestones.length <= SCORE_IMPROVEMENT_FRACTIONS.length,
+      "no more milestones than fractions",
+    );
+    let prevGen = 0;
+    let prevScore = summary.initialScore;
+    for (const milestone of summary.milestones) {
+      assert(
+        SCORE_IMPROVEMENT_FRACTIONS.includes(milestone.fraction),
+        `unexpected fraction ${milestone.fraction}`,
+      );
+      const target = summary.initialScore +
+        milestone.fraction * summary.totalImprovement;
+      assert(
+        milestone.score >= target - 1e-9,
+        "milestone score must reach its fraction target",
+      );
+      assert(milestone.generation >= prevGen, "generations non-decreasing");
+      assert(milestone.score >= prevScore - 1e-9, "scores non-decreasing");
+      assert(milestone.generation >= 1, "generation is 1-based");
+      assert(milestone.scoredCount > 0, "scored-count must be positive");
+      prevGen = milestone.generation;
+      prevScore = milestone.score;
+    }
+  }
+});
+
+Deno.test("evolveDataSet records finalPopulationSize when adaptive sizing enabled", async () => {
+  await initWasmForTests();
+
+  const creature = new Creature(2, 1);
+  const result = await creature.evolveDataSet(XOR, {
+    iterations: 4,
+    populationSize: 15,
+    threads: 1,
+    adaptivePopulation: { enabled: true },
+  });
+
+  assertEquals(result.populationSize, 15);
+  // With adaptive sizing on, the final effective population size is recorded.
+  assertEquals(typeof result.finalPopulationSize, "number");
+  assert(
+    (result.finalPopulationSize ?? 0) > 0,
+    "finalPopulationSize must be positive",
+  );
+});

--- a/test/creature/ScoreImprovementMilestones.ts
+++ b/test/creature/ScoreImprovementMilestones.ts
@@ -1,0 +1,99 @@
+/**
+ * Unit tests for the score-improvement milestone summary (Issue #3422): the
+ * compact best-score trajectory kept during a run is frozen into 25/50/75/90%
+ * milestones recording the time, generation and cumulative scored-count at
+ * which each fraction of the total improvement was reached.
+ */
+
+import { assertEquals } from "@std/assert";
+import {
+  createScoreTrajectory,
+  finaliseScoreImprovementMilestones,
+  recordScoreImprovement,
+  SCORE_IMPROVEMENT_FRACTIONS,
+} from "@creature/ScoreImprovementMilestones.ts";
+
+Deno.test("finaliseScoreImprovementMilestones - empty trajectory yields zeros", () => {
+  const result = finaliseScoreImprovementMilestones(createScoreTrajectory());
+  assertEquals(result.initialScore, 0);
+  assertEquals(result.finalScore, 0);
+  assertEquals(result.totalImprovement, 0);
+  assertEquals(result.milestones, []);
+});
+
+Deno.test("finaliseScoreImprovementMilestones - single point has no improvement", () => {
+  const trajectory = createScoreTrajectory();
+  recordScoreImprovement(trajectory, {
+    score: 0.4,
+    generation: 1,
+    timeMs: 10,
+    scoredCount: 5,
+  });
+
+  const result = finaliseScoreImprovementMilestones(trajectory);
+  assertEquals(result.initialScore, 0.4);
+  assertEquals(result.finalScore, 0.4);
+  assertEquals(result.totalImprovement, 0);
+  assertEquals(result.milestones, []);
+});
+
+Deno.test("finaliseScoreImprovementMilestones - records first point reaching each fraction", () => {
+  const trajectory = createScoreTrajectory();
+  // Baseline 0.0 → final 1.0, so total improvement is 1.0 and the fraction
+  // targets are exactly 0.25/0.5/0.75/0.9.
+  const points = [
+    { score: 0.0, generation: 1, timeMs: 100, scoredCount: 10 },
+    { score: 0.3, generation: 2, timeMs: 200, scoredCount: 20 }, // >= 0.25
+    { score: 0.6, generation: 4, timeMs: 400, scoredCount: 40 }, // >= 0.5
+    { score: 0.8, generation: 6, timeMs: 600, scoredCount: 60 }, // >= 0.75
+    { score: 1.0, generation: 9, timeMs: 900, scoredCount: 90 }, // >= 0.9
+  ];
+  for (const p of points) recordScoreImprovement(trajectory, p);
+
+  const result = finaliseScoreImprovementMilestones(trajectory);
+  assertEquals(result.initialScore, 0.0);
+  assertEquals(result.finalScore, 1.0);
+  assertEquals(result.totalImprovement, 1.0);
+  assertEquals(result.milestones.length, SCORE_IMPROVEMENT_FRACTIONS.length);
+
+  assertEquals(result.milestones[0], {
+    fraction: 0.25,
+    generation: 2,
+    timeMs: 200,
+    scoredCount: 20,
+    score: 0.3,
+  });
+  assertEquals(result.milestones[1].fraction, 0.5);
+  assertEquals(result.milestones[1].generation, 4);
+  assertEquals(result.milestones[2].fraction, 0.75);
+  assertEquals(result.milestones[2].generation, 6);
+  assertEquals(result.milestones[3].fraction, 0.9);
+  assertEquals(result.milestones[3].generation, 9);
+});
+
+Deno.test("finaliseScoreImprovementMilestones - one big jump satisfies every fraction", () => {
+  const trajectory = createScoreTrajectory();
+  recordScoreImprovement(trajectory, {
+    score: 0.1,
+    generation: 1,
+    timeMs: 50,
+    scoredCount: 5,
+  });
+  // A single leap straight to the top: every fraction target is met by the
+  // same generation.
+  recordScoreImprovement(trajectory, {
+    score: 0.9,
+    generation: 2,
+    timeMs: 120,
+    scoredCount: 12,
+  });
+
+  const result = finaliseScoreImprovementMilestones(trajectory);
+  assertEquals(result.milestones.length, SCORE_IMPROVEMENT_FRACTIONS.length);
+  for (const milestone of result.milestones) {
+    assertEquals(milestone.generation, 2);
+    assertEquals(milestone.timeMs, 120);
+    assertEquals(milestone.scoredCount, 12);
+    assertEquals(milestone.score, 0.9);
+  }
+});


### PR DESCRIPTION
# Record population size and options in evolve statistics (Issue #3422)

## Summary

The run-level result returned by `evolveDir`/`evolveDataSet`/`evolveEnv`/
`evolveRL` (the shape GRQ-cluster persists as `result.json`) previously reported
only `error`, `score`, `generation`, `time`, `phaseTimingTotals` and
`scorerUtilisation` — enough to see a run's outcome but not enough to compare
configurations across machines or judge which gives the best rate of score
improvement. This PR adds the missing tuning inputs so each run is
self-contained. Judging "optimal" (most variants checked per hour, best rate of
score gain) happens downstream; the library only records the data. **Closes
#3422.**

New fields on every `evolve*` result:

- **`populationSize`** — configured population size, always recorded explicitly
  (the primary tuning variable), even when it came from a default.
- **`finalPopulationSize`** — final effective population size, present **only**
  when adaptive population sizing (`AdaptivePopulationConfig`) is enabled.
- **`requestedOptions`** — echo of just the options the caller requested
  (changes from defaults, not the full resolved config). Function/callback
  options are recorded as `"[function]"` and non-serialisable values as
  `"[unserialisable]"` — recorded by name with a marker rather than dropped
  silently.
- **`hardware`** — CPU cores, total memory and host identifier for cross-machine
  comparison. Best-effort fields degrade to `null` (never throw) when
  `--allow-sys` is not granted.
- **`scoreImprovement`** — a milestone summary of the score-improvement curve:
  the time, generation and cumulative scored-count when the run reached
  25/50/75/90% of its total improvement. Computed at run end from a compact
  in-memory best-score trajectory that only grows on a champion improvement — no
  per-generation series is kept or persisted (the issue explicitly does not want
  a large JSON).

The existing throughput counters (`generation`, `scorerUtilisation` scored
count, `time`) are unchanged; per-hour rates remain the caller's to derive.

### Design

The additions live in four small, single-responsibility modules so each piece is
testable in isolation, and a shared `EvolveResult` type replaces the four
previously-inlined return shapes (DRY):

- `src/creature/EvolveHardwareDescriptors.ts` — `captureHardwareDescriptors()`
- `src/creature/EvolveOptionsEcho.ts` — `serialiseOptionsEcho()`
- `src/creature/ScoreImprovementMilestones.ts` — trajectory + milestone
  finaliser
- `src/creature/EvolveRunStatistics.ts` — `buildEvolveRunStatistics()` +
  `EvolveResult`

## Evidence

Backend/library change — no web interface to screenshot. Verified via the unit
and integration tests below (all pass) and the full `./quality.sh` gate
(`7754 passed | 0 failed`).

The score-improvement milestones are derived from a compact trajectory that only
grows when the best score improves — nothing per-generation is stored:

```mermaid
flowchart LR
    Gen[Generation cycle] -->|champion improved?| Rec{best score<br/>strictly up?}
    Rec -- no --> Gen
    Rec -- yes --> Point[Append trajectory point<br/>score / generation / time / scoredCount]
    Point --> Gen
    Gen -->|run ends| Fin[Finalise: for each of<br/>25/50/75/90% pick first<br/>point reaching the target]
    Fin --> Out[scoreImprovement on result]
```

### Deno regression avoided

Hardware capture uses native `navigator.hardwareConcurrency`, `Deno.hostname()`
and `Deno.systemMemoryInfo()` rather than any Node `os` module — no Node tooling
or dependency was introduced.

## Test Plan

New unit tests (pure helpers):

- `test/creature/EvolveOptionsEcho.ts` — echoes serialisable options, records
  functions/non-serialisable values by marker, skips `undefined`, deep-clones
  nested values.
- `test/creature/ScoreImprovementMilestones.ts` — empty/single-point/no-gain
  edge cases, first-point-reaching-each-fraction selection, single big jump.
- `test/creature/EvolveHardwareDescriptors.ts` — descriptor shape; best-effort
  fields are a typed value or `null` and never throw without `--allow-sys`.

New integration test:

- `test/creature/EvolveRunStatistics.ts` — `evolveDataSet` records
  `populationSize` and only the requested options; hardware descriptors present;
  score-improvement milestones ordered and reaching their targets;
  `finalPopulationSize` recorded when adaptive sizing is enabled.

Regression coverage: existing `EvolvePhaseTimingTotals`,
`EvolveScorerUtilisation`, `evolveRL_test`, `EvolveEnv` and the full suite
continue to pass.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mryfth1a-0a9c10`<!-- vibe-worker-issue-3422 -->