### PR TITLE
Dispose replaced champion clones and release caches on evolve teardown (Issue #3434)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-3434.md
+++ b/docs/archive/pr-summaries/pr-summary-3434.md
@@ -1,0 +1,91 @@
+# evolveDir: dispose replaced champion clones and release population/caches on teardown
+
+## Summary
+
+`evolveDir` (and its siblings `evolveEnv` / `evolveRL`) leaked at the **run**
+level: each champion improvement overwrote `bestCreature` with a fresh
+`shallowClone()` and left the superseded clone reachable until GC, and after the
+run neither the population members nor the final champion clone were disposed
+and the process-global breed/discovery caches were left populated. Repeated
+`evolve*` calls in one process therefore accumulated sticky WASM compilation
+templates and breed/discovery indexes and pinned RSS high. Per-generation
+dropout dispose (#1568) already runs inside `NeatEvolution`; this closes the
+run-level gap. **Closes #3434.**
+
+The fix adds a small shared teardown module,
+[`src/creature/EvolveTeardown.ts`](../../../src/creature/EvolveTeardown.ts),
+wired into all three entry points (`evolveDataSet` is covered transitively — it
+delegates to `evolveDir`):
+
+1. **Dispose-on-replace** — `adoptChampionClone(previousBest, fittest, score)`
+   disposes the superseded champion before cloning the new one. This is safe
+   because the evolve loop passes the current champion into `neat.evolve()` as a
+   read-only parent _before_ the replace, and `neat.evolve()` clones (never
+   retains) it — so the old champion is dead once the call returns.
+2. **Population dispose on exit** —
+   `disposeEvolvePopulation(neat.population,
+   creature)` disposes every
+   population member from the run except the caller creature (member 0 of the
+   population). The champion is restored into the caller via `loadFrom`, which
+   rebuilds the caller's own arrays, so the caller stays valid. The temporary
+   `bestCreature` clone is disposed after `loadFrom`.
+3. **Cache release on exit** — `releaseEvolveCaches()` clears the process-global
+   `DistanceCache`, the WASM compilation cache, and the shared subnetwork hash
+   index, so a second `evolve*` in the same process starts from a clean
+   baseline.
+
+## Evidence
+
+This is a backend/lifecycle change — no web interface to screenshot. Verified
+via unit tests plus the existing evolve integration suites.
+
+### Run-level teardown flow
+
+```mermaid
+flowchart TD
+    subgraph Loop["evolve loop (per generation)"]
+        A[neat.evolve bestCreature<br/>reads champion as parent] --> B{champion improved?}
+        B -- yes --> C["adoptChampionClone:<br/>previousBest.dispose()<br/>then clone new champion"]
+        B -- no --> D[keep current champion]
+        C --> A
+        D --> A
+    end
+    Loop --> E[loop completes]
+    E --> F[terminate workers /<br/>await replay queue]
+    F --> G["creature.loadFrom(bestCreature)<br/>rebuilds caller arrays"]
+    G --> H["writeCreatures (checkpoint)"]
+    H --> I["disposeEvolvePopulation<br/>(keep caller creature)"]
+    I --> J["bestCreature.dispose()"]
+    J --> K["releaseEvolveCaches:<br/>DistanceCache + WASM compilation<br/>+ subnetwork index"]
+    K --> L[return EvolveResult]
+```
+
+### Test results
+
+- New unit tests: `deno test test/creature/EvolveTeardown.ts` → **7 passed**.
+- evolveDir integration: `test/creature/CreatureTrainEvolve.ts` → 19 passed.
+- evolveEnv / evolveRL: `test/creature/EvolveEnv.ts`,
+  `test/creature/evolveRL_test.ts`,
+  `test/creature/evolveRL_heapStability_test.ts` → 24 passed.
+- `deno fmt` / `deno lint` clean on all changed files.
+
+> One pre-existing, unrelated failure remains in
+> `test/ErrorGuidedStructuralEvolution/DiscoveryHeapAbortBoundaryIntegration.ts`
+> (it asserts the machine's **live** V8 heap fraction is critical; it fails on a
+> clean baseline of this branch too, with none of this issue's files loaded). It
+> stems from the recent #3433 heap-guard alignment, not from this change, and is
+> out of scope here.
+
+## Test Plan
+
+Added `test/creature/EvolveTeardown.ts` — pure "what" tests, no timing APIs:
+
+- `adoptChampionClone` disposes the previous champion, returns a fresh,
+  independent clone with the new score, and leaves the source `fittest` intact.
+- `adoptChampionClone` with no previous champion (first win) just returns the
+  clone.
+- `disposeEvolvePopulation` disposes every member except the caller creature and
+  returns the disposed count (including the caller-at-index-0 case).
+- `releaseEvolveCaches` clears a seeded `DistanceCache` entry, the shared
+  subnetwork index, and a seeded WASM compilation template (probed by unique
+  keys so the assertions are robust under the parallel test runner).

--- a/src/creature/CreatureTraining.ts
+++ b/src/creature/CreatureTraining.ts
@@ -78,6 +78,11 @@ import type { Fitness } from "@architecture/Fitness.ts";
 import type { EpisodeAdapter } from "@creature/EpisodeAdapter.ts";
 import { buildRLSeedSet } from "@creature/EvolveRLSeedSet.ts";
 import {
+  adoptChampionClone,
+  disposeEvolvePopulation,
+  releaseEvolveCaches,
+} from "@creature/EvolveTeardown.ts";
+import {
   accumulatePhaseTiming,
   createPhaseTimingAccumulator,
   finalisePhaseTimingTotals,
@@ -611,10 +616,13 @@ export async function evolveDir(
       // Issue #2276: Use shallowClone() instead of exportJSONWithRuntimeIds +
       // fromJSON round-trip. shallowClone() is 2.4–3.5x faster (Issue #1586)
       // and preserves all necessary state including runtime IDs and UUIDs.
-      bestCreature = fittest.shallowClone() as InstanceType<
-        typeof CreatureClass
-      >;
-      bestCreature.score = bestScore;
+      // Issue #3434: dispose the superseded champion clone before overwriting
+      // it so its topology arrays / WASM activation are released immediately.
+      bestCreature = adoptChampionClone(
+        bestCreature,
+        fittest,
+        bestScore,
+      ) as InstanceType<typeof CreatureClass>;
       championImproved = true;
     }
 
@@ -780,6 +788,15 @@ export async function evolveDir(
   if (config.creatureStore) {
     await writeCreatures(neat, config.creatureStore);
   }
+
+  // Issue #3434: run-level lifecycle teardown. The champion has been restored
+  // into (and any checkpoint written from) the population above, so dispose the
+  // run's population (keeping the caller creature), dispose the temporary
+  // champion clone, and release the process-global breed/discovery caches so a
+  // second evolveDir in the same process starts from a clean baseline.
+  disposeEvolvePopulation(neat.population, creature);
+  bestCreature?.dispose();
+  releaseEvolveCaches();
 
   Deno.removeSignalListener("SIGTERM", signalListener);
   const time = Date.now() - start;
@@ -968,10 +985,12 @@ export async function evolveEnv<S, A>(
       assert(parsedError >= 0, "Error is negative");
       error = parsedError;
       bestScore = fittestScore;
-      bestCreature = fittest.shallowClone() as InstanceType<
-        typeof CreatureClass
-      >;
-      bestCreature.score = bestScore;
+      // Issue #3434: dispose the superseded champion clone before overwriting.
+      bestCreature = adoptChampionClone(
+        bestCreature,
+        fittest,
+        bestScore,
+      ) as InstanceType<typeof CreatureClass>;
       championImproved = true;
     }
 
@@ -1115,6 +1134,13 @@ export async function evolveEnv<S, A>(
   if (config.creatureStore) {
     await writeCreatures(neat, config.creatureStore);
   }
+
+  // Issue #3434: run-level lifecycle teardown — dispose the run's population
+  // (keeping the caller creature), dispose the temporary champion clone, and
+  // release the process-global breed/discovery caches.
+  disposeEvolvePopulation(neat.population, creature);
+  bestCreature?.dispose();
+  releaseEvolveCaches();
 
   Deno.removeSignalListener("SIGTERM", signalListener);
   options.signal?.removeEventListener("abort", abortListener);
@@ -1501,10 +1527,12 @@ export async function evolveRL<S, A>(
       assert(parsedError >= 0, "Error is negative");
       error = parsedError;
       bestScore = fittestScore;
-      bestCreature = fittest.shallowClone() as InstanceType<
-        typeof CreatureClass
-      >;
-      bestCreature.score = bestScore;
+      // Issue #3434: dispose the superseded champion clone before overwriting.
+      bestCreature = adoptChampionClone(
+        bestCreature,
+        fittest,
+        bestScore,
+      ) as InstanceType<typeof CreatureClass>;
       championImproved = true;
     }
 
@@ -1715,6 +1743,13 @@ export async function evolveRL<S, A>(
   if (config.creatureStore) {
     await writeCreatures(neat, config.creatureStore);
   }
+
+  // Issue #3434: run-level lifecycle teardown — dispose the run's population
+  // (keeping the caller creature), dispose the temporary champion clone, and
+  // release the process-global breed/discovery caches.
+  disposeEvolvePopulation(neat.population, creature);
+  bestCreature?.dispose();
+  releaseEvolveCaches();
 
   Deno.removeSignalListener("SIGTERM", signalListener);
   options.signal?.removeEventListener("abort", abortListener);

--- a/src/creature/EvolveTeardown.ts
+++ b/src/creature/EvolveTeardown.ts
@@ -1,0 +1,98 @@
+/**
+ * EvolveTeardown.ts - Run-level lifecycle teardown shared by the `evolve*`
+ * entry points (Issue #3434).
+ *
+ * `evolveDir`, `evolveEnv`, and `evolveRL` share the same outer shape: they
+ * track a champion clone across generations, restore it into the caller
+ * creature at the end, then return. Before this module they leaked in two
+ * ways:
+ *
+ *  1. Each champion improvement overwrote `bestCreature` with a fresh
+ *     `shallowClone()` and left the superseded clone's topology arrays and
+ *     cached WASM activation reachable until the next GC.
+ *  2. After the run, `neat.population` members and the final champion clone
+ *     were never disposed, and the process-global breed/discovery caches
+ *     (DistanceCache, WASM compilation cache, shared subnetwork index) were
+ *     left populated — so a second `evolve*` call in the same process started
+ *     from a dirty baseline and RSS crept up across repeated runs.
+ *
+ * Per-generation dropout dispose (#1568) already runs inside `NeatEvolution`;
+ * these helpers are the missing run-level counterpart. Keeping them in one
+ * module keeps the three entry points DRY and independently testable.
+ */
+
+import type { Creature } from "@creature";
+import { clearDistanceCache } from "@breed/DistanceCache.ts";
+import { clearWasmCompilationCache } from "@wasm/WasmCompilationCache.ts";
+import { getSharedSubnetworkIndex } from "@discovery/SubnetworkHashIndex.ts";
+
+/**
+ * Adopt a new champion clone, disposing the one it replaces (Issue #3434).
+ *
+ * The evolve loop passes the current champion into `neat.evolve()` as a
+ * read-only parent before this is called, and `neat.evolve()` clones (never
+ * retains) that creature — so the superseded champion is safe to dispose here.
+ * The returned clone is independent of both `previousBest` and `fittest`
+ * (`shallowClone()` builds fresh neuron/synapse arrays), so disposing
+ * `previousBest` first cannot corrupt the clone.
+ *
+ * @param previousBest The champion being replaced (`undefined` on first win).
+ * @param fittest The generation's fittest creature to clone as the new champion.
+ * @param score Score to stamp on the new champion clone.
+ * @returns The fresh champion clone with `score` applied.
+ */
+export function adoptChampionClone(
+  previousBest: Creature | undefined,
+  fittest: Creature,
+  score: number,
+): Creature {
+  previousBest?.dispose();
+  const clone = fittest.shallowClone();
+  clone.score = score;
+  return clone;
+}
+
+/**
+ * Dispose every population creature from a finished run except the caller's
+ * creature, which the caller keeps using after `evolve*` returns (Issue #3434).
+ *
+ * The caller creature is member 0 of `neat.population` (see
+ * `Neat.populatePopulation`), so it is skipped by identity. Population members
+ * are independent of the caller creature — the champion is restored into the
+ * caller via `loadFrom`, which rebuilds the caller's arrays — so disposing the
+ * rest cannot invalidate it.
+ *
+ * @param population The run's final population.
+ * @param keep The caller creature to preserve.
+ * @returns The number of population members disposed.
+ */
+export function disposeEvolvePopulation(
+  population: readonly Creature[],
+  keep: Creature,
+): number {
+  let disposed = 0;
+  for (const member of population) {
+    if (member === keep) continue;
+    member.dispose();
+    disposed++;
+  }
+  return disposed;
+}
+
+/**
+ * Release the process-global breed/discovery caches at the end of an `evolve*`
+ * run (Issue #3434): the DistanceCache, the WASM compilation cache, and the
+ * shared subnetwork hash index.
+ *
+ * Safe to call only once a run has finished producing its final creature and
+ * its worker pool has been terminated — every entry is a rebuildable cache, so
+ * the restored caller creature simply recompiles its WASM template on next use.
+ * Clearing them here ensures a second `evolve*` in the same process starts from
+ * a clean baseline rather than inheriting the previous run's sticky templates
+ * and breed/discovery indexes.
+ */
+export function releaseEvolveCaches(): void {
+  clearDistanceCache();
+  clearWasmCompilationCache();
+  getSharedSubnetworkIndex().clear();
+}

--- a/test/creature/EvolveTeardown.ts
+++ b/test/creature/EvolveTeardown.ts
@@ -1,0 +1,199 @@
+/**
+ * Tests for the run-level `evolve*` lifecycle teardown helpers (Issue #3434).
+ *
+ * These are pure "what" tests — they call the real helpers with real creatures
+ * and caches and assert on the observable outcome (disposed topology arrays,
+ * emptied caches, preserved caller creature). No timing APIs are used, so they
+ * are deterministic under the parallel test runner. Each cache test body is
+ * synchronous (no `await`) so it runs atomically with respect to any
+ * cross-file test that shares these process-global singletons.
+ */
+
+import { assertEquals } from "@std/assert";
+import { Creature } from "@creature";
+import {
+  adoptChampionClone,
+  disposeEvolvePopulation,
+  releaseEvolveCaches,
+} from "@creature/EvolveTeardown.ts";
+import {
+  clearDistanceCache,
+  getCachedDistance,
+  setCachedDistance,
+} from "@breed/DistanceCache.ts";
+import {
+  ensureWasmTemplate,
+  hasWasmTemplate,
+} from "@wasm/WasmCompilationCache.ts";
+import { getSharedSubnetworkIndex } from "@discovery/SubnetworkHashIndex.ts";
+import { CreatureUtil } from "@architecture/CreatureUtils.ts";
+
+function makeCreature(uuid: string): Creature {
+  const c = new Creature(3, 2, { layers: [{ count: 4, squash: "LOGISTIC" }] });
+  c.uuid = uuid;
+  c.score = 0.5;
+  return c;
+}
+
+Deno.test(
+  "adoptChampionClone disposes the previous champion and returns a fresh clone",
+  () => {
+    const previous = makeCreature("teardown-previous");
+    const fittest = makeCreature("teardown-fittest");
+    const fittestNeuronCount = fittest.neurons.length;
+
+    const next = adoptChampionClone(previous, fittest, 0.9);
+
+    // Previous champion disposed: topology arrays released.
+    assertEquals(previous.neurons.length, 0, "previous neurons not released");
+    assertEquals(previous.synapses.length, 0, "previous synapses not released");
+
+    // The returned clone is a distinct, valid champion carrying the new score.
+    assertEquals(next === fittest, false, "clone must not alias fittest");
+    assertEquals(next === previous, false, "clone must not alias previous");
+    assertEquals(next.score, 0.9, "score not stamped on clone");
+    assertEquals(
+      next.neurons.length,
+      fittestNeuronCount,
+      "clone topology should match the fittest it was cloned from",
+    );
+
+    // The source fittest is untouched by disposing the previous champion.
+    assertEquals(
+      fittest.neurons.length,
+      fittestNeuronCount,
+      "fittest must not be disposed",
+    );
+  },
+);
+
+Deno.test(
+  "adoptChampionClone with no previous champion returns the clone (first win)",
+  () => {
+    const fittest = makeCreature("teardown-first-win");
+    const next = adoptChampionClone(undefined, fittest, 0.42);
+
+    assertEquals(next === fittest, false, "clone must not alias fittest");
+    assertEquals(next.score, 0.42, "score not stamped on clone");
+    assertEquals(
+      next.neurons.length,
+      fittest.neurons.length,
+      "clone topology should match the fittest",
+    );
+  },
+);
+
+Deno.test(
+  "disposeEvolvePopulation disposes every member except the caller creature",
+  () => {
+    const keep = makeCreature("teardown-keep");
+    const a = makeCreature("teardown-a");
+    const b = makeCreature("teardown-b");
+    const keepNeuronCount = keep.neurons.length;
+
+    // Mirror the real population ordering: the caller creature is member 0.
+    const population = [keep, a, b];
+
+    const disposed = disposeEvolvePopulation(population, keep);
+
+    assertEquals(disposed, 2, "should report two disposed members");
+    assertEquals(a.neurons.length, 0, "member a not disposed");
+    assertEquals(b.neurons.length, 0, "member b not disposed");
+    assertEquals(
+      keep.neurons.length,
+      keepNeuronCount,
+      "caller creature must remain valid",
+    );
+    assertEquals(
+      keep.synapses.length > 0,
+      true,
+      "caller creature synapses must remain",
+    );
+  },
+);
+
+Deno.test(
+  "disposeEvolvePopulation returns 0 when only the caller creature is present",
+  () => {
+    const keep = makeCreature("teardown-solo");
+    const keepNeuronCount = keep.neurons.length;
+
+    const disposed = disposeEvolvePopulation([keep], keep);
+
+    assertEquals(disposed, 0, "no members should be disposed");
+    assertEquals(
+      keep.neurons.length,
+      keepNeuronCount,
+      "caller creature must remain valid",
+    );
+  },
+);
+
+Deno.test(
+  "releaseEvolveCaches clears a DistanceCache entry",
+  () => {
+    // Unique UUIDs so the assertion is robust under parallel cross-file tests
+    // that share the process-global DistanceCache.
+    const a = "teardown-distance-a-3434";
+    const b = "teardown-distance-b-3434";
+    clearDistanceCache();
+    setCachedDistance(a, b, 0.375);
+    assertEquals(getCachedDistance(a, b), 0.375, "entry not seeded");
+
+    releaseEvolveCaches();
+
+    assertEquals(
+      getCachedDistance(a, b),
+      undefined,
+      "DistanceCache entry should be cleared",
+    );
+  },
+);
+
+Deno.test(
+  "releaseEvolveCaches clears the shared subnetwork index",
+  () => {
+    const hash = "teardown-subnetwork-hash-3434";
+    const index = getSharedSubnetworkIndex();
+    index.insert(hash, {
+      source: "success",
+      changeType: "teardown-test",
+      cacheKey: "teardown-key",
+    });
+    assertEquals(
+      getSharedSubnetworkIndex().lookup(hash).length,
+      1,
+      "subnetwork entry not seeded",
+    );
+
+    releaseEvolveCaches();
+
+    assertEquals(
+      getSharedSubnetworkIndex().lookup(hash).length,
+      0,
+      "shared subnetwork index should be cleared",
+    );
+  },
+);
+
+Deno.test(
+  "releaseEvolveCaches clears the WASM compilation cache",
+  () => {
+    // A distinctive topology so the hash is unlikely to collide with any
+    // template a concurrent test compiles.
+    const creature = new Creature(7, 3, {
+      layers: [{ count: 11, squash: "TANH" }],
+    });
+    const hash = CreatureUtil.getTopologyHash(creature);
+    ensureWasmTemplate(creature);
+    assertEquals(hasWasmTemplate(hash), true, "WASM template not seeded");
+
+    releaseEvolveCaches();
+
+    assertEquals(
+      hasWasmTemplate(hash),
+      false,
+      "WASM compilation cache should be cleared",
+    );
+  },
+);


### PR DESCRIPTION
# evolveDir: dispose replaced champion clones and release population/caches on teardown

## Summary

`evolveDir` (and its siblings `evolveEnv` / `evolveRL`) leaked at the **run**
level: each champion improvement overwrote `bestCreature` with a fresh
`shallowClone()` and left the superseded clone reachable until GC, and after the
run neither the population members nor the final champion clone were disposed
and the process-global breed/discovery caches were left populated. Repeated
`evolve*` calls in one process therefore accumulated sticky WASM compilation
templates and breed/discovery indexes and pinned RSS high. Per-generation
dropout dispose (#1568) already runs inside `NeatEvolution`; this closes the
run-level gap. **Closes #3434.**

The fix adds a small shared teardown module,
[`src/creature/EvolveTeardown.ts`](../../../src/creature/EvolveTeardown.ts),
wired into all three entry points (`evolveDataSet` is covered transitively — it
delegates to `evolveDir`):

1. **Dispose-on-replace** — `adoptChampionClone(previousBest, fittest, score)`
   disposes the superseded champion before cloning the new one. This is safe
   because the evolve loop passes the current champion into `neat.evolve()` as a
   read-only parent _before_ the replace, and `neat.evolve()` clones (never
   retains) it — so the old champion is dead once the call returns.
2. **Population dispose on exit** —
   `disposeEvolvePopulation(neat.population,
   creature)` disposes every
   population member from the run except the caller creature (member 0 of the
   population). The champion is restored into the caller via `loadFrom`, which
   rebuilds the caller's own arrays, so the caller stays valid. The temporary
   `bestCreature` clone is disposed after `loadFrom`.
3. **Cache release on exit** — `releaseEvolveCaches()` clears the process-global
   `DistanceCache`, the WASM compilation cache, and the shared subnetwork hash
   index, so a second `evolve*` in the same process starts from a clean
   baseline.

## Evidence

This is a backend/lifecycle change — no web interface to screenshot. Verified
via unit tests plus the existing evolve integration suites.

### Run-level teardown flow

```mermaid
flowchart TD
    subgraph Loop["evolve loop (per generation)"]
        A[neat.evolve bestCreature<br/>reads champion as parent] --> B{champion improved?}
        B -- yes --> C["adoptChampionClone:<br/>previousBest.dispose()<br/>then clone new champion"]
        B -- no --> D[keep current champion]
        C --> A
        D --> A
    end
    Loop --> E[loop completes]
    E --> F[terminate workers /<br/>await replay queue]
    F --> G["creature.loadFrom(bestCreature)<br/>rebuilds caller arrays"]
    G --> H["writeCreatures (checkpoint)"]
    H --> I["disposeEvolvePopulation<br/>(keep caller creature)"]
    I --> J["bestCreature.dispose()"]
    J --> K["releaseEvolveCaches:<br/>DistanceCache + WASM compilation<br/>+ subnetwork index"]
    K --> L[return EvolveResult]
```

### Test results

- New unit tests: `deno test test/creature/EvolveTeardown.ts` → **7 passed**.
- evolveDir integration: `test/creature/CreatureTrainEvolve.ts` → 19 passed.
- evolveEnv / evolveRL: `test/creature/EvolveEnv.ts`,
  `test/creature/evolveRL_test.ts`,
  `test/creature/evolveRL_heapStability_test.ts` → 24 passed.
- `deno fmt` / `deno lint` clean on all changed files.

> One pre-existing, unrelated failure remains in
> `test/ErrorGuidedStructuralEvolution/DiscoveryHeapAbortBoundaryIntegration.ts`
> (it asserts the machine's **live** V8 heap fraction is critical; it fails on a
> clean baseline of this branch too, with none of this issue's files loaded). It
> stems from the recent #3433 heap-guard alignment, not from this change, and is
> out of scope here.

## Test Plan

Added `test/creature/EvolveTeardown.ts` — pure "what" tests, no timing APIs:

- `adoptChampionClone` disposes the previous champion, returns a fresh,
  independent clone with the new score, and leaves the source `fittest` intact.
- `adoptChampionClone` with no previous champion (first win) just returns the
  clone.
- `disposeEvolvePopulation` disposes every member except the caller creature and
  returns the disposed count (including the caller-at-index-0 case).
- `releaseEvolveCaches` clears a seeded `DistanceCache` entry, the shared
  subnetwork index, and a seeded WASM compilation template (probed by unique
  keys so the assertions are robust under the parallel test runner).



## Milestone
This PR is part of the **OOME** milestone and targets the `milestone/oome` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mrzomd0w-73a91f`<!-- vibe-worker-issue-3434 -->