### PR TITLE
Align AnalysisHeapGuard with MemoryMonitor heap_size_limit denominator (#3433)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-3433.md
+++ b/docs/archive/pr-summaries/pr-summary-3433.md
@@ -1,0 +1,70 @@
+# Align AnalysisHeapGuard with the MemoryMonitor heap_size_limit denominator
+
+## Summary
+
+Issue #3410 fixed `MemoryMonitor` to measure heap pressure against the real V8
+`heap_size_limit` (the OOM ceiling resolved via `resolveHeapLimit`), not the
+dynamically-committed `heapTotal`. Discovery's
+`AnalysisHeapGuard.sampleHeapPressure` was still computing its usage fraction as
+`heapUsed / heapTotal`, so its degrade/abort decisions could disagree with
+`MemoryMonitor` on the same `Deno.memoryUsage()` / V8 sample — firing CRITICAL
+against a tiny committed heap while gigabytes of headroom remained.
+
+`sampleHeapPressure` now resolves the denominator through the same shared
+`resolveHeapLimit` helper `MemoryMonitor` uses, so the two agree on the pressure
+level for any given sample. The off-heap RSS / `nativeBudgetBytes` abort rules
+(Issue #3025) are unchanged and still apply on top of the corrected V8 fraction.
+`HeapGuardSample` gains a `heapLimit` field mirroring the resolved denominator.
+
+Closes #3433.
+
+## Change flow
+
+```mermaid
+flowchart LR
+    S[Deno.memoryUsage sample] --> R[resolveHeapLimit]
+    R --> F["usageFraction = heapUsed / heapLimit"]
+    F --> P[determinePressureLevel]
+    P --> MM[MemoryMonitor.checkMemoryAndEvict]
+    P --> HG[AnalysisHeapGuard.sampleHeapPressure]
+    HG --> RSS["RSS / nativeBudgetBytes abort rules (#3025)"]
+```
+
+Both `MemoryMonitor` and the Discovery heap guard now flow through the same
+`resolveHeapLimit` denominator, so they classify pressure identically.
+
+## Evidence
+
+Backend/CLI change — no web interface to screenshot. Verified via unit tests
+(`deno test`), `deno fmt --check`, `deno lint`, and `deno check`.
+
+Old formula (`heapUsed / heapTotal`): 231 MB / 269 MB ≈ 0.86 → CRITICAL. New
+formula (`heapUsed / heapLimit`): 231 MB / 4373 MB ≈ 0.05 → normal. The
+regression test below fails on the old formula and passes on the shared helper.
+
+## Test Plan
+
+Added to `test/ErrorGuidedStructuralEvolution/AnalysisHeapGuard.ts`:
+
+- `sampleHeapPressure: small committed heapTotal + large heapLimit is NOT
+  critical (#3433)`
+  — the #3410 regression mirror; CRITICAL under the old formula, normal under
+  the shared denominator.
+- `sampleHeapPressure: divides heapUsed by heapLimit not heapTotal (#3433)`.
+- `sampleHeapPressure: critical when heapUsed near heapLimit (#3433)`.
+- `sampleHeapPressure: falls back to heapTotal when heapLimit unreported
+  (#3433)`
+  — preserves legacy behaviour when the runtime cannot report the limit.
+- `isHeapCritical: large heapLimit keeps a small committed heap non-critical
+  (#3433)`.
+
+Updated existing `HeapGuardSample` literals in the same file and in
+`test/ErrorGuidedStructuralEvolution/DiscoveryAnalysisMemory.ts` to include the
+new `heapLimit` field. All existing #3025 / #2594 guard tests still pass
+unchanged (27 tests in `AnalysisHeapGuard.ts`), and the #3410 `MemoryMonitor`
+tests remain green.
+
+## Docs
+
+`docs/troubleshooting/MEMORY.md` now notes that the Discovery analysis-extension
+guard shares the `resolveHeapLimit` denominator with `MemoryMonitor`.

--- a/docs/troubleshooting/MEMORY.md
+++ b/docs/troubleshooting/MEMORY.md
@@ -83,6 +83,13 @@ holder.
 > `[MemoryMonitor] Heap: <used> / <limit> (<pct>%)` log line shows the real
 > ceiling. When the runtime cannot report the limit the monitor falls back to
 > `heapTotal` (legacy behaviour).
+>
+> **Discovery shares this denominator.** The Discovery analysis-extension guard
+> (`AnalysisHeapGuard.sampleHeapPressure`) resolves its pressure fraction with
+> the same `resolveHeapLimit` helper, so the guard's degrade/abort decisions and
+> the `MemoryMonitor` pressure level agree for the same `Deno.memoryUsage()` /
+> V8 sample (Issue #3433). The guard's off-heap RSS / `nativeBudgetBytes` abort
+> rules (Issue #3025) still apply on top of the corrected V8 fraction.
 
 **Step 2 — Adjust `MemoryMonitor` thresholds:**
 

--- a/src/architecture/ErrorGuidedStructuralEvolution/AnalysisHeapGuard.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/AnalysisHeapGuard.ts
@@ -23,6 +23,7 @@ import {
   determinePressureLevel,
   type MemoryUsageProvider,
   type PressureLevel,
+  resolveHeapLimit,
 } from "@neat/MemoryMonitor.ts";
 import type { Logger } from "@utils/Logger.ts";
 
@@ -32,6 +33,13 @@ export interface HeapGuardSample {
   pressureLevel: PressureLevel;
   heapUsed: number;
   heapTotal: number;
+  /**
+   * The V8 old-space heap **limit** in bytes — the real OOM ceiling used as the
+   * pressure denominator, shared with `MemoryMonitor` via `resolveHeapLimit`
+   * (Issue #3433). Falls back to the committed `heapTotal` when the provider
+   * does not report the limit.
+   */
+  heapLimit: number;
   /**
    * Resident-set size in bytes (off-heap / native / Rust + V8). Issue #3025.
    * `0` when the provider does not report RSS.
@@ -65,10 +73,15 @@ export function _setHeapGuardProviderForTests(
 /**
  * Sample the current heap pressure using the configured thresholds.
  *
- * Returns the raw sample together with the derived `pressureLevel`. When
- * `heapTotal` is reported as 0 (e.g. on a runtime that does not expose heap
- * stats), the sample is treated as `normal` — we never abort discovery on
- * missing telemetry.
+ * Returns the raw sample together with the derived `pressureLevel`. The usage
+ * fraction divides `heapUsed` by the real V8 old-space **limit** resolved via
+ * the shared `resolveHeapLimit` helper — the same denominator `MemoryMonitor`
+ * uses (Issue #3433) — not the committed `heapTotal`, which starts small and
+ * grows over the run. Dividing by `heapTotal` made the guard read CRITICAL
+ * against a tiny committed heap and disagree with `MemoryMonitor` on the same
+ * sample. When the resolved limit is 0 (e.g. a runtime that exposes neither the
+ * limit nor `heapTotal`), the sample is treated as `normal` — we never abort
+ * discovery on missing telemetry.
  */
 export function sampleHeapPressure(
   memoryConfig: RequiredMemoryConfig,
@@ -77,10 +90,9 @@ export function sampleHeapPressure(
   const effectiveProvider = provider ?? _providerOverride ??
     defaultMemoryUsageProvider;
   const sample = effectiveProvider();
-  const usageFraction = sample.heapTotal > 0
-    ? sample.heapUsed / sample.heapTotal
-    : 0;
-  const pressureLevel = sample.heapTotal > 0
+  const heapLimit = resolveHeapLimit(sample);
+  const usageFraction = heapLimit > 0 ? sample.heapUsed / heapLimit : 0;
+  const pressureLevel = heapLimit > 0
     ? determinePressureLevel(usageFraction, memoryConfig)
     : "normal";
   return {
@@ -88,6 +100,7 @@ export function sampleHeapPressure(
     pressureLevel,
     heapUsed: sample.heapUsed,
     heapTotal: sample.heapTotal,
+    heapLimit,
     rss: sample.rss ?? 0,
     external: sample.external ?? 0,
   };

--- a/test/ErrorGuidedStructuralEvolution/AnalysisHeapGuard.ts
+++ b/test/ErrorGuidedStructuralEvolution/AnalysisHeapGuard.ts
@@ -63,6 +63,72 @@ Deno.test("sampleHeapPressure: heapTotal=0 reports normal (no telemetry)", () =>
   assertEquals(sample.usageFraction, 0);
 });
 
+// --- Issue #3433: share the MemoryMonitor heap_size_limit denominator -------
+
+Deno.test("sampleHeapPressure: small committed heapTotal + large heapLimit is NOT critical (#3433)", () => {
+  // Mirrors #3410: heapUsed/heapTotal would read 231/269 ≈ 86% (CRITICAL), but
+  // dividing by the real V8 limit (4373 MB) gives ≈5% → normal. The guard must
+  // agree with MemoryMonitor and use the limit, not the committed heap.
+  const sample = sampleHeapPressure(
+    DEFAULT_MEMORY_CONFIG,
+    fixedProvider({
+      heapUsed: Math.round(231 * MB),
+      heapTotal: Math.round(269 * MB),
+      heapLimit: Math.round(4373 * MB),
+    }),
+  );
+  assert(
+    sample.usageFraction < 0.1,
+    `expected fraction against the limit, got ${sample.usageFraction}`,
+  );
+  assertEquals(sample.pressureLevel, "normal");
+  assertEquals(sample.heapLimit, Math.round(4373 * MB));
+});
+
+Deno.test("sampleHeapPressure: divides heapUsed by heapLimit not heapTotal (#3433)", () => {
+  const sample = sampleHeapPressure(
+    DEFAULT_MEMORY_CONFIG,
+    fixedProvider({ heapUsed: 90, heapTotal: 100, heapLimit: 1000 }),
+  );
+  assertEquals(sample.usageFraction, 0.09);
+  assertEquals(sample.pressureLevel, "normal");
+});
+
+Deno.test("sampleHeapPressure: critical when heapUsed near heapLimit (#3433)", () => {
+  const sample = sampleHeapPressure(
+    DEFAULT_MEMORY_CONFIG,
+    fixedProvider({ heapUsed: 950, heapTotal: 1000, heapLimit: 1000 }),
+  );
+  assertEquals(sample.usageFraction, 0.95);
+  assertEquals(sample.pressureLevel, "critical");
+});
+
+Deno.test("sampleHeapPressure: falls back to heapTotal when heapLimit unreported (#3433)", () => {
+  const sample = sampleHeapPressure(
+    DEFAULT_MEMORY_CONFIG,
+    fixedProvider({ heapUsed: 95, heapTotal: 100 }),
+  );
+  assertEquals(sample.heapLimit, 100);
+  assertEquals(sample.usageFraction, 0.95);
+  assertEquals(sample.pressureLevel, "critical");
+});
+
+Deno.test("isHeapCritical: large heapLimit keeps a small committed heap non-critical (#3433)", () => {
+  const config = { ...DEFAULT_MEMORY_CONFIG, nativeBudgetBytes: NATIVE_BUDGET };
+  assertEquals(
+    isHeapCritical(
+      config,
+      fixedProvider({
+        heapUsed: Math.round(231 * MB),
+        heapTotal: Math.round(269 * MB),
+        heapLimit: Math.round(4373 * MB),
+        rss: Math.round(13289 * MB),
+      }),
+    ),
+    false,
+  );
+});
+
 Deno.test("isHeapCritical: returns true when heap at critical", () => {
   assertEquals(
     isHeapCritical(
@@ -164,6 +230,7 @@ function criticalSample(rss: number): HeapGuardSample {
     pressureLevel: "critical",
     heapUsed: Math.round(231 * MB),
     heapTotal: Math.round(269 * MB),
+    heapLimit: Math.round(269 * MB),
     rss,
     external: Math.round(47 * MB),
   };
@@ -231,6 +298,7 @@ Deno.test("shouldAbortOnHeapPressure: non-critical never aborts even with budget
     pressureLevel: "normal",
     heapUsed: 10,
     heapTotal: 100,
+    heapLimit: 100,
     rss: NATIVE_BUDGET + MB, // even over budget — not critical, so no abort
     external: 0,
   };

--- a/test/ErrorGuidedStructuralEvolution/DiscoveryAnalysisMemory.ts
+++ b/test/ErrorGuidedStructuralEvolution/DiscoveryAnalysisMemory.ts
@@ -62,6 +62,7 @@ function sample(overrides: Partial<HeapGuardSample> = {}): HeapGuardSample {
     pressureLevel: "normal",
     heapUsed: 50 * MB,
     heapTotal: 100 * MB,
+    heapLimit: 100 * MB,
     rss: 100 * MB,
     external: 0,
     ...overrides,


### PR DESCRIPTION
# Align AnalysisHeapGuard with the MemoryMonitor heap_size_limit denominator

## Summary

Issue #3410 fixed `MemoryMonitor` to measure heap pressure against the real V8
`heap_size_limit` (the OOM ceiling resolved via `resolveHeapLimit`), not the
dynamically-committed `heapTotal`. Discovery's
`AnalysisHeapGuard.sampleHeapPressure` was still computing its usage fraction as
`heapUsed / heapTotal`, so its degrade/abort decisions could disagree with
`MemoryMonitor` on the same `Deno.memoryUsage()` / V8 sample — firing CRITICAL
against a tiny committed heap while gigabytes of headroom remained.

`sampleHeapPressure` now resolves the denominator through the same shared
`resolveHeapLimit` helper `MemoryMonitor` uses, so the two agree on the pressure
level for any given sample. The off-heap RSS / `nativeBudgetBytes` abort rules
(Issue #3025) are unchanged and still apply on top of the corrected V8 fraction.
`HeapGuardSample` gains a `heapLimit` field mirroring the resolved denominator.

Closes #3433.

## Change flow

```mermaid
flowchart LR
    S[Deno.memoryUsage sample] --> R[resolveHeapLimit]
    R --> F["usageFraction = heapUsed / heapLimit"]
    F --> P[determinePressureLevel]
    P --> MM[MemoryMonitor.checkMemoryAndEvict]
    P --> HG[AnalysisHeapGuard.sampleHeapPressure]
    HG --> RSS["RSS / nativeBudgetBytes abort rules (#3025)"]
```

Both `MemoryMonitor` and the Discovery heap guard now flow through the same
`resolveHeapLimit` denominator, so they classify pressure identically.

## Evidence

Backend/CLI change — no web interface to screenshot. Verified via unit tests
(`deno test`), `deno fmt --check`, `deno lint`, and `deno check`.

Old formula (`heapUsed / heapTotal`): 231 MB / 269 MB ≈ 0.86 → CRITICAL. New
formula (`heapUsed / heapLimit`): 231 MB / 4373 MB ≈ 0.05 → normal. The
regression test below fails on the old formula and passes on the shared helper.

## Test Plan

Added to `test/ErrorGuidedStructuralEvolution/AnalysisHeapGuard.ts`:

- `sampleHeapPressure: small committed heapTotal + large heapLimit is NOT
  critical (#3433)`
  — the #3410 regression mirror; CRITICAL under the old formula, normal under
  the shared denominator.
- `sampleHeapPressure: divides heapUsed by heapLimit not heapTotal (#3433)`.
- `sampleHeapPressure: critical when heapUsed near heapLimit (#3433)`.
- `sampleHeapPressure: falls back to heapTotal when heapLimit unreported
  (#3433)`
  — preserves legacy behaviour when the runtime cannot report the limit.
- `isHeapCritical: large heapLimit keeps a small committed heap non-critical
  (#3433)`.

Updated existing `HeapGuardSample` literals in the same file and in
`test/ErrorGuidedStructuralEvolution/DiscoveryAnalysisMemory.ts` to include the
new `heapLimit` field. All existing #3025 / #2594 guard tests still pass
unchanged (27 tests in `AnalysisHeapGuard.ts`), and the #3410 `MemoryMonitor`
tests remain green.

## Docs

`docs/troubleshooting/MEMORY.md` now notes that the Discovery analysis-extension
guard shares the `resolveHeapLimit` denominator with `MemoryMonitor`.



## Milestone
This PR is part of the **OOME** milestone and targets the `milestone/oome` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mrzomd0w-73a91f`<!-- vibe-worker-issue-3433 -->