### PR TITLE
Milestone: #3451 🟠 Delete GRQ-logs-derived WASM compile-trap fixtures and replay test

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.9.35",
+  "version": "5.9.36",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.9.34",
+  "version": "5.9.35",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-3461.md
+++ b/docs/archive/pr-summaries/pr-summary-3461.md
@@ -1,0 +1,77 @@
+# Verify in-tree synthetic coverage before deleting the grq-2681 WASM trap replay test
+
+## Summary
+
+Go/no-go gate for the deletion sub-issue #3451: **confirm** that the regression
+pinned by the private-`GRQ-logs`-derived replay test
+`test/wasm/Grq2681TrapReplay.ts` remains covered by the two in-tree
+**synthetic** reproducers, so its removal loses no coverage.
+
+**Verdict: GO — coverage is intact.** Both synthetic tests still assert the two
+behaviours the replay depended on, and both pass on the milestone branch
+(`milestone/3451-delete-grq-logs-derived-wasm-compile-trap-fix`). This PR
+records that verification and adds a short **coverage-lineage** note to each
+synthetic test so future readers see the coverage relationship in-tree.
+
+This is a verification/documentation change — no behaviour changes. Closes
+#3461.
+
+### What the deleted replay pinned vs. what the synthetic tests pin
+
+The replay (`Grq2681TrapReplay.ts`, #2683/#2681) loaded nine large production
+creature snapshots (~1670 neurons, 2461 inputs) to confirm PR #2678
+(position-blind topology-hash collision fix) also resolved the larger
+`unreachable` `CompiledNetwork::new` trap. The _failure mode_ it pinned — a
+position-blind topology-hash collision serving a stale WASM template across two
+valid orderings of the same UUID set — is reproduced synthetically, with no
+private data, by:
+
+| Behaviour the replay depended on                                       | In-tree synthetic anchor                           | Assertion                                                                                                                                                         |
+| ---------------------------------------------------------------------- | -------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Position-order topology-hash invariant PR #2678 fixed                  | `TopologyHashPositionOrderingIssue2670.ts` (#2670) | `assertNotEquals(hash1, hash2)` for two creatures with the same UUID/synapse sets but swapped neuron positions; both compile cleanly from a freshly cleared cache |
+| `unreachable` `CompiledNetwork::new` producer-gate trap driven to zero | `LunarLanderShapeProducerGate.ts` (#2668)          | `BASELINE_REJECT_ALLOWANCE = 0` — the mutate/breed loop must record zero producer-gate rejects on a synthetic lunar_lander shape                                  |
+
+The only difference is scale (large captured shapes vs. tiny synthetic ones),
+not failure mode. The size difference is not a distinct behaviour: the trap is a
+cache-collision mechanism, exercised identically at any size.
+
+```mermaid
+flowchart LR
+    R["Grq2681TrapReplay.ts<br/>(deleted, private GRQ-logs data)"] -. "same failure mode,<br/>no private data" .-> S
+    subgraph S["In-tree synthetic coverage"]
+      T["TopologyHashPositionOrderingIssue2670.ts<br/>position-order hash invariant"]
+      L["LunarLanderShapeProducerGate.ts<br/>producer-gate trap = 0"]
+    end
+    S --> G{"Coverage intact?"}
+    G -- "Yes → GO" --> D["Deletion #3451 may proceed"]
+    G -- "No → NO-GO" --> X["Strengthen synthetic test<br/>(synthetic creature only)"]
+```
+
+## Evidence
+
+Backend/test-only change — no web interface to screenshot. Verification is the
+passing WASM test run on the milestone branch:
+
+```
+running 2 tests from ./test/wasm/TopologyHashPositionOrderingIssue2670.ts
+Issue #2670: topology hash distinguishes valid topological orderings of the same UUID set ... ok (2ms)
+Issue #2670: WASM compile gate succeeds for both orderings sharing a UUID-set ... ok (821µs)
+running 2 tests from ./test/wasm/LunarLanderShapeProducerGate.ts
+Issue #2668: lunar_lander-shape mutation/breed loop keeps producer-gate rejects under the baseline ... ok (66ms)
+Issue #2668: reproducer is deterministic across three consecutive runs at the same seed ... ok (148ms)
+
+ok | 4 passed | 0 failed (307ms)
+```
+
+`./quality.sh --lint-only` and `./quality.sh --check-only` both pass.
+
+## Test Plan
+
+- Re-ran the two synthetic WASM tests after the comment-only edits — 4 passed, 0
+  failed. No assertions were weakened.
+- Confirmed both tests still assert (a) the `unreachable` producer-gate trap is
+  driven to zero (`BASELINE_REJECT_ALLOWANCE = 0`) and (b) the position-order
+  topology-hash invariant (`assertNotEquals` + both compile cleanly from a
+  cleared cache).
+- No new private-derived data introduced; the coverage-lineage notes are code
+  comments only.

--- a/docs/archive/pr-summaries/pr-summary-3462.md
+++ b/docs/archive/pr-summaries/pr-summary-3462.md
@@ -1,0 +1,77 @@
+# PR Summary — Delete private GRQ-logs-derived WASM compile-trap fixtures and `Grq2681TrapReplay.ts`
+
+## Summary
+
+Completes the public-repo purge of private-repo-derived (`GRQ-logs`) content for
+the WASM compile-trap regression. Closes #3462.
+
+The bulk of the deletion — the nine `test/fixtures/wasm-compile-traps/grq-2681/`
+production fixtures (~3.5 MB of offspring/mother/father/error quadruples), the
+empty parent `test/fixtures/wasm-compile-traps/` directory, and the replay test
+`test/wasm/Grq2681TrapReplay.ts` — already landed on the milestone branch via
+the parent-issue work (#3459). What remained were **three residual literal
+references** to the deleted test in the coverage-lineage docblocks that #3461
+added to the two synthetic reproducers. Those literals still tripped this
+issue's acceptance grep:
+
+```
+grep -rn "GRQ-logs\|grq-2681\|Grq2681" test/
+```
+
+This PR rewords those three comment lines to drop the literal `` `GRQ-logs` `` /
+`` `Grq2681TrapReplay.ts` `` tokens while preserving the coverage-lineage
+explanation and every issue anchor (`#2683/#2681`, `#3451`, `#3461`). After this
+change the acceptance grep returns **no matches**, so the public repo no longer
+names the private repository or the deleted replay test anywhere under `test/`.
+
+Per the issue scope, the concept-level `GRQ-logs` mentions in
+`docs/VERSION_VISIBILITY.md` / `docs/PROFILING_REPORT_3397.md` were **not**
+touched.
+
+### What changed
+
+| File                                                 | Change                                                                                                                                                        |
+| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `test/wasm/TopologyHashPositionOrderingIssue2670.ts` | Reworded coverage-lineage comment: `` private-`GRQ-logs`-derived replay test `Grq2681TrapReplay.ts` `` → `private-repo-derived WASM compile-trap replay test` |
+| `test/wasm/LunarLanderShapeProducerGate.ts`          | Same reword of its coverage-lineage comment                                                                                                                   |
+
+```mermaid
+flowchart LR
+    A["#3459: delete fixtures + Grq2681TrapReplay.ts"] --> C
+    B["#3461: add coverage-lineage comments<br/>(named the deleted test)"] --> C
+    C["#3462: reword residual comment refs<br/>→ acceptance grep clean"] --> D["Public repo self-contained"]
+```
+
+## Acceptance criteria
+
+- ✅ Fixture directory, empty parent, and `Grq2681TrapReplay.ts` are gone
+  (already removed via #3459; confirmed absent on this branch).
+- ✅ `grep -rn "GRQ-logs\|grq-2681\|Grq2681" test/` returns **no matches**.
+- ✅ No private-derived data remains committed.
+- ✅ The coverage anchors that now solely own the regression still pass — no
+  dangling import or fixture-path reference.
+
+## Evidence
+
+Backend/test-only change — no web interface to screenshot. Verification is the
+acceptance grep plus the two synthetic coverage anchors:
+
+```
+$ grep -rn "GRQ-logs\|grq-2681\|Grq2681" test/
+# (no output — clean)
+
+$ deno test --allow-read --allow-write --allow-env --allow-ffi \
+    test/wasm/TopologyHashPositionOrderingIssue2670.ts \
+    test/wasm/LunarLanderShapeProducerGate.ts
+ok | 4 passed | 0 failed (306ms)
+```
+
+## Test Plan
+
+- No new tests: this is a documentation-comment reword within the two existing
+  reproducers, plus verification that the prior deletion is complete.
+- Re-ran the two in-tree synthetic coverage anchors that now solely own the WASM
+  compile-trap regression — `test/wasm/TopologyHashPositionOrderingIssue2670.ts`
+  (#2670/#2678) and `test/wasm/LunarLanderShapeProducerGate.ts` (#2668) — both
+  green (4 passed).
+- Ran the full `./quality.sh` gate.

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -249,6 +249,7 @@
     "disjoint",
     "distill",
     "distillation",
+    "docblocks",
     "dlopen",
     "dylib",
     "egse",

--- a/test/wasm/LunarLanderShapeProducerGate.ts
+++ b/test/wasm/LunarLanderShapeProducerGate.ts
@@ -29,6 +29,18 @@
  *   the existing buggy producers; #2666 will drive it to zero. Bumping the
  *   allowance is NOT how to "fix" this test — root-cause the trap and bring
  *   the count down instead.
+ *
+ * Coverage lineage (Issue #3461):
+ *
+ *   Together with `TopologyHashPositionOrderingIssue2670.ts`, this test is
+ *   the in-tree, synthetic coverage anchor that let the private-`GRQ-logs`-
+ *   derived replay test `Grq2681TrapReplay.ts` (#2683/#2681) be deleted
+ *   under #3451 without losing coverage. That replay confirmed the
+ *   `unreachable` `CompiledNetwork::new` producer-gate trap stayed at zero
+ *   on large captured production shapes; this test drives the same
+ *   producer-gate trap to zero (`BASELINE_REJECT_ALLOWANCE = 0`) on a
+ *   synthetic lunar_lander shape with no private data. The scale differs;
+ *   the failure mode pinned is the same.
  */
 
 import { assert, assertEquals } from "@std/assert";

--- a/test/wasm/LunarLanderShapeProducerGate.ts
+++ b/test/wasm/LunarLanderShapeProducerGate.ts
@@ -33,8 +33,8 @@
  * Coverage lineage (Issue #3461):
  *
  *   Together with `TopologyHashPositionOrderingIssue2670.ts`, this test is
- *   the in-tree, synthetic coverage anchor that let the private-`GRQ-logs`-
- *   derived replay test `Grq2681TrapReplay.ts` (#2683/#2681) be deleted
+ *   the in-tree, synthetic coverage anchor that let the private-repo-derived
+ *   WASM compile-trap replay test (#2683/#2681) be deleted
  *   under #3451 without losing coverage. That replay confirmed the
  *   `unreachable` `CompiledNetwork::new` producer-gate trap stayed at zero
  *   on large captured production shapes; this test drives the same

--- a/test/wasm/TopologyHashPositionOrderingIssue2670.ts
+++ b/test/wasm/TopologyHashPositionOrderingIssue2670.ts
@@ -28,7 +28,7 @@
  * Coverage lineage (Issue #3461):
  *
  *   This synthetic test is the go/no-go coverage anchor for the removal of
- *   the private-`GRQ-logs`-derived replay test `Grq2681TrapReplay.ts`
+ *   the private-repo-derived WASM compile-trap replay test
  *   (#2683/#2681, deleted under #3451). That replay loaded nine large
  *   production creature snapshots to confirm PR #2678 also resolved the
  *   `unreachable` `CompiledNetwork::new` trap. The *failure mode* it pinned

--- a/test/wasm/TopologyHashPositionOrderingIssue2670.ts
+++ b/test/wasm/TopologyHashPositionOrderingIssue2670.ts
@@ -24,6 +24,18 @@
  *     3. Compiling both via `getOrCompileWasmModule` from a freshly cleared
  *        cache and confirming both compile cleanly — the second creature
  *        must NOT hit a stale template from the first.
+ *
+ * Coverage lineage (Issue #3461):
+ *
+ *   This synthetic test is the go/no-go coverage anchor for the removal of
+ *   the private-`GRQ-logs`-derived replay test `Grq2681TrapReplay.ts`
+ *   (#2683/#2681, deleted under #3451). That replay loaded nine large
+ *   production creature snapshots to confirm PR #2678 also resolved the
+ *   `unreachable` `CompiledNetwork::new` trap. The *failure mode* it pinned
+ *   — a position-blind topology-hash collision serving a stale WASM
+ *   template across two valid orderings of the same UUID set — is exactly
+ *   the invariant asserted here, reproduced synthetically with no private
+ *   data. Do not weaken these assertions without re-checking #3451.
  */
 
 import { assert, assertNotEquals } from "@std/assert";


### PR DESCRIPTION
## Milestone: #3451 🟠 Delete GRQ-logs-derived WASM compile-trap fixtures and replay test

This PR merges the completed milestone branch into Develop.
Closes #3465

### Issues addressed
- #3462: Delete private GRQ-logs-derived WASM compile-trap fixtures and Grq2681TrapReplay.ts (#3451)
- #3461: Verify in-tree synthetic coverage before deleting the grq-2681 WASM trap replay test (#3451)

### Review notes
All individual issues were reviewed and merged into the milestone branch via separate PRs.
This final PR consolidates all changes for a comprehensive review before merging to Develop.