### PR TITLE
Checkpoint: cap writeCreatures peak memory with bounded batches (#3436)

### DIFF
--- a/bench/CheckpointWritePeakHeap.ts
+++ b/bench/CheckpointWritePeakHeap.ts
@@ -1,0 +1,265 @@
+/**
+ * Benchmark: peak heap of a per-generation checkpoint write (Issue #3436).
+ *
+ * Before #3436 `writeCreatures` exported and stringified **every** population
+ * member up front and then `Promise.all`-ed the writes, so peak heap grew as
+ * `populationSize × genome JSON`. After #3436 creatures are exported,
+ * stringified, and written in bounded batches, so at most `batchSize` genome
+ * JSON strings are alive at once.
+ *
+ * Methodology (mirrors bench/DiscoveryAnalysisCacheRelease.ts):
+ *   - The orchestrator spawns one fresh `deno run` subprocess per
+ *     (mode, scenario) so each measurement starts from an empty heap.
+ *   - `promise-all` replicates the pre-#3436 code verbatim; `batched` calls
+ *     the shipped `writeCreatures`.
+ *   - Both modes sample `Deno.memoryUsage()` at the same point — immediately
+ *     before each file write — plus once at the end.
+ *   - Median of 3 runs per (mode, scenario) damps GC timing noise.
+ *
+ * Run:
+ *   deno run --allow-all bench/CheckpointWritePeakHeap.ts
+ */
+
+import { emptyDirSync } from "@std/fs";
+import { Creature } from "@creature";
+import {
+  type CheckpointSource,
+  writeCreatures,
+} from "@creature/CheckpointWriter.ts";
+import { applySeedWarmupTagsAtSave } from "@architecture/CreatureFactory.ts";
+
+const MB = 1024 * 1024;
+
+type Mode = "promise-all" | "batched";
+
+interface SampleStats {
+  mode: Mode;
+  populationSize: number;
+  peakUsedMB: number;
+  peakRssMB: number;
+  bytesWritten: number;
+}
+
+// =============================================================================
+// Child-process worker
+// =============================================================================
+
+function buildPopulation(size: number): Creature[] {
+  const population: Creature[] = [];
+  for (let i = 0; i < size; i++) {
+    const creature = new Creature(20, 5, {
+      layers: [{ count: 80 }, { count: 80 }],
+    });
+    creature.score = i;
+    population.push(creature);
+  }
+  return population;
+}
+
+/** Children run with `--expose-gc` so samples measure the LIVE set. */
+const forceGc = (globalThis as { gc?: () => void }).gc;
+
+/**
+ * Samples peak **live** heap: without a forced collection `heapUsed` counts
+ * released-but-uncollected strings, which hides the very difference under
+ * test. Sampling every `SAMPLE_EVERY` writes (identical points in both
+ * modes) keeps the GC cost tolerable.
+ */
+const SAMPLE_EVERY = 8;
+
+function peakSampler() {
+  let peakUsed = 0;
+  let peakRss = 0;
+  let writeIndex = 0;
+
+  const sample = () => {
+    forceGc?.();
+    const m = Deno.memoryUsage();
+    if (m.heapUsed > peakUsed) peakUsed = m.heapUsed;
+    if (m.rss > peakRss) peakRss = m.rss;
+  };
+
+  return {
+    /** Called immediately before each file write. */
+    observe() {
+      if (writeIndex % SAMPLE_EVERY === 0) sample();
+      writeIndex++;
+    },
+    sample,
+    peakUsedMB: () => peakUsed / MB,
+    peakRssMB: () => peakRss / MB,
+  };
+}
+
+/** Pre-#3436 implementation: stringify the whole population, then Promise.all. */
+async function writeCreaturesPromiseAll(
+  source: CheckpointSource,
+  dir: string,
+  sampler: ReturnType<typeof peakSampler>,
+): Promise<void> {
+  emptyDirSync(dir);
+  const writes: Promise<void>[] = [];
+  let counter = 1;
+  for (const creature of source.population) {
+    const json = creature.exportJSON();
+    applySeedWarmupTagsAtSave(
+      json,
+      source.warmupGenerations,
+      source.currentGeneration,
+    );
+    const txt = JSON.stringify(json);
+    sampler.observe();
+    writes.push(Deno.writeTextFile(`${dir}/${counter}.json`, txt));
+    counter++;
+  }
+  await Promise.all(writes);
+  sampler.sample();
+}
+
+async function runChild(
+  mode: Mode,
+  populationSize: number,
+): Promise<SampleStats> {
+  const dir = await Deno.makeTempDir({ prefix: "neat_ckpt_heap_" });
+  const sampler = peakSampler();
+  const population = buildPopulation(populationSize);
+  const source: CheckpointSource = {
+    population,
+    warmupGenerations: 0,
+    currentGeneration: 0,
+  };
+
+  try {
+    if (mode === "promise-all") {
+      await writeCreaturesPromiseAll(source, dir, sampler);
+    } else {
+      await writeCreatures(source, dir, {
+        writeTextFile: (path, text) => {
+          sampler.observe();
+          return Deno.writeTextFile(path, text);
+        },
+      });
+      sampler.sample();
+    }
+
+    const entries = await Array.fromAsync(Deno.readDir(dir));
+    const sizes = await Promise.all(
+      entries.map((entry) => Deno.stat(`${dir}/${entry.name}`)),
+    );
+    const bytesWritten = sizes.reduce((total, stat) => total + stat.size, 0);
+
+    return {
+      mode,
+      populationSize,
+      peakUsedMB: sampler.peakUsedMB(),
+      peakRssMB: sampler.peakRssMB(),
+      bytesWritten,
+    };
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+}
+
+// =============================================================================
+// Orchestration
+// =============================================================================
+
+const SCENARIOS = [16, 54, 128, 256];
+
+function pct(before: number, after: number): string {
+  if (before === 0) return "n/a";
+  return `${(100 * (before - after) / before).toFixed(1)}%`;
+}
+
+async function spawnChild(
+  mode: Mode,
+  populationSize: number,
+): Promise<SampleStats> {
+  const cmd = new Deno.Command(Deno.execPath(), {
+    args: [
+      "run",
+      "--allow-all",
+      "--v8-flags=--expose-gc",
+      new URL(import.meta.url).pathname,
+      "--child",
+      mode,
+      String(populationSize),
+    ],
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const { stdout, stderr, code } = await cmd.output();
+  if (code !== 0) {
+    throw new Error(
+      `child exited ${code}: ${new TextDecoder().decode(stderr)}`,
+    );
+  }
+  const out = new TextDecoder().decode(stdout).trim();
+  const line = out.split("\n").find((l) => l.startsWith("{"));
+  if (!line) throw new Error(`no JSON output from child:\n${out}`);
+  return JSON.parse(line) as SampleStats;
+}
+
+const median = (xs: number[]) =>
+  [...xs].sort((a, b) => a - b)[Math.floor(xs.length / 2)];
+
+async function main() {
+  console.log("Checkpoint write peak heap — Issue #3436");
+  console.log("  promise-all = pre-#3436 (whole population stringified first)");
+  console.log("  batched     = post-#3436 (bounded batches of 8)");
+  console.log("  Each measurement runs in a fresh subprocess.\n");
+
+  for (const populationSize of SCENARIOS) {
+    const before: SampleStats[] = [];
+    const after: SampleStats[] = [];
+    for (let i = 0; i < 3; i++) {
+      // Sequential — parallel children would contend for physical memory.
+      // deno-lint-ignore no-await-in-loop
+      before.push(await spawnChild("promise-all", populationSize));
+      // deno-lint-ignore no-await-in-loop
+      after.push(await spawnChild("batched", populationSize));
+    }
+
+    const beforePeak = median(before.map((r) => r.peakUsedMB));
+    const afterPeak = median(after.map((r) => r.peakUsedMB));
+    const beforeRss = median(before.map((r) => r.peakRssMB));
+    const afterRss = median(after.map((r) => r.peakRssMB));
+
+    console.log(`\n=== population ${populationSize} (median of 3) ===`);
+    console.log(
+      `  peak heapUsed: promise-all=${beforePeak.toFixed(1)}MB  batched=${
+        afterPeak.toFixed(1)
+      }MB  (reduction ${pct(beforePeak, afterPeak)})`,
+    );
+    console.log(
+      `  peak rss:      promise-all=${beforeRss.toFixed(1)}MB  batched=${
+        afterRss.toFixed(1)
+      }MB  (saved ${(beforeRss - afterRss).toFixed(1)}MB, ${
+        pct(beforeRss, afterRss)
+      })`,
+    );
+    console.log(
+      `  bytes written: promise-all=${before[0].bytesWritten}  batched=${
+        after[0].bytesWritten
+      }  (delta ${after[0].bytesWritten - before[0].bytesWritten})`,
+    );
+  }
+}
+
+// =============================================================================
+// Entry point
+// =============================================================================
+
+if (Deno.args[0] === "--child") {
+  // Fail loud: without --expose-gc the samples would count uncollected
+  // garbage and silently understate the difference under test.
+  if (!forceGc) {
+    throw new Error(
+      "child requires --v8-flags=--expose-gc for live-heap sampling",
+    );
+  }
+  const stats = await runChild(Deno.args[1] as Mode, Number(Deno.args[2]));
+  console.log(JSON.stringify(stats));
+} else {
+  await main();
+}

--- a/deno.json
+++ b/deno.json
@@ -82,6 +82,7 @@
       "bench/ActivateAndTraceApp.ts",
       "bench/ActivateApp.ts",
       "bench/AdaptiveLearningRateConvergence.ts",
+      "bench/CheckpointWritePeakHeap.ts",
       "bench/CosineAnnealingWarmRestart.ts",
       "bench/CreatureStateNodeMap.ts",
       "bench/DenseNumberMapBenchmark.ts",

--- a/docs/PERFORMANCE_TUNING.md
+++ b/docs/PERFORMANCE_TUNING.md
@@ -396,6 +396,29 @@ out of memory.
 > breaches it and there is nothing left to evict, the process will crash. Always
 > leave at least 10–15% headroom below your system's physical memory limit.
 
+### Checkpoint Write Memory (`creatureStore`)
+
+Per-generation checkpoints (`creatureStore` plus `checkpointEveryGeneration`)
+land on an already-hot generation, so the checkpoint itself must not become the
+peak. Creatures are exported, serialised, and written in **bounded batches** of
+8 (Issue #3436), so the transient checkpoint footprint is capped by the batch
+size rather than by the population size.
+
+```mermaid
+flowchart LR
+    P[Population] --> B1[Batch 1..8]
+    B1 --> S1[exportJSON + stringify] --> W1[write + await] --> R1[released]
+    R1 --> B2[Batch 9..16]
+    B2 --> S2[exportJSON + stringify] --> W2[write + await] --> R2[released]
+    R2 --> Bn[…remaining batches]
+```
+
+Each batch's serialised genomes and in-flight write buffers are released before
+the next batch allocates its own, so peak checkpoint memory no longer scales
+with `populationSize × genome JSON`. File contents and numbering (`1.json`,
+`2.json`, …) are unchanged. No configuration is required — this is the default
+and only behaviour.
+
 ### Understanding Cache Diagnostics
 
 Use `getCacheStats()` to inspect cache health at any point during training:

--- a/docs/archive/pr-summaries/pr-summary-3436.md
+++ b/docs/archive/pr-summaries/pr-summary-3436.md
@@ -1,0 +1,107 @@
+## Summary
+
+Per-generation checkpoints used to export and serialise **every** population
+member up front and then `Promise.all` the writes, so the transient checkpoint
+footprint scaled as `populationSize × genome JSON` on top of an already-hot
+generation — exactly the pressure seen with `checkpointEveryGeneration` and
+large adaptive populations (#3430). `writeCreatures` now writes in **bounded
+batches of 8**: each batch is exported, stringified, written, and awaited before
+the next batch allocates anything. Closes #3436.
+
+The write path moved out of the 1700-line `CreatureTraining.ts` into a small
+focused module, `src/creature/CheckpointWriter.ts`, so it is directly testable.
+File contents, file numbering, semanticVersion healing (#2349) and warm-up tag
+stamping (#2909) are unchanged.
+
+```mermaid
+flowchart LR
+    subgraph Before["Before — peak scales with population"]
+        P1[Population] --> A1[export + stringify ALL] --> W1[Promise.all every write]
+    end
+    subgraph After["After — peak capped by batch size"]
+        P2[Population] --> B1[Batch 1..8] --> S1[export + stringify] --> D1[write + await] --> R1[released]
+        R1 --> B2[Batch 9..16] --> S2[export + stringify] --> D2[write + await] --> R2[released]
+        R2 --> Bn[…remaining batches]
+    end
+```
+
+## Evidence
+
+Backend/CLI change — no web interface to screenshot.
+
+### Benchmark: `bench/CheckpointWritePeakHeap.ts`
+
+One fresh `deno run` subprocess per (mode, scenario) so each measurement starts
+from an empty heap; children run with `--v8-flags=--expose-gc` so samples
+measure the **live** set rather than uncollected garbage; median of 3 runs.
+`promise-all` replicates the pre-#3436 code verbatim, `batched` calls the
+shipped `writeCreatures`. Creatures are 20→5 with two hidden layers of 80 (~1 MB
+of JSON each).
+
+| Population | peak RSS before | peak RSS after | Saved            |
+| ---------- | --------------- | -------------- | ---------------- |
+| 16         | 252.2 MB        | 247.7 MB       | 4.5 MB (1.8%)    |
+| 54         | 475.9 MB        | 432.7 MB       | 43.2 MB (9.1%)   |
+| 128        | 917.0 MB        | 812.3 MB       | 104.7 MB (11.4%) |
+| 256        | 1575.0 MB       | 1359.1 MB      | 215.9 MB (13.7%) |
+
+Bytes written are identical between modes (differences in the table's raw output
+come only from each subprocess building its own random population).
+
+The saving grows linearly with population — that is the point: the transient
+checkpoint cost is now capped by the batch size instead of the population size.
+
+`peak heapUsed` is unchanged (≈0.0%) at every size, and that is the expected,
+honest result: `Deno.writeTextFile` encodes the string to bytes at call time, so
+the accumulation the old code caused was in **native** in-flight write buffers
+(visible in RSS), not in V8 heap strings. The V8-side bound — at most
+`batchSize` genome JSON strings alive at once — is verified directly by the unit
+tests rather than by sampling.
+
+Reproduce:
+
+```bash
+deno run --allow-all bench/CheckpointWritePeakHeap.ts
+```
+
+### Quality gate
+
+`./quality.sh` passes: `7834 passed | 0 failed | 4 ignored`.
+
+## Test Plan
+
+New behavioural tests in `test/creature/CheckpointWriteBatching.ts` (11 tests,
+all calling the real `writeCreatures`):
+
+- `caps concurrent checkpoint writes at the batch size` — an injected write seam
+  records overlapping writes; peak in-flight is exactly the requested batch size
+  (fails against the pre-#3436 `Promise.all` implementation, where peak equals
+  the population size).
+- `peak concurrency is independent of population size` — populations of 12 and
+  120 produce the same peak in-flight count, bounded by
+  `DEFAULT_CHECKPOINT_WRITE_BATCH_SIZE`.
+- `produces the same files regardless of batch size` — `batchSize: 1` and
+  `batchSize: 64` write byte-identical files.
+- `numbers files 1..N in population order` — checkpoint `i+1.json` holds
+  population member `i`.
+- `empties stale checkpoint files first` and
+  `with an empty population writes
+  nothing`.
+- `heals an invalid semanticVersion before writing (#2349)`.
+- `stamps warm-up tags on every batch while warming (#2909)` and
+  `strips warm-up tags once warm (#2909)` — verified across batch boundaries.
+- `rejects an invalid batch size loudly` (RangeError for 0, -1, 1.5, NaN) and
+  `propagates a write failure instead of swallowing it` — no silent failure.
+
+Existing coverage kept green and unmodified: `test/NEAT/AsyncDiskIO.ts`,
+`test/creature/SemanticVersionWriteGuard.ts`,
+`test/config/CheckpointEveryGeneration.ts`,
+`test/config/CheckpointWriteTiming.ts`, `test/NEAT/SeedWarmupAccumulation.ts`.
+
+## Security self-check
+
+- No new external input surface: `writeCreatures` takes an in-process population
+  and a caller-supplied directory, as before.
+- `batchSize` is validated (positive integer) and fails loud with `RangeError`.
+- Write failures reject rather than being swallowed.
+- No new dependencies, no secrets, no shell/SQL/HTTP surface.

--- a/src/creature/CheckpointWriter.ts
+++ b/src/creature/CheckpointWriter.ts
@@ -1,0 +1,111 @@
+/**
+ * CheckpointWriter.ts — bounded-batch checkpoint writing (Issue #3436).
+ *
+ * Extracted from `CreatureTraining.ts` so the checkpoint write path is a
+ * small, focused, directly testable module.
+ *
+ * Issue #2275 made checkpoint writes async with compact JSON. That version
+ * exported and stringified **every** population member up front and then
+ * `Promise.all`-ed the writes, so peak heap grew as
+ * `populationSize × genome JSON` on top of an already-hot generation —
+ * painful with `checkpointEveryGeneration` and large adaptive populations
+ * (Issue #3430).
+ *
+ * Issue #3436 caps that peak: creatures are exported, stringified, and
+ * written in bounded batches, so at most `batchSize` genome JSON strings are
+ * alive at once regardless of population size. File contents are unchanged.
+ */
+
+import { emptyDirSync } from "@std/fs";
+import type { Creature } from "@creature";
+import { CURRENT_CREATURE_SEMANTIC_VERSION } from "@creature";
+import {
+  assertValidWriteableSemanticVersion,
+  isValidWriteableSemanticVersion,
+} from "@upgrade/SemanticVersionValidation.ts";
+import { applySeedWarmupTagsAtSave } from "@architecture/CreatureFactory.ts";
+
+/**
+ * Default number of checkpoint files exported, stringified, and written
+ * concurrently. Small enough to bound peak heap, large enough to keep the
+ * filesystem busy.
+ */
+export const DEFAULT_CHECKPOINT_WRITE_BATCH_SIZE = 8;
+
+/** The population state a checkpoint write needs — satisfied by `Neat`. */
+export interface CheckpointSource {
+  readonly population: Creature[];
+  readonly warmupGenerations: number;
+  readonly currentGeneration: number;
+}
+
+/** Optional overrides; production callers pass none. */
+export interface CheckpointWriteOptions {
+  /**
+   * Maximum genome JSON strings held (and writes in flight) at once.
+   * Defaults to {@link DEFAULT_CHECKPOINT_WRITE_BATCH_SIZE}.
+   */
+  batchSize?: number;
+  /** Test seam for the per-file write. Defaults to `Deno.writeTextFile`. */
+  writeTextFile?: (path: string, text: string) => Promise<void>;
+}
+
+/**
+ * Write every population member to `dir` as `1.json`, `2.json`, … in
+ * bounded batches.
+ *
+ * The directory is emptied first, so the checkpoint always reflects exactly
+ * the current population.
+ *
+ * @throws RangeError when `batchSize` is not a positive integer.
+ */
+export async function writeCreatures(
+  source: CheckpointSource,
+  dir: string,
+  options: CheckpointWriteOptions = {},
+): Promise<void> {
+  const batchSize = options.batchSize ?? DEFAULT_CHECKPOINT_WRITE_BATCH_SIZE;
+  if (!Number.isInteger(batchSize) || batchSize < 1) {
+    throw new RangeError(
+      `batchSize must be a positive integer, got ${batchSize}`,
+    );
+  }
+  const writeTextFile = options.writeTextFile ??
+    ((path: string, text: string) => Deno.writeTextFile(path, text));
+
+  emptyDirSync(dir);
+
+  const population = source.population;
+  for (let start = 0; start < population.length; start += batchSize) {
+    const end = Math.min(start + batchSize, population.length);
+    const batch: Promise<void>[] = [];
+    for (let indx = start; indx < end; indx++) {
+      const creature = population[indx];
+      // Issue #2349: never write a creature without a valid semanticVersion.
+      // If a creature somehow lost its version (empty, undefined, or pre-2.x),
+      // heal it to the current default rather than writing an invalid value
+      // that aborts downstream tools (GRQ worker).
+      if (!isValidWriteableSemanticVersion(creature.semanticVersion)) {
+        creature.semanticVersion = CURRENT_CREATURE_SEMANTIC_VERSION;
+      }
+      const json = creature.exportJSON();
+      assertValidWriteableSemanticVersion(json.semanticVersion);
+      // Issue #2909: stamp warm-up tags only at this export boundary. Stamp the
+      // exported JSON (not the live population member) so the saved file is
+      // correct regardless of which creature is saved: while warming it carries
+      // the Neat-level counter, and once warm both tags are stripped.
+      applySeedWarmupTagsAtSave(
+        json,
+        source.warmupGenerations,
+        source.currentGeneration,
+      );
+      batch.push(
+        writeTextFile(`${dir}/${indx + 1}.json`, JSON.stringify(json)),
+      );
+    }
+    // Awaiting per batch is the point of Issue #3436: the batch's JSON
+    // strings become garbage before the next batch allocates its own.
+    // deno-lint-ignore no-await-in-loop
+    await Promise.all(batch);
+  }
+}

--- a/src/creature/CreatureTraining.ts
+++ b/src/creature/CreatureTraining.ts
@@ -8,14 +8,9 @@
 import { assert } from "@std/assert";
 import { yellow } from "@std/fmt/colors";
 import { format } from "@std/fmt/duration";
-import { emptyDirSync } from "@std/fs";
 import { getTag } from "@stsoftware/tags/mod";
 import type { Creature } from "@creature";
-import { CURRENT_CREATURE_SEMANTIC_VERSION } from "@creature";
-import {
-  assertValidWriteableSemanticVersion,
-  isValidWriteableSemanticVersion,
-} from "@upgrade/SemanticVersionValidation.ts";
+import { writeCreatures } from "@creature/CheckpointWriter.ts";
 import { TopologyError } from "@errors/TopologyError.ts";
 import { DatasetError } from "@errors/DatasetError.ts";
 import { openDatasetFileSync } from "@architecture/DatasetIO.ts";
@@ -48,10 +43,7 @@ import {
 import { buildOutgoingSynapsesMap } from "@propagate/sparse/CalculatePathsToOutput.ts";
 import { SparseConfig } from "@propagate/sparse/SparseConfig.ts";
 import { exportJSONWithRuntimeIds } from "@architecture/PopulateRuntimeIdsFromCreature.ts";
-import {
-  applySeedWarmupTagsAtSave,
-  buildWarmupEventFields,
-} from "@architecture/CreatureFactory.ts";
+import { buildWarmupEventFields } from "@architecture/CreatureFactory.ts";
 import { BufferPool } from "@utils/BufferPool.ts";
 import {
   type DiscoveryDirResult,
@@ -389,47 +381,6 @@ export function traceDir(
   );
 
   return { error: averageError, score: creature.score };
-}
-
-/**
- * Write creatures to a directory for checkpointing.
- *
- * Issue #2275: Converted to async I/O with compact JSON serialisation.
- * Benchmarks showed 32-54% improvement over the previous synchronous
- * approach (which used pretty-printed JSON.stringify(..., null, 1) +
- * Deno.writeTextFileSync per creature). Compact JSON (no indentation)
- * is 2.4x faster to serialise, and async file writes with Promise.all
- * unblock the event loop during checkpoint writes.
- */
-async function writeCreatures(neat: Neat, dir: string): Promise<void> {
-  emptyDirSync(dir);
-  const writes: Promise<void>[] = [];
-  let counter = 1;
-  for (const c of neat.population) {
-    // Issue #2349: never write a creature without a valid semanticVersion.
-    // If a creature somehow lost its version (empty, undefined, or pre-2.x),
-    // heal it to the current default rather than writing an invalid value
-    // that aborts downstream tools (GRQ worker).
-    if (!isValidWriteableSemanticVersion(c.semanticVersion)) {
-      c.semanticVersion = CURRENT_CREATURE_SEMANTIC_VERSION;
-    }
-    const json = c.exportJSON();
-    assertValidWriteableSemanticVersion(json.semanticVersion);
-    // Issue #2909: stamp warm-up tags only at this export boundary. Stamp the
-    // exported JSON (not the live population member) so the saved file is
-    // correct regardless of which creature is saved: while warming it carries
-    // the Neat-level counter, and once warm both tags are stripped.
-    applySeedWarmupTagsAtSave(
-      json,
-      neat.warmupGenerations,
-      neat.currentGeneration,
-    );
-    const txt = JSON.stringify(json);
-    const filePath = dir + "/" + counter + ".json";
-    writes.push(Deno.writeTextFile(filePath, txt));
-    counter++;
-  }
-  await Promise.all(writes);
 }
 
 /**

--- a/test/creature/CheckpointWriteBatching.ts
+++ b/test/creature/CheckpointWriteBatching.ts
@@ -1,0 +1,303 @@
+/**
+ * Issue #3436 — checkpoint writes must be bounded-batch, not
+ * "stringify the whole population then Promise.all".
+ *
+ * These are outcome tests: they assert on the number of genome JSON strings
+ * alive at once (observed through the injected write seam), on the files
+ * actually produced, and on the semanticVersion / warm-up tag invariants at
+ * the export boundary (#2349 / #2909).
+ */
+
+import { assert, assertEquals, assertRejects } from "@std/assert";
+import { addTag, getTag, type TagsInterface } from "@stsoftware/tags/mod";
+import { Creature } from "@creature";
+import { CURRENT_CREATURE_SEMANTIC_VERSION } from "@creature";
+import {
+  type CheckpointSource,
+  DEFAULT_CHECKPOINT_WRITE_BATCH_SIZE,
+  writeCreatures,
+} from "@creature/CheckpointWriter.ts";
+
+function buildPopulation(size: number): Creature[] {
+  const population: Creature[] = [];
+  for (let i = 0; i < size; i++) {
+    const creature = new Creature(3, 1, { layers: [{ count: 4 }] });
+    creature.score = i;
+    population.push(creature);
+  }
+  return population;
+}
+
+function source(
+  population: Creature[],
+  warmupGenerations = 0,
+  currentGeneration = 0,
+): CheckpointSource {
+  return { population, warmupGenerations, currentGeneration };
+}
+
+interface CheckpointJson extends TagsInterface {
+  semanticVersion?: string;
+}
+
+/** Read `1.json` … `<count>.json` from `dir`, parsed, in file order. */
+function readCheckpoints(
+  dir: string,
+  count: number,
+): Promise<CheckpointJson[]> {
+  return Promise.all(
+    Array.from(
+      { length: count },
+      (_, i) =>
+        Deno.readTextFile(`${dir}/${i + 1}.json`).then((text) =>
+          JSON.parse(text) as CheckpointJson
+        ),
+    ),
+  );
+}
+
+/** Sorted file names in `dir`. */
+async function listNames(dir: string): Promise<string[]> {
+  const entries = await Array.fromAsync(Deno.readDir(dir));
+  return entries.map((entry) => entry.name).sort();
+}
+
+/** Records how many writes (and therefore JSON strings) overlap in time. */
+function makeTrackingWriter() {
+  const files = new Map<string, string>();
+  let inFlight = 0;
+  let peakInFlight = 0;
+  const writeTextFile = (path: string, text: string): Promise<void> => {
+    inFlight++;
+    if (inFlight > peakInFlight) peakInFlight = inFlight;
+    return new Promise<void>((resolve) => {
+      // Resolve on a later microtask so overlapping writes are observable.
+      queueMicrotask(() => {
+        files.set(path, text);
+        inFlight--;
+        resolve();
+      });
+    });
+  };
+  return { files, writeTextFile, peak: () => peakInFlight };
+}
+
+Deno.test("writeCreatures caps concurrent checkpoint writes at the batch size", async () => {
+  const dir = await Deno.makeTempDir({ prefix: "neat_ckpt_batch_" });
+  try {
+    const tracker = makeTrackingWriter();
+    const population = buildPopulation(40);
+
+    await writeCreatures(source(population), dir, {
+      batchSize: 4,
+      writeTextFile: tracker.writeTextFile,
+    });
+
+    assertEquals(tracker.files.size, 40, "every creature written");
+    assertEquals(
+      tracker.peak(),
+      4,
+      "at most batchSize checkpoint strings alive at once",
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("writeCreatures peak concurrency is independent of population size", async () => {
+  const dir = await Deno.makeTempDir({ prefix: "neat_ckpt_scale_" });
+  try {
+    const small = makeTrackingWriter();
+    const large = makeTrackingWriter();
+
+    await writeCreatures(source(buildPopulation(12)), dir, {
+      writeTextFile: small.writeTextFile,
+    });
+    await writeCreatures(source(buildPopulation(120)), dir, {
+      writeTextFile: large.writeTextFile,
+    });
+
+    assertEquals(large.files.size, 120);
+    assertEquals(
+      large.peak(),
+      small.peak(),
+      "peak in-flight writes must not grow with population size",
+    );
+    assert(
+      large.peak() <= DEFAULT_CHECKPOINT_WRITE_BATCH_SIZE,
+      `peak ${large.peak()} exceeded default batch size`,
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("writeCreatures produces the same files regardless of batch size", async () => {
+  const dirA = await Deno.makeTempDir({ prefix: "neat_ckpt_eqA_" });
+  const dirB = await Deno.makeTempDir({ prefix: "neat_ckpt_eqB_" });
+  try {
+    const population = buildPopulation(9);
+    await writeCreatures(source(population), dirA, { batchSize: 1 });
+    await writeCreatures(source(population), dirB, { batchSize: 64 });
+
+    const [batchedOne, batchedAll] = await Promise.all([
+      readCheckpoints(dirA, 9),
+      readCheckpoints(dirB, 9),
+    ]);
+    for (let i = 0; i < 9; i++) {
+      assertEquals(
+        JSON.stringify(batchedOne[i]),
+        JSON.stringify(batchedAll[i]),
+        `${i + 1}.json must be identical across batch sizes`,
+      );
+    }
+
+    assertEquals(
+      (await listNames(dirA)).length,
+      9,
+      "exactly one file per creature",
+    );
+  } finally {
+    await Deno.remove(dirA, { recursive: true });
+    await Deno.remove(dirB, { recursive: true });
+  }
+});
+
+Deno.test("writeCreatures numbers files 1..N in population order", async () => {
+  const dir = await Deno.makeTempDir({ prefix: "neat_ckpt_order_" });
+  try {
+    const population = buildPopulation(20);
+    population.forEach((creature, i) => addTag(creature, "member", `${i}`));
+    await writeCreatures(source(population), dir, { batchSize: 3 });
+
+    const written = await readCheckpoints(dir, population.length);
+    written.forEach((parsed, i) => {
+      assertEquals(
+        getTag(parsed, "member"),
+        `${i}`,
+        `${i + 1}.json must hold population member ${i}`,
+      );
+    });
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("writeCreatures empties stale checkpoint files first", async () => {
+  const dir = await Deno.makeTempDir({ prefix: "neat_ckpt_empty_" });
+  try {
+    await Deno.writeTextFile(`${dir}/99.json`, "{}");
+    await writeCreatures(source(buildPopulation(2)), dir, { batchSize: 1 });
+
+    assertEquals(
+      await listNames(dir),
+      ["1.json", "2.json"],
+      "stale files removed",
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("writeCreatures with an empty population writes nothing", async () => {
+  const dir = await Deno.makeTempDir({ prefix: "neat_ckpt_none_" });
+  try {
+    await Deno.writeTextFile(`${dir}/1.json`, "{}");
+    await writeCreatures(source([]), dir);
+    assertEquals((await listNames(dir)).length, 0);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("writeCreatures heals an invalid semanticVersion before writing (#2349)", async () => {
+  const dir = await Deno.makeTempDir({ prefix: "neat_ckpt_semver_" });
+  try {
+    const population = buildPopulation(5);
+    population[3].semanticVersion = "";
+    await writeCreatures(source(population), dir, { batchSize: 2 });
+
+    const written = await readCheckpoints(dir, 5);
+    assertEquals(written[3].semanticVersion, CURRENT_CREATURE_SEMANTIC_VERSION);
+    assertEquals(
+      population[3].semanticVersion,
+      CURRENT_CREATURE_SEMANTIC_VERSION,
+      "live population member healed too",
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("writeCreatures stamps warm-up tags on every batch while warming (#2909)", async () => {
+  const dir = await Deno.makeTempDir({ prefix: "neat_ckpt_warm_" });
+  try {
+    const population = buildPopulation(10);
+    // Warming: currentGeneration <= warmupGenerations.
+    await writeCreatures(source(population, 100, 7), dir, { batchSize: 3 });
+
+    const written = await readCheckpoints(dir, 10);
+    written.forEach((parsed, i) => {
+      assertEquals(getTag(parsed, "warmupGenerations"), "100", `${i + 1}.json`);
+      assertEquals(getTag(parsed, "currentGeneration"), "7", `${i + 1}.json`);
+    });
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("writeCreatures strips warm-up tags once warm (#2909)", async () => {
+  const dir = await Deno.makeTempDir({ prefix: "neat_ckpt_wa_" });
+  try {
+    const population = buildPopulation(6);
+    // Warm: currentGeneration > warmupGenerations.
+    await writeCreatures(source(population, 5, 9), dir, { batchSize: 4 });
+
+    const written = await readCheckpoints(dir, 6);
+    written.forEach((parsed, i) => {
+      assertEquals(getTag(parsed, "warmupGenerations"), null, `${i + 1}.json`);
+      assertEquals(getTag(parsed, "currentGeneration"), null, `${i + 1}.json`);
+    });
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("writeCreatures rejects an invalid batch size loudly", async () => {
+  const dir = await Deno.makeTempDir({ prefix: "neat_ckpt_bad_" });
+  try {
+    const population = buildPopulation(2);
+    await Promise.all(
+      [0, -1, 1.5, Number.NaN].map((bad) =>
+        assertRejects(
+          () => writeCreatures(source(population), dir, { batchSize: bad }),
+          RangeError,
+          "batchSize",
+        )
+      ),
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("writeCreatures propagates a write failure instead of swallowing it", async () => {
+  const dir = await Deno.makeTempDir({ prefix: "neat_ckpt_fail_" });
+  try {
+    const population = buildPopulation(6);
+    await assertRejects(
+      () =>
+        writeCreatures(source(population), dir, {
+          batchSize: 2,
+          writeTextFile: (path: string) =>
+            path.endsWith("3.json")
+              ? Promise.reject(new Error("disk full"))
+              : Promise.resolve(),
+        }),
+      Error,
+      "disk full",
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});


### PR DESCRIPTION
## Summary

Per-generation checkpoints used to export and serialise **every** population
member up front and then `Promise.all` the writes, so the transient checkpoint
footprint scaled as `populationSize × genome JSON` on top of an already-hot
generation — exactly the pressure seen with `checkpointEveryGeneration` and
large adaptive populations (#3430). `writeCreatures` now writes in **bounded
batches of 8**: each batch is exported, stringified, written, and awaited before
the next batch allocates anything. Closes #3436.

The write path moved out of the 1700-line `CreatureTraining.ts` into a small
focused module, `src/creature/CheckpointWriter.ts`, so it is directly testable.
File contents, file numbering, semanticVersion healing (#2349) and warm-up tag
stamping (#2909) are unchanged.

```mermaid
flowchart LR
    subgraph Before["Before — peak scales with population"]
        P1[Population] --> A1[export + stringify ALL] --> W1[Promise.all every write]
    end
    subgraph After["After — peak capped by batch size"]
        P2[Population] --> B1[Batch 1..8] --> S1[export + stringify] --> D1[write + await] --> R1[released]
        R1 --> B2[Batch 9..16] --> S2[export + stringify] --> D2[write + await] --> R2[released]
        R2 --> Bn[…remaining batches]
    end
```

## Evidence

Backend/CLI change — no web interface to screenshot.

### Benchmark: `bench/CheckpointWritePeakHeap.ts`

One fresh `deno run` subprocess per (mode, scenario) so each measurement starts
from an empty heap; children run with `--v8-flags=--expose-gc` so samples
measure the **live** set rather than uncollected garbage; median of 3 runs.
`promise-all` replicates the pre-#3436 code verbatim, `batched` calls the
shipped `writeCreatures`. Creatures are 20→5 with two hidden layers of 80 (~1 MB
of JSON each).

| Population | peak RSS before | peak RSS after | Saved            |
| ---------- | --------------- | -------------- | ---------------- |
| 16         | 252.2 MB        | 247.7 MB       | 4.5 MB (1.8%)    |
| 54         | 475.9 MB        | 432.7 MB       | 43.2 MB (9.1%)   |
| 128        | 917.0 MB        | 812.3 MB       | 104.7 MB (11.4%) |
| 256        | 1575.0 MB       | 1359.1 MB      | 215.9 MB (13.7%) |

Bytes written are identical between modes (differences in the table's raw output
come only from each subprocess building its own random population).

The saving grows linearly with population — that is the point: the transient
checkpoint cost is now capped by the batch size instead of the population size.

`peak heapUsed` is unchanged (≈0.0%) at every size, and that is the expected,
honest result: `Deno.writeTextFile` encodes the string to bytes at call time, so
the accumulation the old code caused was in **native** in-flight write buffers
(visible in RSS), not in V8 heap strings. The V8-side bound — at most
`batchSize` genome JSON strings alive at once — is verified directly by the unit
tests rather than by sampling.

Reproduce:

```bash
deno run --allow-all bench/CheckpointWritePeakHeap.ts
```

### Quality gate

`./quality.sh` passes: `7834 passed | 0 failed | 4 ignored`.

## Test Plan

New behavioural tests in `test/creature/CheckpointWriteBatching.ts` (11 tests,
all calling the real `writeCreatures`):

- `caps concurrent checkpoint writes at the batch size` — an injected write seam
  records overlapping writes; peak in-flight is exactly the requested batch size
  (fails against the pre-#3436 `Promise.all` implementation, where peak equals
  the population size).
- `peak concurrency is independent of population size` — populations of 12 and
  120 produce the same peak in-flight count, bounded by
  `DEFAULT_CHECKPOINT_WRITE_BATCH_SIZE`.
- `produces the same files regardless of batch size` — `batchSize: 1` and
  `batchSize: 64` write byte-identical files.
- `numbers files 1..N in population order` — checkpoint `i+1.json` holds
  population member `i`.
- `empties stale checkpoint files first` and
  `with an empty population writes
  nothing`.
- `heals an invalid semanticVersion before writing (#2349)`.
- `stamps warm-up tags on every batch while warming (#2909)` and
  `strips warm-up tags once warm (#2909)` — verified across batch boundaries.
- `rejects an invalid batch size loudly` (RangeError for 0, -1, 1.5, NaN) and
  `propagates a write failure instead of swallowing it` — no silent failure.

Existing coverage kept green and unmodified: `test/NEAT/AsyncDiskIO.ts`,
`test/creature/SemanticVersionWriteGuard.ts`,
`test/config/CheckpointEveryGeneration.ts`,
`test/config/CheckpointWriteTiming.ts`, `test/NEAT/SeedWarmupAccumulation.ts`.

## Security self-check

- No new external input surface: `writeCreatures` takes an in-process population
  and a caller-supplied directory, as before.
- `batchSize` is validated (positive integer) and fails loud with `RangeError`.
- Write failures reject rather than being swallowed.
- No new dependencies, no secrets, no shell/SQL/HTTP surface.



## Milestone
This PR is part of the **OOME** milestone and targets the `milestone/oome` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mrzrq5ih-9fa804`<!-- vibe-worker-issue-3436 -->