### PR TITLE
Discard late completions after abandon; release replay clones (Issue #3435)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-3435.md
+++ b/docs/archive/pr-summaries/pr-summary-3435.md
@@ -1,0 +1,96 @@
+# Discard late completions after abandon; release replay clones promptly
+
+## Summary
+
+Long-running discovery/training/replay work kept strong references to live
+`Creature` payloads for the whole async lifetime, and a hard-deadline abandon
+cleared the in-progress Maps but did **not** stop late-resolving worker promises
+from pushing full result blobs back into `discoveryComplete` /
+`trainingComplete` — re-inflating the heap right after the run had deliberately
+shed the work. Replay clones were likewise retained across generations.
+
+This change:
+
+1. **Discards late completions after a hard-deadline abandon.**
+   `Neat.abandonInFlightPastHardDeadline()` now bumps a monotonic `abandonEpoch`
+   token. Each scheduled discovery/training task captures the token at schedule
+   time; the completion handlers guard on it (`isRunAbandonedSince`) and route
+   pushes through new `recordDiscoveryComplete` / `recordTrainingComplete`
+   helpers that discard — without mutating the maps — when the run was abandoned
+   or the task is no longer tracked. The guard runs **before** any heavy work
+   (building the improved creature, rebuilding the trained creature,
+   fine-tuning, trace writing, or serialising the failed creature), so no large
+   result blob is built or queued after abandon.
+
+2. **Releases replay clones promptly.** `DiscoveryReplayQueue` now disposes each
+   replay clone in the `.finally` (on completion, failure, or abort), disposes a
+   superseded queued clone when a newer fittest overwrites it, and disposes the
+   queued clone dropped when `waitForCompletion` stops at the hard cap.
+
+Closes #3435.
+
+## Evidence
+
+Backend/library change — no UI. Verified via new unit tests (below) and the
+existing discovery-replay / hard-deadline suites (all green).
+
+### Abandon → late-resolve flow
+
+```mermaid
+sequenceDiagram
+    participant Sched as scheduleTraining/Discovery
+    participant Neat
+    participant Worker
+    Sched->>Neat: capture scheduledEpoch = abandonEpoch
+    Sched->>Worker: dispatch task
+    Note over Neat: hard deadline passes
+    Neat->>Neat: abandonInFlightPastHardDeadline()<br/>clear maps, abandonEpoch++
+    Worker-->>Sched: promise resolves late
+    Sched->>Neat: isRunAbandonedSince(scheduledEpoch)?
+    alt epoch stale (abandoned)
+        Sched->>Sched: return early — no blob built, nothing queued
+    else epoch current
+        Sched->>Neat: recordTrainingComplete(...) → push
+    end
+```
+
+### Replay clone lifecycle
+
+```mermaid
+stateDiagram-v2
+    [*] --> InFlight: scheduleReplay clones fittest
+    InFlight --> Disposed: finally (done / fail / abort)
+    [*] --> Queued: replay already running
+    Queued --> Disposed: superseded by newer fittest
+    Queued --> Disposed: dropped at hard cap (waitForCompletion)
+    Queued --> InFlight: promoted when slot frees
+```
+
+## Test Plan
+
+New tests (behavioural only — no timing assertions, per #2888):
+
+- `test/NEAT/NeatAbandonLateCompletion.ts`
+  - `recordDiscoveryComplete` / `recordTrainingComplete` record a live task's
+    result and release the in-progress bookkeeping.
+  - Both discard a late completion after `abandonInFlightPastHardDeadline`
+    (nothing re-inflates the complete queues).
+  - Both discard when the task is no longer tracked (per-task abandon).
+  - `abandonInFlightPastHardDeadline` bumps the token so prior tasks read as
+    abandoned while post-abandon tasks are honoured; a below-cap call leaves the
+    token untouched.
+- `test/NEAT/DiscoveryReplayQueueDisposal.ts`
+  - Replay clone is disposed on completion and on failure (caller's creature
+    untouched).
+  - A superseded queued clone is dropped without a third replay; every started
+    clone ends disposed.
+  - The queued clone dropped at the hard cap does not start.
+
+Regression coverage: existing `NeatHardDeadlineEnforcement`,
+`DiscoveryReplayQueue*`, `NeatFinishUp`, `TrainingRegressionSkip`, and
+`PoolBorrowing` suites all pass unchanged.
+
+## Deno regression avoided
+
+Implemented entirely with Deno-native tooling (`deno test`, `deno lint`,
+`deno fmt`, `deno check`) — no Node tooling or dependencies introduced.

--- a/src/NEAT/DiscoveryReplayQueue.ts
+++ b/src/NEAT/DiscoveryReplayQueue.ts
@@ -213,7 +213,10 @@ export class DiscoveryReplayQueue {
 
     if (this.#replayInProgress) {
       // Queue this creature to be processed when the current replay completes
-      // Only keep the most recent queued creature
+      // Only keep the most recent queued creature.
+      // Issue #3435: dispose the previously queued clone we are about to drop so
+      // its topology is not retained until the next scheduleReplay overwrites it.
+      this.#queuedCreature?.creature.dispose();
       this.#queuedCreature = {
         creature: creature.shallowClone(),
         dataDir,
@@ -286,6 +289,11 @@ export class DiscoveryReplayQueue {
         this.#currentPromise = null;
         this.#currentAbort = null;
 
+        // Issue #3435: release the replay clone's topology promptly on
+        // completion, failure, or cooperative abort so it is not retained across
+        // generations while the next queued replay runs.
+        creature.dispose();
+
         // Process the next queued creature if any
         if (this.#queuedCreature) {
           const queued = this.#queuedCreature;
@@ -342,6 +350,9 @@ export class DiscoveryReplayQueue {
       // never starts, signal the in-flight replay to abort, and return without
       // awaiting — the abandoned replay stops at its next candidate boundary.
       if (capped && Date.now() >= hardDeadlineTS!) {
+        // Issue #3435: dispose the dropped queued clone before releasing it so
+        // its topology is not retained after we stop waiting at the hard cap.
+        this.#queuedCreature?.creature.dispose();
         this.#queuedCreature = null;
         this.#currentAbort?.abort();
         return;

--- a/src/NEAT/Neat.ts
+++ b/src/NEAT/Neat.ts
@@ -251,6 +251,16 @@ export class Neat {
   discoveryInProgress = new Map<string, Promise<void>>();
   discoveryComplete: ResponseData[] = [];
   trainingComplete: ResponseData[] = [];
+  /**
+   * Issue #3435: monotonic abandon token, bumped whenever in-flight
+   * discovery/training work is abandoned past the hard deadline
+   * ({@link abandonInFlightPastHardDeadline}). Each scheduled task captures the
+   * token at schedule time; a late-resolving promise whose captured token no
+   * longer matches discards its (potentially large) result payload instead of
+   * re-inflating {@link discoveryComplete} / {@link trainingComplete} after the
+   * run has already shed the work.
+   */
+  abandonEpoch = 0;
   alreadyScheduledMap = new Map<string, number>();
   /**
    * Issue #2382: tracks per-creature training regression history so
@@ -733,6 +743,71 @@ export class Neat {
     this.discoveryInProgress.clear();
     this.trainingInProgress.clear();
     this.trainingDeadlines.clear();
+    // Issue #3435: invalidate every task scheduled before this abandon so their
+    // late-resolving promises discard their result blobs rather than re-inflate
+    // the complete queues after we have deliberately shed the work.
+    this.abandonEpoch++;
+    return true;
+  }
+
+  /**
+   * Issue #3435: true when the run has abandoned in-flight work since a task was
+   * scheduled at `scheduledEpoch`. Used by the discovery/training completion
+   * handlers to discard late results instead of pushing them into the complete
+   * queues.
+   */
+  isRunAbandonedSince(scheduledEpoch: number): boolean {
+    return scheduledEpoch !== this.abandonEpoch;
+  }
+
+  /**
+   * Issue #3435: record a completed discovery unless the task was abandoned
+   * since it was scheduled. A completion is discarded when either the run was
+   * abandoned past the hard deadline (`scheduledEpoch` no longer current) or the
+   * task is no longer tracked in {@link discoveryInProgress} (e.g. cleared by
+   * abandon). Discarded completions leave the maps untouched — the entry has
+   * already been removed by abandon, or belongs to a newer task for the same
+   * UUID that must not be clobbered.
+   *
+   * @returns `true` when the result was recorded, `false` when discarded.
+   */
+  recordDiscoveryComplete(
+    uuid: string,
+    scheduledEpoch: number,
+    result: ResponseData,
+  ): boolean {
+    if (
+      this.isRunAbandonedSince(scheduledEpoch) ||
+      !this.discoveryInProgress.has(uuid)
+    ) {
+      return false;
+    }
+    this.discoveryComplete.push(result);
+    this.discoveryInProgress.delete(uuid);
+    return true;
+  }
+
+  /**
+   * Issue #3435: record a completed training result unless the task was
+   * abandoned since it was scheduled. Mirrors {@link recordDiscoveryComplete}
+   * for the training maps, also releasing the per-task deadline on success.
+   *
+   * @returns `true` when the result was recorded, `false` when discarded.
+   */
+  recordTrainingComplete(
+    uuid: string,
+    scheduledEpoch: number,
+    result: ResponseData,
+  ): boolean {
+    if (
+      this.isRunAbandonedSince(scheduledEpoch) ||
+      !this.trainingInProgress.has(uuid)
+    ) {
+      return false;
+    }
+    this.trainingComplete.push(result);
+    this.trainingInProgress.delete(uuid);
+    this.trainingDeadlines.delete(uuid);
     return true;
   }
 

--- a/src/NEAT/NeatScheduling.ts
+++ b/src/NEAT/NeatScheduling.ts
@@ -177,10 +177,22 @@ export function scheduleDiscovery(
     );
   }
 
+  // Issue #3435: capture the abandon token at schedule time so a late-resolving
+  // discovery promise discards its result (rather than re-inflating the complete
+  // queue) if the run abandons in-flight work past the hard deadline meanwhile.
+  const scheduledEpoch = neat.abandonEpoch;
+
   const discoveryPromise = w.discover(creature, discoveryConfig);
 
   const p = discoveryPromise.then((r) => {
     assert(r.discover, "No discovery found");
+
+    // Issue #3435: discard late completions after a hard-deadline abandon before
+    // doing any heavy work (building the improved creature) or pushing a large
+    // result blob into the complete queue.
+    if (neat.isRunAbandonedSince(scheduledEpoch)) {
+      return;
+    }
 
     const discoveryDurationMS = Date.now() - taskStartTime;
     neat.lastDiscoveryDurationMS = discoveryDurationMS;
@@ -216,9 +228,16 @@ export function scheduleDiscovery(
       }
     }
 
-    neat.discoveryComplete.push(r);
-    neat.discoveryInProgress.delete(uuid);
+    // Issue #3435: guarded push — discarded (with no map mutation) when the run
+    // abandoned this task since it was scheduled.
+    neat.recordDiscoveryComplete(uuid, scheduledEpoch, r);
   }).catch((error) => {
+    // Issue #3435: a late failure after abandon must not push a stub into the
+    // complete queue either.
+    if (neat.isRunAbandonedSince(scheduledEpoch)) {
+      return;
+    }
+
     getLogger().error(
       `[Neat] Discovery failed for creature ${
         uuid.substring(Math.max(0, uuid.length - 8))
@@ -226,9 +245,7 @@ export function scheduleDiscovery(
       error,
     );
 
-    neat.discoveryInProgress.delete(uuid);
-
-    neat.discoveryComplete.push({
+    neat.recordDiscoveryComplete(uuid, scheduledEpoch, {
       taskID: 0,
       duration: 0,
       discover: {
@@ -363,8 +380,19 @@ export function scheduleTraining(
     dataFuzzing: neat.config.dataFuzzing,
   };
 
+  // Issue #3435: capture the abandon token at schedule time so a late-resolving
+  // training promise discards its result if the run abandons in-flight work past
+  // the hard deadline before it settles.
+  const scheduledEpoch = neat.abandonEpoch;
+
   const p = w.train(creature, trainOptions).then((r) => {
     assert(r.train, "No train found");
+
+    // Issue #3435: discard late completions after a hard-deadline abandon before
+    // rebuilding the trained creature, fine-tuning, or writing traces.
+    if (neat.isRunAbandonedSince(scheduledEpoch)) {
+      return;
+    }
 
     const errorTx = getTag(creature, "error");
     assert(errorTx, "No error tag found");
@@ -436,9 +464,9 @@ export function scheduleTraining(
       neat.trainingRegressionTracker.recordImprovement(uuid);
     }
 
-    neat.trainingComplete.push(r);
-    neat.trainingInProgress.delete(uuid);
-    neat.trainingDeadlines.delete(uuid);
+    // Issue #3435: guarded push — discarded (with no map mutation) when the run
+    // abandoned this task since it was scheduled.
+    neat.recordTrainingComplete(uuid, scheduledEpoch, r);
 
     if (neat.config.traceStore) {
       if (r.train.trace) {
@@ -454,15 +482,18 @@ export function scheduleTraining(
       }
     }
   }).catch((error) => {
+    // Issue #3435: a late failure after abandon must not push a stub (or
+    // serialise the creature) into the complete queue.
+    if (neat.isRunAbandonedSince(scheduledEpoch)) {
+      return;
+    }
+
     getLogger().error(
       `Training failed for creature ${
         uuid.substring(Math.max(0, uuid.length - 8))
       }:`,
       error,
     );
-
-    neat.trainingInProgress.delete(uuid);
-    neat.trainingDeadlines.delete(uuid);
 
     // Issue #2546: training has already failed for this creature; serialise
     // it for the diagnostic record without re-running the writer-side
@@ -481,7 +512,7 @@ export function scheduleTraining(
       };
     }
 
-    neat.trainingComplete.push({
+    neat.recordTrainingComplete(uuid, scheduledEpoch, {
       taskID: 0,
       duration: 0,
       train: {

--- a/test/ErrorGuidedStructuralEvolution/DiscoveryHeapAbortBoundaryIntegration.ts
+++ b/test/ErrorGuidedStructuralEvolution/DiscoveryHeapAbortBoundaryIntegration.ts
@@ -152,7 +152,17 @@ Deno.test(
     // The explicit #3022 rule, encoded as an assertion: EITHER the serialized
     // worker heap sample is below CRITICAL at the boundary, OR the guard does
     // not abort while configured budget headroom exists.
-    const guardSample: HeapGuardSample = sampleHeapPressure(config);
+    //
+    // Sample the *injected* worker-default heap, not the live process. Passing
+    // the provider explicitly keeps this deterministic: since Issue #3433/#3410
+    // the usage fraction divides by the real V8 old-space *limit* (~GBs), so
+    // sampling `Deno.memoryUsage()` here would read far below CRITICAL and the
+    // line-171 assertion — which asserts the worker-default fraction IS
+    // critical — would fail non-deterministically on the runner's live heap.
+    const guardSample: HeapGuardSample = sampleHeapPressure(
+      config,
+      fixedProvider(sample),
+    );
     const belowCritical = guardSample.usageFraction < config.criticalThreshold;
     const budgetHeadroom = config.nativeBudgetBytes > 0 &&
       guardSample.rss <= config.nativeBudgetBytes;

--- a/test/NEAT/DiscoveryReplayQueueDisposal.ts
+++ b/test/NEAT/DiscoveryReplayQueueDisposal.ts
@@ -1,0 +1,168 @@
+import { assert, assertEquals } from "@std/assert";
+import type { Creature } from "@creature";
+import type { DiscoveryReplayDirResult } from "@discovery/DiscoveryReplayRunner.ts";
+import {
+  DiscoveryReplayQueue,
+  type DiscoveryReplayQueueDeps,
+} from "@neat/DiscoveryReplayQueue.ts";
+import type { NeatOptions } from "@config/NeatOptions.ts";
+import { makeBaseCreature } from "../fixtures/SimpleCreatures.ts";
+
+/**
+ * Tests for Issue #3435 — the DiscoveryReplayQueue must release its creature
+ * clones promptly on completion, supersession, and hard-cap timeout so full
+ * topologies are not retained across generations.
+ *
+ * `Creature.dispose()` empties `neurons`/`synapses`, so a disposed clone reads
+ * as `neurons.length === 0`. Assertions are behavioural (topology released),
+ * never elapsed-time measurements.
+ */
+
+const OK_RESULT: DiscoveryReplayDirResult = {
+  original: { error: 0.5, score: 0.5 },
+  evaluatedSingles: 0,
+  evaluatedCombos: 0,
+  pruned: 0,
+  skippedAlreadyApplied: 0,
+  skippedNotApplicable: 0,
+};
+
+const OPTIONS: NeatOptions = {
+  discoveryCacheDir: "/tmp/cache",
+  costOfGrowth: 0,
+};
+
+Deno.test("DiscoveryReplayQueue - disposes the replay clone on completion", async () => {
+  let captured: Creature | undefined;
+  const deps: DiscoveryReplayQueueDeps = {
+    replayDir: (creature: Creature) => {
+      captured = creature;
+      return Promise.resolve(OK_RESULT);
+    },
+  };
+  const queue = new DiscoveryReplayQueue(deps);
+
+  const creature = makeBaseCreature();
+  assert(creature.neurons.length > 0, "fixture must start with neurons");
+
+  queue.scheduleReplay(creature, "/tmp/data", OPTIONS);
+  await queue.waitForCompletion();
+
+  assert(captured, "replay clone should have been passed to replayDir");
+  assertEquals(
+    captured!.neurons.length,
+    0,
+    "the replay clone must be disposed once the replay completes",
+  );
+  // The caller's original creature must remain intact (only the clone is freed).
+  assert(
+    creature.neurons.length > 0,
+    "disposing the clone must not touch the caller's creature",
+  );
+});
+
+Deno.test("DiscoveryReplayQueue - disposes the replay clone on failure", async () => {
+  let captured: Creature | undefined;
+  const deps: DiscoveryReplayQueueDeps = {
+    replayDir: (creature: Creature) => {
+      captured = creature;
+      return Promise.reject(new Error("boom"));
+    },
+  };
+  const queue = new DiscoveryReplayQueue(deps);
+
+  queue.scheduleReplay(makeBaseCreature(), "/tmp/data", OPTIONS);
+  await queue.waitForCompletion();
+
+  assert(captured, "replay clone should have been passed to replayDir");
+  assertEquals(
+    captured!.neurons.length,
+    0,
+    "the replay clone must be disposed even when the replay fails",
+  );
+});
+
+Deno.test("DiscoveryReplayQueue - disposes a superseded queued clone", async () => {
+  const started: Creature[] = [];
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+
+  const deps: DiscoveryReplayQueueDeps = {
+    replayDir: async (creature: Creature) => {
+      started.push(creature);
+      // Hold the first replay open so the next two schedules queue behind it.
+      if (started.length === 1) {
+        await gate;
+      }
+      return OK_RESULT;
+    },
+  };
+  const queue = new DiscoveryReplayQueue(deps);
+
+  queue.scheduleReplay(makeBaseCreature(), "/tmp/data", OPTIONS); // starts
+  queue.scheduleReplay(makeBaseCreature(), "/tmp/data", OPTIONS); // queued #1
+  // Queued #2 supersedes #1; the dropped #1 clone is disposed on supersession.
+  queue.scheduleReplay(makeBaseCreature(), "/tmp/data", OPTIONS);
+
+  release();
+  await queue.waitForCompletion();
+
+  // Exactly two replays ran (the first, then the surviving queued creature);
+  // the superseded queued clone was dropped without a third replay.
+  assertEquals(
+    started.length,
+    2,
+    "only the surviving queued replay should run",
+  );
+  for (const c of started) {
+    assertEquals(
+      c.neurons.length,
+      0,
+      "every started replay clone must be disposed on completion",
+    );
+  }
+});
+
+Deno.test("DiscoveryReplayQueue - disposes the queued clone dropped at the hard cap", async () => {
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const started: Creature[] = [];
+
+  const deps: DiscoveryReplayQueueDeps = {
+    replayDir: async (creature: Creature) => {
+      started.push(creature);
+      if (started.length === 1) {
+        await gate; // keep the first replay in-flight past the cap
+      }
+      return OK_RESULT;
+    },
+  };
+  const queue = new DiscoveryReplayQueue(deps);
+
+  queue.scheduleReplay(makeBaseCreature(), "/tmp/data", OPTIONS); // starts
+  queue.scheduleReplay(makeBaseCreature(), "/tmp/data", OPTIONS); // queued
+
+  // Hard cap already passed → waitForCompletion drops the queued clone and
+  // aborts the in-flight replay without starting the queued one.
+  await queue.waitForCompletion(Date.now() - 1);
+
+  assertEquals(
+    started.length,
+    1,
+    "the queued replay must not start after the hard cap",
+  );
+
+  // Let the in-flight replay settle so the test leaks no timers/promises.
+  release();
+  await queue.waitForCompletion();
+
+  assertEquals(
+    started.length,
+    1,
+    "the dropped queued clone stays dropped after the cap",
+  );
+});

--- a/test/NEAT/NeatAbandonLateCompletion.ts
+++ b/test/NEAT/NeatAbandonLateCompletion.ts
@@ -1,0 +1,275 @@
+import { assert, assertEquals } from "@std/assert";
+import type { NeatOptions } from "@config/NeatOptions.ts";
+import { Neat } from "@neat/Neat.ts";
+import { WorkerHandler } from "@multithreading/workers/WorkerHandler.ts";
+import type { ResponseData } from "@multithreading/workers/WorkerHandler.ts";
+import {
+  type DataRecordInterface,
+  makeDataDir,
+} from "@architecture/DataSet.ts";
+
+/**
+ * Unit tests for Issue #3435 — discard late completions after abandon.
+ *
+ * When discovery/training work is abandoned past the hard deadline, a
+ * late-resolving worker promise must not push its (potentially large) result
+ * payload back into `discoveryComplete` / `trainingComplete` and re-inflate the
+ * heap after the run has deliberately shed the work. The guarded record methods
+ * capture an abandon token at schedule time and discard on mismatch.
+ *
+ * Assertions are behavioural (queue contents + return value), never elapsed-time
+ * measurements (#2888).
+ */
+
+function createTestDataDir(input: number, output: number): string {
+  const records: DataRecordInterface[] = [];
+  for (let i = 0; i < 10; i++) {
+    records.push({
+      input: new Float32Array(
+        Array.from({ length: input }, () => Math.random()),
+      ),
+      output: new Float32Array(
+        Array.from({ length: output }, () => Math.random()),
+      ),
+    });
+  }
+  return makeDataDir(records, 2000);
+}
+
+function createTestWorkers(dataDir: string): WorkerHandler[] {
+  return [new WorkerHandler(dataDir, "MSE", true)];
+}
+
+async function terminateWorkers(workers: WorkerHandler[]): Promise<void> {
+  await Promise.all(workers.map((w) => w.waitUntilReady().catch(() => {})));
+  for (const w of workers) {
+    w.terminate();
+  }
+}
+
+function fakeDiscoveryResult(uuid: string): ResponseData {
+  return { taskID: 1, duration: 0, discover: { ID: uuid } };
+}
+
+function fakeTrainingResult(uuid: string): ResponseData {
+  return {
+    taskID: 1,
+    duration: 0,
+    train: {
+      ID: uuid,
+      creature: { neurons: [], synapses: [], input: 2, output: 1 },
+      error: 0.1,
+      trace: { neurons: [], synapses: [], input: 2, output: 1 },
+    },
+  };
+}
+
+Deno.test("recordDiscoveryComplete: records a completion for a live task", async () => {
+  const dataDir = createTestDataDir(2, 1);
+  const workers = createTestWorkers(dataDir);
+  try {
+    const options: NeatOptions = { populationSize: 10 };
+    const neat = new Neat(2, 1, options, workers);
+
+    const uuid = "disc-live";
+    const epoch = neat.abandonEpoch;
+    neat.discoveryInProgress.set(uuid, Promise.resolve());
+
+    const recorded = neat.recordDiscoveryComplete(
+      uuid,
+      epoch,
+      fakeDiscoveryResult(uuid),
+    );
+
+    assert(recorded, "A live, non-abandoned completion must be recorded");
+    assertEquals(neat.discoveryComplete.length, 1);
+    assertEquals(
+      neat.discoveryInProgress.has(uuid),
+      false,
+      "recording a completion releases the in-progress bookkeeping",
+    );
+  } finally {
+    await terminateWorkers(workers);
+  }
+});
+
+Deno.test("recordDiscoveryComplete: discards late completion after hard-deadline abandon", async () => {
+  const dataDir = createTestDataDir(2, 1);
+  const workers = createTestWorkers(dataDir);
+  try {
+    const options: NeatOptions = { populationSize: 10 };
+    const neat = new Neat(2, 1, options, workers);
+
+    const uuid = "disc-late";
+    // Schedule-time token captured before the task is abandoned.
+    const epoch = neat.abandonEpoch;
+    neat.discoveryInProgress.set(uuid, new Promise(() => {}));
+
+    // Hard-deadline abandon clears the maps and bumps the abandon token.
+    neat.abandonInFlightPastHardDeadline(Date.now() - 1000);
+
+    const recorded = neat.recordDiscoveryComplete(
+      uuid,
+      epoch,
+      fakeDiscoveryResult(uuid),
+    );
+
+    assertEquals(
+      recorded,
+      false,
+      "A late completion after abandon is discarded",
+    );
+    assertEquals(
+      neat.discoveryComplete.length,
+      0,
+      "no result blob may re-inflate discoveryComplete after abandon",
+    );
+  } finally {
+    await terminateWorkers(workers);
+  }
+});
+
+Deno.test("recordDiscoveryComplete: discards when the task is no longer tracked", async () => {
+  const dataDir = createTestDataDir(2, 1);
+  const workers = createTestWorkers(dataDir);
+  try {
+    const options: NeatOptions = { populationSize: 10 };
+    const neat = new Neat(2, 1, options, workers);
+
+    const uuid = "disc-untracked";
+    const epoch = neat.abandonEpoch;
+    // Never registered in discoveryInProgress (e.g. cleared by a per-task abandon).
+
+    const recorded = neat.recordDiscoveryComplete(
+      uuid,
+      epoch,
+      fakeDiscoveryResult(uuid),
+    );
+
+    assertEquals(recorded, false, "An untracked completion is discarded");
+    assertEquals(neat.discoveryComplete.length, 0);
+  } finally {
+    await terminateWorkers(workers);
+  }
+});
+
+Deno.test("recordTrainingComplete: records a completion for a live task", async () => {
+  const dataDir = createTestDataDir(2, 1);
+  const workers = createTestWorkers(dataDir);
+  try {
+    const options: NeatOptions = { populationSize: 10 };
+    const neat = new Neat(2, 1, options, workers);
+
+    const uuid = "train-live";
+    const epoch = neat.abandonEpoch;
+    neat.trainingInProgress.set(uuid, Promise.resolve());
+    neat.trainingDeadlines.set(uuid, Date.now() + 60_000);
+
+    const recorded = neat.recordTrainingComplete(
+      uuid,
+      epoch,
+      fakeTrainingResult(uuid),
+    );
+
+    assert(recorded, "A live, non-abandoned completion must be recorded");
+    assertEquals(neat.trainingComplete.length, 1);
+    assertEquals(neat.trainingInProgress.has(uuid), false);
+    assertEquals(
+      neat.trainingDeadlines.has(uuid),
+      false,
+      "recording a completion releases the per-task deadline",
+    );
+  } finally {
+    await terminateWorkers(workers);
+  }
+});
+
+Deno.test("recordTrainingComplete: discards late completion after hard-deadline abandon", async () => {
+  const dataDir = createTestDataDir(2, 1);
+  const workers = createTestWorkers(dataDir);
+  try {
+    const options: NeatOptions = { populationSize: 10 };
+    const neat = new Neat(2, 1, options, workers);
+
+    const uuid = "train-late";
+    const epoch = neat.abandonEpoch;
+    neat.trainingInProgress.set(uuid, new Promise(() => {}));
+    neat.trainingDeadlines.set(uuid, Date.now() + 60_000);
+
+    neat.abandonInFlightPastHardDeadline(Date.now() - 1000);
+
+    const recorded = neat.recordTrainingComplete(
+      uuid,
+      epoch,
+      fakeTrainingResult(uuid),
+    );
+
+    assertEquals(
+      recorded,
+      false,
+      "A late completion after abandon is discarded",
+    );
+    assertEquals(
+      neat.trainingComplete.length,
+      0,
+      "no result blob may re-inflate trainingComplete after abandon",
+    );
+  } finally {
+    await terminateWorkers(workers);
+  }
+});
+
+Deno.test("abandonInFlightPastHardDeadline: bumps the abandon token so prior tasks are invalidated", async () => {
+  const dataDir = createTestDataDir(2, 1);
+  const workers = createTestWorkers(dataDir);
+  try {
+    const options: NeatOptions = { populationSize: 10 };
+    const neat = new Neat(2, 1, options, workers);
+
+    const epochBefore = neat.abandonEpoch;
+    assertEquals(
+      neat.isRunAbandonedSince(epochBefore),
+      false,
+      "a freshly captured token is not abandoned",
+    );
+
+    neat.trainingInProgress.set("t", new Promise(() => {}));
+    neat.abandonInFlightPastHardDeadline(Date.now() - 1000);
+
+    assert(
+      neat.isRunAbandonedSince(epochBefore),
+      "the token captured before abandon must now read as abandoned",
+    );
+    // A task scheduled after the abandon captures the new token and is honoured.
+    const epochAfter = neat.abandonEpoch;
+    assertEquals(neat.isRunAbandonedSince(epochAfter), false);
+  } finally {
+    await terminateWorkers(workers);
+  }
+});
+
+Deno.test("abandon before the cap does not invalidate scheduled tasks", async () => {
+  const dataDir = createTestDataDir(2, 1);
+  const workers = createTestWorkers(dataDir);
+  try {
+    const options: NeatOptions = { populationSize: 10 };
+    const neat = new Neat(2, 1, options, workers);
+
+    const epoch = neat.abandonEpoch;
+    neat.trainingInProgress.set("t", Promise.resolve());
+
+    // Deadline in the future: no abandon, token unchanged.
+    neat.abandonInFlightPastHardDeadline(Date.now() + 60_000);
+
+    assertEquals(neat.isRunAbandonedSince(epoch), false);
+    const recorded = neat.recordTrainingComplete(
+      "t",
+      epoch,
+      fakeTrainingResult("t"),
+    );
+    assert(recorded, "completion before the cap is still recorded");
+    assertEquals(neat.trainingComplete.length, 1);
+  } finally {
+    await terminateWorkers(workers);
+  }
+});


### PR DESCRIPTION
# Discard late completions after abandon; release replay clones promptly

## Summary

Long-running discovery/training/replay work kept strong references to live
`Creature` payloads for the whole async lifetime, and a hard-deadline abandon
cleared the in-progress Maps but did **not** stop late-resolving worker promises
from pushing full result blobs back into `discoveryComplete` /
`trainingComplete` — re-inflating the heap right after the run had deliberately
shed the work. Replay clones were likewise retained across generations.

This change:

1. **Discards late completions after a hard-deadline abandon.**
   `Neat.abandonInFlightPastHardDeadline()` now bumps a monotonic `abandonEpoch`
   token. Each scheduled discovery/training task captures the token at schedule
   time; the completion handlers guard on it (`isRunAbandonedSince`) and route
   pushes through new `recordDiscoveryComplete` / `recordTrainingComplete`
   helpers that discard — without mutating the maps — when the run was abandoned
   or the task is no longer tracked. The guard runs **before** any heavy work
   (building the improved creature, rebuilding the trained creature,
   fine-tuning, trace writing, or serialising the failed creature), so no large
   result blob is built or queued after abandon.

2. **Releases replay clones promptly.** `DiscoveryReplayQueue` now disposes each
   replay clone in the `.finally` (on completion, failure, or abort), disposes a
   superseded queued clone when a newer fittest overwrites it, and disposes the
   queued clone dropped when `waitForCompletion` stops at the hard cap.

Closes #3435.

## Evidence

Backend/library change — no UI. Verified via new unit tests (below) and the
existing discovery-replay / hard-deadline suites (all green).

### Abandon → late-resolve flow

```mermaid
sequenceDiagram
    participant Sched as scheduleTraining/Discovery
    participant Neat
    participant Worker
    Sched->>Neat: capture scheduledEpoch = abandonEpoch
    Sched->>Worker: dispatch task
    Note over Neat: hard deadline passes
    Neat->>Neat: abandonInFlightPastHardDeadline()<br/>clear maps, abandonEpoch++
    Worker-->>Sched: promise resolves late
    Sched->>Neat: isRunAbandonedSince(scheduledEpoch)?
    alt epoch stale (abandoned)
        Sched->>Sched: return early — no blob built, nothing queued
    else epoch current
        Sched->>Neat: recordTrainingComplete(...) → push
    end
```

### Replay clone lifecycle

```mermaid
stateDiagram-v2
    [*] --> InFlight: scheduleReplay clones fittest
    InFlight --> Disposed: finally (done / fail / abort)
    [*] --> Queued: replay already running
    Queued --> Disposed: superseded by newer fittest
    Queued --> Disposed: dropped at hard cap (waitForCompletion)
    Queued --> InFlight: promoted when slot frees
```

## Test Plan

New tests (behavioural only — no timing assertions, per #2888):

- `test/NEAT/NeatAbandonLateCompletion.ts`
  - `recordDiscoveryComplete` / `recordTrainingComplete` record a live task's
    result and release the in-progress bookkeeping.
  - Both discard a late completion after `abandonInFlightPastHardDeadline`
    (nothing re-inflates the complete queues).
  - Both discard when the task is no longer tracked (per-task abandon).
  - `abandonInFlightPastHardDeadline` bumps the token so prior tasks read as
    abandoned while post-abandon tasks are honoured; a below-cap call leaves the
    token untouched.
- `test/NEAT/DiscoveryReplayQueueDisposal.ts`
  - Replay clone is disposed on completion and on failure (caller's creature
    untouched).
  - A superseded queued clone is dropped without a third replay; every started
    clone ends disposed.
  - The queued clone dropped at the hard cap does not start.

Regression coverage: existing `NeatHardDeadlineEnforcement`,
`DiscoveryReplayQueue*`, `NeatFinishUp`, `TrainingRegressionSkip`, and
`PoolBorrowing` suites all pass unchanged.

## Deno regression avoided

Implemented entirely with Deno-native tooling (`deno test`, `deno lint`,
`deno fmt`, `deno check`) — no Node tooling or dependencies introduced.



## Milestone
This PR is part of the **OOME** milestone and targets the `milestone/oome` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mrzomd0w-73a91f`<!-- vibe-worker-issue-3435 -->