### PR TITLE
Drop unserialisable option markers, echo creature count (Issue #3427)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,11 +30,11 @@ adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).
   enough to compare configurations across the fleet. It records the configured
   `populationSize` (plus the final actual size when adaptive population sizing
   is enabled), host `hardware` descriptors (CPU cores, total memory, host id), a
-  JSON-safe echo of the caller's `requestedOptions` (callbacks recorded by
-  marker, never serialised), and an `improvement` milestone summary — the
-  generation / elapsed time / creatures scored at which the run reached
-  25/50/75/90% of its total score improvement (no per-generation series). New
-  public type exports: `EvolveRunStatistics`, `HardwareDescriptor`,
+  JSON-safe echo of the caller's `requestedOptions` (see the #3427 note under
+  Changed for how non-serialisable options are handled), and an `improvement`
+  milestone summary — the generation / elapsed time / creatures scored at which
+  the run reached 25/50/75/90% of its total score improvement (no per-generation
+  series). New public type exports: `EvolveRunStatistics`, `HardwareDescriptor`,
   `OptionsEcho`, `ImprovementSummary`, `ImprovementMilestone`.
 - **Issue #3412:** New `DatasetError` typed error (exported from the public
   barrel) makes a vanished training dataset fail loud and clear. When the
@@ -85,6 +85,17 @@ adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).
   (`bench/NoveltyDeceptiveEscape.ts`) and acceptance test show novelty escaping
   a local optimum in far fewer generations than fitness-only search. See
   [`docs/NOVELTY_SEARCH.md`](./docs/NOVELTY_SEARCH.md).
+
+### Changed
+
+- **Issue #3427:** The `requestedOptions` echo (Issue #3422) no longer records
+  non-serialisable options with a `"[function]"` / `"[unserialisable]"` marker —
+  such entries are now dropped entirely, since the markers carry no tuning value
+  and are pure noise in every GRQ-cluster snapshot. The one exception is
+  `creatures`: instead of dropping the seed-creature array it is echoed as its
+  **count** (a number, e.g. `"creatures": 12`; an empty seed array echoes as
+  `0`), because seed size can matter when comparing runs. The
+  `OPTION_FUNCTION_MARKER` / `OPTION_UNSERIALISABLE_MARKER` exports are removed.
 
 ### Fixed
 

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.9.30",
+  "version": "5.9.31",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/api/EVOLUTION.md
+++ b/docs/api/EVOLUTION.md
@@ -215,8 +215,10 @@ below mirror `src/creature/EvolveRunStatistics.ts`.
 // population sizing (AdaptivePopulationConfig) is enabled.
 
 // requestedOptions — echo of just the options the caller requested (changes
-// from defaults). Function/callback options are recorded as "[function]" and
-// non-serialisable values as "[unserialisable]" rather than dropped silently.
+// from defaults). Non-serialisable options (functions/callbacks and other
+// values that cannot round-trip through JSON) are dropped entirely. The one
+// exception is `creatures`: the seed array is echoed as its count (a number),
+// e.g. `creatures: 12`; an empty seed array echoes as 0 (Issue #3427).
 type OptionsEcho = Record<string, unknown>;
 
 // hardware — machine descriptors for cross-machine comparison. The best-effort

--- a/docs/archive/pr-summaries/pr-summary-3427.md
+++ b/docs/archive/pr-summaries/pr-summary-3427.md
@@ -1,0 +1,60 @@
+## Summary
+
+The `requestedOptions` echo added by #3422 (`serialiseOptionsEcho` in
+`src/creature/EvolveOptionsEcho.ts`) recorded every caller-supplied option,
+replacing values that cannot round-trip through JSON with a `"[function]"` /
+`"[unserialisable]"` marker. Those marker entries — notably `creatures` (the
+seed-creature array), which landed as `"[unserialisable]"` in every GRQ-cluster
+snapshot — are pure noise with no tuning value.
+
+This change drops **every** marker-valued entry from the echo: any option whose
+value cannot serialise (functions, callbacks, non-JSON values) is now omitted
+entirely — no marker remains. The one exception is `creatures`: instead of
+dropping the seed array it is echoed as its **count** (a number, e.g.
+`"creatures": 12`), since seed size can matter when comparing runs. An empty
+seed array echoes as `0`; when the caller supplies no `creatures` option at all,
+nothing is echoed. Serialisable options (e.g. `creatureStore`) are unaffected.
+
+The now-unused `OPTION_FUNCTION_MARKER` / `OPTION_UNSERIALISABLE_MARKER` exports
+are removed. Historic snapshot files already committed in GRQ-cluster are not
+rewritten; the new field shape applies to future runs once GRQ picks up a
+NEAT-AI release containing this fix (release is human-gated, out of scope here).
+
+Closes #3427.
+
+## Evidence
+
+Backend/library change with no web interface to screenshot. Verified via unit
+and integration tests (all passing) — see the Test Plan below.
+
+```mermaid
+flowchart TD
+    A[option key/value] --> B{value === undefined?}
+    B -- yes --> S[skip]
+    B -- no --> C{key is 'creatures'<br/>and Array?}
+    C -- yes --> D["echo count (value.length)"]
+    C -- no --> E{typeof function?}
+    E -- yes --> S
+    E -- no --> F{JSON round-trips?}
+    F -- no --> S
+    F -- yes --> G[echo cloned value]
+```
+
+## Test Plan
+
+`test/creature/EvolveOptionsEcho.ts` (updated):
+
+- `drops function options entirely` — function/callback options are omitted, not
+  marked.
+- `drops non-serialisable (circular) values` — circular values are omitted, not
+  marked.
+- `echoes the creatures seed array as its count` — `creatures: [...]` → count.
+- `echoes an empty creatures array as 0`.
+- `omits creatures when the caller supplies none`.
+- Retained: serialisable echo, undefined skipping, empty-input, deep-clone.
+
+`test/creature/EvolveRunStatistics_integration.ts` (updated):
+
+- `evolveDataSet returns run-level tuning statistics` now asserts the
+  `onTrainingEvent` callback is dropped from `requestedOptions` (not echoed as a
+  marker) and never appears in the serialised result JSON.

--- a/docs/event-driven-evolution.md
+++ b/docs/event-driven-evolution.md
@@ -627,7 +627,7 @@ const { statistics } = await creature.evolveDataSet(data, opts);
 //   adaptivePopulation: false,    // AdaptivePopulationConfig.enabled
 //   // finalPopulationSize: 137,  // present ONLY when adaptivePopulation is on
 //   hardware: { cpuCores: 32, totalMemoryBytes: 67_000_000_000, host: "GRQ-7" },
-//   requestedOptions: { populationSize: 150, threads: 32, onTrainingEvent: "[function]" },
+//   requestedOptions: { populationSize: 150, threads: 32 }, // callbacks dropped; `creatures` echoed as a count
 //   improvement: {
 //     firstScore: 0.42, finalScore: 0.91, totalImprovement: 0.49,
 //     milestones: [ { fraction: 0.25, generation: 12, timeMs: 41000, scoredCount: 18000, score: 0.54 }, … ],

--- a/src/creature/EvolveOptionsEcho.ts
+++ b/src/creature/EvolveOptionsEcho.ts
@@ -1,6 +1,6 @@
 /**
  * Echo of the caller-supplied evolve options recorded on the run-level result
- * (Issue #3422).
+ * (Issue #3422, revised by Issue #3427).
  *
  * Only the options the calling program actually requested are echoed — the raw
  * options object passed to `evolveDir`/`evolveDataSet`/`evolveEnv`/`evolveRL`,
@@ -9,19 +9,21 @@
  * request keeps the persisted `result.json` small and shows exactly which knobs
  * a run turned.
  *
- * Options are serialised as passed. Non-serialisable entries are recorded by
- * name with a marker instead of being silently dropped: function/callback
- * options (e.g. `onTrainingEvent`, `customCost`, `logger`) become
- * `"[function]"` and anything that cannot round-trip through JSON (e.g. an
- * `AbortSignal`) becomes `"[unserialisable]"`. Recording the key with a marker
- * keeps the echo honest about what the caller requested without persisting an
- * unusable value.
+ * Options are serialised as passed. Entries whose value cannot round-trip
+ * through JSON — function/callback options (e.g. `onTrainingEvent`,
+ * `customCost`, `logger`) and anything else non-serialisable (e.g. an
+ * `AbortSignal`) — are dropped entirely rather than recorded with a marker
+ * (Issue #3427): such markers carry no tuning value and are pure noise.
+ *
+ * The one exception is `creatures`, the seed-creature array. It never
+ * round-trips cleanly, but its size can matter when comparing runs, so instead
+ * of dropping it the echo records the seed-creature **count** as a number
+ * (e.g. `"creatures": 12`). An empty seed array echoes as `0`; when the caller
+ * supplies no `creatures` option at all, nothing is echoed.
  */
 
-/** Marker recorded for a function/callback-valued option. */
-export const OPTION_FUNCTION_MARKER = "[function]";
-/** Marker recorded for an option that cannot round-trip through JSON. */
-export const OPTION_UNSERIALISABLE_MARKER = "[unserialisable]";
+/** Option name whose value is echoed as a seed-creature count, not the array. */
+const CREATURES_OPTION = "creatures";
 
 /** JSON-safe echo of the caller-requested options, keyed by option name. */
 export type OptionsEcho = Record<string, unknown>;
@@ -29,8 +31,9 @@ export type OptionsEcho = Record<string, unknown>;
 /**
  * Serialise the caller-supplied options object into a JSON-safe
  * {@link OptionsEcho}. Only the caller's own enumerable keys are echoed;
- * `undefined` values are skipped, functions become {@link OPTION_FUNCTION_MARKER},
- * and non-serialisable values become {@link OPTION_UNSERIALISABLE_MARKER}.
+ * `undefined` values are skipped, the `creatures` seed array is echoed as its
+ * count, and any other value that cannot round-trip through JSON (functions,
+ * non-serialisable values) is dropped entirely — no marker is recorded.
  */
 export function serialiseOptionsEcho(
   options: object | undefined,
@@ -40,20 +43,26 @@ export function serialiseOptionsEcho(
 
   for (const [key, value] of Object.entries(options)) {
     if (value === undefined) continue;
-    if (typeof value === "function") {
-      echo[key] = OPTION_FUNCTION_MARKER;
+
+    // Seed creatures never round-trip cleanly; record the count instead of the
+    // (unserialisable) array so seed size stays comparable between runs.
+    if (key === CREATURES_OPTION && Array.isArray(value)) {
+      echo[key] = value.length;
       continue;
     }
+
+    // Functions/callbacks cannot serialise — drop them, no marker.
+    if (typeof value === "function") continue;
+
     try {
       const json = JSON.stringify(value);
       // JSON.stringify returns undefined for values with no JSON
-      // representation (e.g. a bare symbol); treat that as unserialisable.
-      echo[key] = json === undefined
-        ? OPTION_UNSERIALISABLE_MARKER
-        : JSON.parse(json);
+      // representation (e.g. a bare symbol); drop those too.
+      if (json === undefined) continue;
+      echo[key] = JSON.parse(json);
     } catch {
-      // Circular reference or a value whose toJSON throws.
-      echo[key] = OPTION_UNSERIALISABLE_MARKER;
+      // Circular reference or a value whose toJSON throws — drop it.
+      continue;
     }
   }
   return echo;

--- a/test/creature/EvolveOptionsEcho.ts
+++ b/test/creature/EvolveOptionsEcho.ts
@@ -1,16 +1,13 @@
 /**
- * Unit tests for {@link serialiseOptionsEcho} (Issue #3422): the caller-supplied
- * evolve options echoed onto the run-level result must round-trip serialisable
- * values, skip `undefined`, and record non-serialisable options by name with a
- * marker rather than dropping them silently.
+ * Unit tests for {@link serialiseOptionsEcho} (Issue #3422, revised by Issue
+ * #3427): the caller-supplied evolve options echoed onto the run-level result
+ * must round-trip serialisable values, skip `undefined`, drop any
+ * non-serialisable option entirely (no marker), and record the `creatures`
+ * seed array as its count.
  */
 
 import { assertEquals } from "@std/assert";
-import {
-  OPTION_FUNCTION_MARKER,
-  OPTION_UNSERIALISABLE_MARKER,
-  serialiseOptionsEcho,
-} from "@creature/EvolveOptionsEcho.ts";
+import { serialiseOptionsEcho } from "@creature/EvolveOptionsEcho.ts";
 
 Deno.test("serialiseOptionsEcho - echoes serialisable options as passed", () => {
   const echo = serialiseOptionsEcho({
@@ -30,7 +27,7 @@ Deno.test("serialiseOptionsEcho - echoes serialisable options as passed", () => 
   });
 });
 
-Deno.test("serialiseOptionsEcho - records function options by name with marker", () => {
+Deno.test("serialiseOptionsEcho - drops function options entirely", () => {
   const echo = serialiseOptionsEcho({
     populationSize: 10,
     onTrainingEvent: () => {},
@@ -39,19 +36,40 @@ Deno.test("serialiseOptionsEcho - records function options by name with marker",
     },
   });
 
-  assertEquals(echo.populationSize, 10);
-  assertEquals(echo.onTrainingEvent, OPTION_FUNCTION_MARKER);
-  assertEquals(echo.customCost, OPTION_FUNCTION_MARKER);
+  assertEquals(echo, { populationSize: 10 });
+  assertEquals(Object.hasOwn(echo, "onTrainingEvent"), false);
+  assertEquals(Object.hasOwn(echo, "customCost"), false);
 });
 
-Deno.test("serialiseOptionsEcho - marks non-serialisable (circular) values", () => {
+Deno.test("serialiseOptionsEcho - drops non-serialisable (circular) values", () => {
   const circular: Record<string, unknown> = { name: "loop" };
   circular.self = circular;
 
   const echo = serialiseOptionsEcho({ populationSize: 5, circular });
 
-  assertEquals(echo.populationSize, 5);
-  assertEquals(echo.circular, OPTION_UNSERIALISABLE_MARKER);
+  assertEquals(echo, { populationSize: 5 });
+  assertEquals(Object.hasOwn(echo, "circular"), false);
+});
+
+Deno.test("serialiseOptionsEcho - echoes the creatures seed array as its count", () => {
+  const echo = serialiseOptionsEcho({
+    creatureStore: ".creatures",
+    creatures: [{ id: "a" }, { id: "b" }, { id: "c" }],
+  });
+
+  assertEquals(echo, { creatureStore: ".creatures", creatures: 3 });
+});
+
+Deno.test("serialiseOptionsEcho - echoes an empty creatures array as 0", () => {
+  const echo = serialiseOptionsEcho({ creatures: [] });
+
+  assertEquals(echo, { creatures: 0 });
+});
+
+Deno.test("serialiseOptionsEcho - omits creatures when the caller supplies none", () => {
+  const echo = serialiseOptionsEcho({ populationSize: 20 });
+
+  assertEquals(Object.hasOwn(echo, "creatures"), false);
 });
 
 Deno.test("serialiseOptionsEcho - skips undefined values", () => {

--- a/test/creature/EvolveRunStatistics_integration.ts
+++ b/test/creature/EvolveRunStatistics_integration.ts
@@ -47,10 +47,13 @@ Deno.test("evolveDataSet returns run-level tuning statistics", async () => {
   assert(Object.hasOwn(result.hardware, "host"));
 
   // Requested options echoed as the caller's changes from defaults, with the
-  // callback recorded by marker (not serialised).
+  // non-serialisable callback dropped entirely rather than marked (Issue #3427).
   assertEquals(result.requestedOptions.populationSize, 12);
   assertEquals(result.requestedOptions.iterations, 8);
-  assertEquals(result.requestedOptions.onTrainingEvent, "[function]");
+  assertEquals(
+    Object.hasOwn(result.requestedOptions, "onTrainingEvent"),
+    false,
+  );
 
   // Improvement summary reflects the run: final score matches result.score and
   // milestone fractions are a subset of the fixed schedule.
@@ -66,8 +69,8 @@ Deno.test("evolveDataSet returns run-level tuning statistics", async () => {
   }
 
   // The whole result must survive JSON serialisation (it lands in result.json),
-  // with the callback recorded by marker rather than a function body.
+  // with the callback dropped rather than echoed as a function body or marker.
   const json = JSON.stringify(result);
   assert(json.length > 0);
-  assert(!json.includes('"onTrainingEvent":{'), "no function body in echo");
+  assert(!json.includes("onTrainingEvent"), "callback dropped from echo");
 });


### PR DESCRIPTION
## Summary

The `requestedOptions` echo added by #3422 (`serialiseOptionsEcho` in
`src/creature/EvolveOptionsEcho.ts`) recorded every caller-supplied option,
replacing values that cannot round-trip through JSON with a `"[function]"` /
`"[unserialisable]"` marker. Those marker entries — notably `creatures` (the
seed-creature array), which landed as `"[unserialisable]"` in every GRQ-cluster
snapshot — are pure noise with no tuning value.

This change drops **every** marker-valued entry from the echo: any option whose
value cannot serialise (functions, callbacks, non-JSON values) is now omitted
entirely — no marker remains. The one exception is `creatures`: instead of
dropping the seed array it is echoed as its **count** (a number, e.g.
`"creatures": 12`), since seed size can matter when comparing runs. An empty
seed array echoes as `0`; when the caller supplies no `creatures` option at all,
nothing is echoed. Serialisable options (e.g. `creatureStore`) are unaffected.

The now-unused `OPTION_FUNCTION_MARKER` / `OPTION_UNSERIALISABLE_MARKER` exports
are removed. Historic snapshot files already committed in GRQ-cluster are not
rewritten; the new field shape applies to future runs once GRQ picks up a
NEAT-AI release containing this fix (release is human-gated, out of scope here).

Closes #3427.

## Evidence

Backend/library change with no web interface to screenshot. Verified via unit
and integration tests (all passing) — see the Test Plan below.

```mermaid
flowchart TD
    A[option key/value] --> B{value === undefined?}
    B -- yes --> S[skip]
    B -- no --> C{key is 'creatures'<br/>and Array?}
    C -- yes --> D["echo count (value.length)"]
    C -- no --> E{typeof function?}
    E -- yes --> S
    E -- no --> F{JSON round-trips?}
    F -- no --> S
    F -- yes --> G[echo cloned value]
```

## Test Plan

`test/creature/EvolveOptionsEcho.ts` (updated):

- `drops function options entirely` — function/callback options are omitted, not
  marked.
- `drops non-serialisable (circular) values` — circular values are omitted, not
  marked.
- `echoes the creatures seed array as its count` — `creatures: [...]` → count.
- `echoes an empty creatures array as 0`.
- `omits creatures when the caller supplies none`.
- Retained: serialisable echo, undefined skipping, empty-input, deep-clone.

`test/creature/EvolveRunStatistics_integration.ts` (updated):

- `evolveDataSet returns run-level tuning statistics` now asserts the
  `onTrainingEvent` callback is dropped from `requestedOptions` (not echoed as a
  marker) and never appears in the serialised result JSON.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mryq6o76-76c9fd`<!-- vibe-worker-issue-3427 -->