### PR TITLE
Reword private GRQ issue-tracker references in source and test comments (Issue #3454)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.9.36",
+  "version": "5.9.37",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-3454.md
+++ b/docs/archive/pr-summaries/pr-summary-3454.md
@@ -43,7 +43,12 @@ repo"/"GRQ shell" pointer, modelled on the existing
 `test/docs/CrossSpeciesBaselineNoPrivateRepo.ts` audit test. It exercises
 committed file content (behaviour), not the source text of any function.
 
-Quality gate: `./quality.sh` → `7844 passed | 0 failed | 4 ignored`.
+The guard now exempts the private-repo **detector tests**
+(`LiveDocsNoPrivateGrqReference.ts`, `CrossSpeciesBaselineNoPrivateRepo.ts`, and
+itself) from the scan: those tests must embed the forbidden `GRQ` patterns
+verbatim as fixtures and test names to verify their own detection, so scanning
+them was a self-referential false positive that made the guard fail on the whole
+tree. The exemption is an explicit, documented allowlist — not a silent skip.
 
 ## Test Plan
 

--- a/docs/archive/pr-summaries/pr-summary-3454.md
+++ b/docs/archive/pr-summaries/pr-summary-3454.md
@@ -1,0 +1,60 @@
+## Summary
+
+Reworded private `stSoftwareAU/GRQ` issue-tracker references out of source and
+test comments so the public repository stays self-contained. `stSoftwareAU/GRQ`
+is a **private** repo, so a `GRQ#NNNN` slug (or a "GRQ repo" / "GRQ shell"
+pointer) in a comment leads public readers to pages they cannot open. Each
+comment now describes the behaviour being guarded at concept level (e.g. "a
+Discovery worker was OOM-killed on a 16 GB production host, so the external
+production runner exports a host-derived worker-memory envelope") and refers to
+"the external production runner" rather than the private repo. Australian
+English retained throughout. Closes #3454.
+
+Reworded references (all `GRQ#NNNN` slugs and repo pointers removed):
+
+- `src/config/DiscoveryWorkerEnvelope.ts` — module header slug and the "in the
+  GRQ repo" runner pointer.
+- `src/config/NeatConfig.ts` — two `Issue GRQ#3295:` comments.
+- `test/config/DiscoveryWorkerEnvelope.ts` — header slug.
+- `test/config/Grq22WorkerCap.ts` — header slug, "GRQ shell" pointers, and the
+  `#3298` (private issue number) in three test names.
+- `test/config/WorkerThreadCapConfig.ts` — `(GRQ#3295)` note.
+- `test/creature/LoadFromObservability.ts` — `GRQ#1497`, `GRQ#1906` regression
+  slugs.
+
+The `GRQ-22` / `GRQ-cluster` / `GRQ-3` host/cluster/log **mnemonics** (no `#`)
+are out of scope — they are not issue-tracker links — and are left unchanged.
+
+## Evidence
+
+Backend/comment-only change — no web interface to screenshot. Verified via a new
+guard test plus the full quality gate.
+
+```mermaid
+flowchart LR
+    A["GRQ#NNNN slug<br/>in a comment"] -->|private repo| B["public reader<br/>hits a 404"]
+    C["concept-level wording<br/>'external production runner'"] -->|self-contained| D["public reader<br/>understands the guard"]
+    A -.reworded.-> C
+```
+
+New guard test `test/docs/NoPrivateGrqIssueSlugs.ts` walks the real `src/` and
+`test/` trees and fails if any file reintroduces a `GRQ#NNNN` slug or a "GRQ
+repo"/"GRQ shell" pointer, modelled on the existing
+`test/docs/CrossSpeciesBaselineNoPrivateRepo.ts` audit test. It exercises
+committed file content (behaviour), not the source text of any function.
+
+Quality gate: `./quality.sh` → `7844 passed | 0 failed | 4 ignored`.
+
+## Test Plan
+
+- Added `test/docs/NoPrivateGrqIssueSlugs.ts`:
+  - `no private GRQ issue-tracker slugs or repo pointers in src/ or test/` —
+    scans the real trees; would fail against the pre-fix comments, passes after
+    the rewording.
+  - `findPrivateGrqRefs` unit cases: flags a `GRQ#` slug, an org-qualified
+    `stSoftwareAU/GRQ#` slug, and a "GRQ repo" pointer; returns empty for
+    self-contained prose (including the `GRQ-22` mnemonic) and for empty input.
+- Re-ran the touched suites: `test/config/DiscoveryWorkerEnvelope.ts`,
+  `test/config/Grq22WorkerCap.ts`, `test/config/WorkerThreadCapConfig.ts` (31
+  passed) and `test/creature/LoadFromObservability.ts` — all green with the
+  reworded comments.

--- a/src/config/DiscoveryWorkerEnvelope.ts
+++ b/src/config/DiscoveryWorkerEnvelope.ts
@@ -1,6 +1,8 @@
 /**
- * Discovery worker-memory envelope → `workerThreadCap` wiring
- * (stSoftwareAU/GRQ#3295, part of GRQ#3267 — Discovery OOM-killed on a 16 GB host).
+ * Discovery worker-memory envelope → `workerThreadCap` wiring: a Discovery
+ * worker was OOM-killed on a 16 GB production host, so the external production
+ * runner exports a host-derived worker-memory envelope that this module turns
+ * into a thread cap.
  *
  * ## Why this exists
  *
@@ -16,7 +18,7 @@
  *
  * ## The fix
  *
- * The external Discovery runner (`worker/Discovery/run.sh`, in the GRQ repo)
+ * The external production runner (`worker/Discovery/run.sh`)
  * carves a host-derived worker-memory envelope and exports it via env. This module
  * reads that envelope and turns it into `workerThreadCap` overrides **automatically**
  * — no per-caller opt-in — so `createNeatConfig` caps the effective thread count to

--- a/src/config/NeatConfig.ts
+++ b/src/config/NeatConfig.ts
@@ -76,7 +76,7 @@ import {
 // Extracted cross-field validation
 import { validateNeatConfig } from "@config/NeatConfigValidation.ts";
 
-// Issue GRQ#3295: automatic Discovery worker-memory envelope → workerThreadCap.
+// Automatic Discovery worker-memory envelope → workerThreadCap wiring.
 import {
   mergeDiscoveryWorkerThreadCapDefaults,
   resolveDiscoveryWorkerThreadCap,
@@ -244,7 +244,7 @@ export function createNeatConfig(options: NeatOptionsInput): NeatConfig {
   });
 
   // Issue #1569: Parse worker thread cap config and apply memory-based capping.
-  // Issue GRQ#3295: when the Discovery runner exports a host-derived worker-memory
+  // When the external production runner exports a host-derived worker-memory
   // envelope (DISCOVERY_WORKER_ENVELOPE_MB) and per-worker V8 budget, wire them in
   // automatically so the cap fires without any per-caller opt-in. Explicit user
   // overrides still win; non-Discovery callers (env unset) keep the cap disabled.

--- a/test/config/DiscoveryWorkerEnvelope.ts
+++ b/test/config/DiscoveryWorkerEnvelope.ts
@@ -1,6 +1,6 @@
 /**
  * Tests for the Discovery worker-memory envelope → workerThreadCap resolver
- * (stSoftwareAU/GRQ#3295).
+ * that guards against the Discovery-worker OOM on a 16 GB production host.
  *
  * These exercise the pure env → overrides mapping with an injected reader, so
  * they are hermetic and never touch the real process environment.

--- a/test/config/Grq22WorkerCap.ts
+++ b/test/config/Grq22WorkerCap.ts
@@ -5,15 +5,14 @@ import {
 } from "@config/NeatConfig.ts";
 
 /**
- * GRQ-22 16 GB heavily-loaded OOM regression (stSoftwareAU/GRQ#3298, part of
- * #3267). Asserts the memory-based worker-thread cap (Issue #1569) reduces the
- * 12 default threads to fit the host-derived worker envelope on the exact
- * GRQ-22 numbers exported by the GRQ shell side, so a 16 GB host under load can
- * never spawn one heavy worker per default thread and OOM (exit 137).
+ * GRQ-22 16 GB heavily-loaded OOM regression guard. Asserts the memory-based
+ * worker-thread cap (Issue #1569) reduces the 12 default threads to fit the
+ * host-derived worker envelope on the exact GRQ-22 numbers the external
+ * production runner exports, so a 16 GB host under load can never spawn one
+ * heavy worker per default thread and OOM (exit 137).
  *
  * GRQ-22 host snapshot (16 GB total / 7840 MB available / 10 CPUs), and the
- * Discovery memory plan the GRQ shell computes from it
- * (worker/shared/memory_calc.sh, Issue #3294):
+ * Discovery memory plan the external production runner computes from it:
  *   heap            3528 MB
  *   worker_envelope 1049 MB   → NEAT-AI workerThreadCap.maxMemoryMB
  *   per_worker_cap   256 MB   → NEAT-AI workerThreadCap.estimatedMemoryPerWorkerMB
@@ -21,20 +20,20 @@ import {
  * Default threads on GRQ-22 = 10 CPUs + DEFAULT_HEAVY_TASK_WORKER_COUNT(2) = 12.
  */
 
-// Exact GRQ-22 plan values exported by the GRQ shell side.
+// Exact GRQ-22 plan values exported by the external production runner.
 const GRQ22_CPUS = 10;
 const GRQ22_DEFAULT_THREADS = GRQ22_CPUS + DEFAULT_HEAVY_TASK_WORKER_COUNT; // 12
 const GRQ22_WORKER_ENVELOPE_MB = 1049;
 const GRQ22_PER_WORKER_CAP_MB = 256;
 
-Deno.test("GRQ-22 #3298: default heavy-task thread count is 12 on a 10-CPU host", () => {
+Deno.test("GRQ-22 OOM cap: default heavy-task thread count is 12 on a 10-CPU host", () => {
   // Locks the 10 + 2 arithmetic the GRQ-22 fixture depends on.
   assertEquals(DEFAULT_HEAVY_TASK_WORKER_COUNT, 2);
   assertEquals(GRQ22_DEFAULT_THREADS, 12);
 });
 
-Deno.test("GRQ-22 #3298: worker cap reduces 12 threads to fit the envelope", () => {
-  // Feed the GRQ-shell-exported envelope + per-worker cap into the NEAT-AI
+Deno.test("GRQ-22 OOM cap: worker cap reduces 12 threads to fit the envelope", () => {
+  // Feed the runner-exported envelope + per-worker cap into the NEAT-AI
   // memory-based thread cap, starting from the 12 default threads.
   const config = createNeatConfig({
     threads: GRQ22_DEFAULT_THREADS,
@@ -62,7 +61,7 @@ Deno.test("GRQ-22 #3298: worker cap reduces 12 threads to fit the envelope", () 
   }
 });
 
-Deno.test("GRQ-22 #3298: uncapped 12 threads would blow the envelope (the OOM this locks out)", () => {
+Deno.test("GRQ-22 OOM cap: uncapped 12 threads would blow the envelope (the OOM this locks out)", () => {
   // The pre-fix failure mode: 12 workers, each sized at the ≥16 GB heap floor
   // (4096 MB), demanded 49152 MB on a host with only 7840 MB available.
   const HEAP_FLOOR_MB = 4096;

--- a/test/config/WorkerThreadCapConfig.ts
+++ b/test/config/WorkerThreadCapConfig.ts
@@ -11,7 +11,7 @@ import {
 import { DISCOVERY_HEAP_SIZE_ENV } from "@workers/WorkerHeapBudget.ts";
 import { getLogger, type Logger, setLogger } from "@utils/Logger.ts";
 
-/** Env vars the Discovery envelope wiring reads (GRQ#3295). */
+/** Env vars the Discovery envelope wiring reads (host-derived OOM cap). */
 const ENVELOPE_ENV_KEYS = [
   DISCOVERY_WORKER_ENVELOPE_ENV,
   DISCOVERY_HEAP_SIZE_ENV,

--- a/test/creature/LoadFromObservability.ts
+++ b/test/creature/LoadFromObservability.ts
@@ -4,9 +4,9 @@
  *  - a usable creature identifier (uuid OR `hash:<8hex>` fallback)
  *  - a `source=...` tag describing the upstream pipeline
  *
- * Without these, GRQ logs show `UUID: unknown` for every event and the
- * upstream corruption source cannot be traced (regression of GRQ#1497,
- * GRQ#1906).
+ * Without these, production logs show `UUID: unknown` for every event and the
+ * upstream corruption source cannot be traced (a regression this test locks
+ * out).
  */
 import { assert, assertEquals } from "@std/assert";
 import { Creature } from "@creature";

--- a/test/docs/NoPrivateGrqIssueSlugs.ts
+++ b/test/docs/NoPrivateGrqIssueSlugs.ts
@@ -1,0 +1,112 @@
+/**
+ * Issue #3454 — source and test comments must stay self-contained for public
+ * readers.
+ *
+ * `stSoftwareAU/GRQ` is a **private** repository, so a `GRQ#NNNN` issue-tracker
+ * slug (or a "GRQ repo" / "GRQ shell" pointer) in a comment sends a public
+ * reader to a page they cannot open. Behaviour being guarded should be
+ * described at concept level instead; where in-repo traceability matters, cite
+ * this repository's own issues/PRs.
+ *
+ * This test walks the real `src/` and `test/` trees and fails if any file
+ * reintroduces a private GRQ issue-tracker slug or repo pointer. It exercises
+ * behaviour (committed file content), not the source text of any function.
+ */
+
+import { assertEquals } from "@std/assert";
+import { fromFileUrl } from "@std/path";
+import { walk } from "@std/fs";
+
+const SRC_DIR = fromFileUrl(new URL("../../src", import.meta.url));
+const TEST_DIR = fromFileUrl(new URL("../../test", import.meta.url));
+
+/** This guard file itself — excluded so its own examples never self-match. */
+const SELF = fromFileUrl(import.meta.url);
+
+/**
+ * Match a private `stSoftwareAU/GRQ` issue-tracker slug (`GRQ#3295`,
+ * `stSoftwareAU/GRQ#3298`) or a pointer at the private repo's shell
+ * ("the GRQ repo", "the GRQ shell").
+ */
+const PRIVATE_GRQ_PATTERN = /GRQ#\d+|GRQ repo|GRQ[- ]shell/i;
+
+/**
+ * Return every 1-indexed line number carrying a private GRQ issue-tracker slug
+ * or repo pointer.
+ *
+ * @param source raw file content
+ * @returns 1-indexed line numbers with a private-GRQ reference
+ */
+export function findPrivateGrqRefs(source: string): number[] {
+  const hits: number[] = [];
+  const lines = source.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    if (PRIVATE_GRQ_PATTERN.test(lines[i])) {
+      hits.push(i + 1);
+    }
+  }
+  return hits;
+}
+
+async function scanTree(root: string): Promise<string[]> {
+  const offenders: string[] = [];
+  for await (
+    const entry of walk(root, { exts: [".ts"], includeDirs: false })
+  ) {
+    if (entry.path === SELF) continue;
+    const source = await Deno.readTextFile(entry.path);
+    const hits = findPrivateGrqRefs(source);
+    if (hits.length > 0) {
+      offenders.push(`${entry.path}:${hits.join(",")}`);
+    }
+  }
+  return offenders;
+}
+
+Deno.test("no private GRQ issue-tracker slugs or repo pointers in src/ or test/ (#3454)", async () => {
+  const offenders = [
+    ...(await scanTree(SRC_DIR)),
+    ...(await scanTree(TEST_DIR)),
+  ];
+  assertEquals(
+    offenders,
+    [],
+    `Found private stSoftwareAU/GRQ issue-tracker slugs or repo pointers in:\n` +
+      `${offenders.join("\n")}\n` +
+      `Reword to concept level (describe the behaviour guarded) and cite this ` +
+      `repository's own issues/PRs where traceability matters.`,
+  );
+});
+
+Deno.test("findPrivateGrqRefs flags a GRQ# issue slug", () => {
+  const src = [
+    "Intro line.",
+    " * Issue GRQ#3295: automatic Discovery worker-memory envelope.",
+    "Closing line.",
+  ].join("\n");
+  assertEquals(findPrivateGrqRefs(src), [2]);
+});
+
+Deno.test("findPrivateGrqRefs flags an org-qualified GRQ# slug", () => {
+  const src = " * (stSoftwareAU/GRQ#3298, part of the OOM guard).\n";
+  assertEquals(findPrivateGrqRefs(src), [1]);
+});
+
+Deno.test("findPrivateGrqRefs flags a GRQ repo pointer", () => {
+  const src =
+    " * The runner (`run.sh`, in the GRQ repo) exports the envelope.\n";
+  assertEquals(findPrivateGrqRefs(src), [1]);
+});
+
+Deno.test("findPrivateGrqRefs returns empty for self-contained prose", () => {
+  const src = [
+    " * A Discovery worker was OOM-killed on a 16 GB production host, so the",
+    " * external production runner exports a host-derived memory envelope.",
+    " * GRQ-22 host snapshot: 16 GB total, 10 CPUs.",
+  ].join("\n");
+  assertEquals(findPrivateGrqRefs(src), []);
+});
+
+Deno.test("findPrivateGrqRefs returns empty for empty input", () => {
+  assertEquals(findPrivateGrqRefs(""), []);
+});

--- a/test/docs/NoPrivateGrqIssueSlugs.ts
+++ b/test/docs/NoPrivateGrqIssueSlugs.ts
@@ -20,8 +20,20 @@ import { walk } from "@std/fs";
 const SRC_DIR = fromFileUrl(new URL("../../src", import.meta.url));
 const TEST_DIR = fromFileUrl(new URL("../../test", import.meta.url));
 
-/** This guard file itself — excluded so its own examples never self-match. */
-const SELF = fromFileUrl(import.meta.url);
+/**
+ * Private-repo *detector* tests — this guard plus its siblings that must embed
+ * the forbidden `GRQ` patterns verbatim as fixtures and test names to verify
+ * their own detection logic. They are the audit, not offenders, so scanning them
+ * would be a self-referential false positive. Any new detector test that carries
+ * literal pattern fixtures belongs here.
+ */
+const DETECTOR_TESTS = new Set(
+  [
+    import.meta.url,
+    new URL("./LiveDocsNoPrivateGrqReference.ts", import.meta.url).href,
+    new URL("./CrossSpeciesBaselineNoPrivateRepo.ts", import.meta.url).href,
+  ].map(fromFileUrl),
+);
 
 /**
  * Match a private `stSoftwareAU/GRQ` issue-tracker slug (`GRQ#3295`,
@@ -53,7 +65,7 @@ async function scanTree(root: string): Promise<string[]> {
   for await (
     const entry of walk(root, { exts: [".ts"], includeDirs: false })
   ) {
-    if (entry.path === SELF) continue;
+    if (DETECTOR_TESTS.has(entry.path)) continue;
     const source = await Deno.readTextFile(entry.path);
     const hits = findPrivateGrqRefs(source);
     if (hits.length > 0) {


### PR DESCRIPTION
## Summary

Reworded private `stSoftwareAU/GRQ` issue-tracker references out of source and
test comments so the public repository stays self-contained. `stSoftwareAU/GRQ`
is a **private** repo, so a `GRQ#NNNN` slug (or a "GRQ repo" / "GRQ shell"
pointer) in a comment leads public readers to pages they cannot open. Each
comment now describes the behaviour being guarded at concept level (e.g. "a
Discovery worker was OOM-killed on a 16 GB production host, so the external
production runner exports a host-derived worker-memory envelope") and refers to
"the external production runner" rather than the private repo. Australian
English retained throughout. Closes #3454.

Reworded references (all `GRQ#NNNN` slugs and repo pointers removed):

- `src/config/DiscoveryWorkerEnvelope.ts` — module header slug and the "in the
  GRQ repo" runner pointer.
- `src/config/NeatConfig.ts` — two `Issue GRQ#3295:` comments.
- `test/config/DiscoveryWorkerEnvelope.ts` — header slug.
- `test/config/Grq22WorkerCap.ts` — header slug, "GRQ shell" pointers, and the
  `#3298` (private issue number) in three test names.
- `test/config/WorkerThreadCapConfig.ts` — `(GRQ#3295)` note.
- `test/creature/LoadFromObservability.ts` — `GRQ#1497`, `GRQ#1906` regression
  slugs.

The `GRQ-22` / `GRQ-cluster` / `GRQ-3` host/cluster/log **mnemonics** (no `#`)
are out of scope — they are not issue-tracker links — and are left unchanged.

## Evidence

Backend/comment-only change — no web interface to screenshot. Verified via a new
guard test plus the full quality gate.

```mermaid
flowchart LR
    A["GRQ#NNNN slug<br/>in a comment"] -->|private repo| B["public reader<br/>hits a 404"]
    C["concept-level wording<br/>'external production runner'"] -->|self-contained| D["public reader<br/>understands the guard"]
    A -.reworded.-> C
```

New guard test `test/docs/NoPrivateGrqIssueSlugs.ts` walks the real `src/` and
`test/` trees and fails if any file reintroduces a `GRQ#NNNN` slug or a "GRQ
repo"/"GRQ shell" pointer, modelled on the existing
`test/docs/CrossSpeciesBaselineNoPrivateRepo.ts` audit test. It exercises
committed file content (behaviour), not the source text of any function.

The guard now exempts the private-repo **detector tests**
(`LiveDocsNoPrivateGrqReference.ts`, `CrossSpeciesBaselineNoPrivateRepo.ts`, and
itself) from the scan: those tests must embed the forbidden `GRQ` patterns
verbatim as fixtures and test names to verify their own detection, so scanning
them was a self-referential false positive that made the guard fail on the whole
tree. The exemption is an explicit, documented allowlist — not a silent skip.

## Test Plan

- Added `test/docs/NoPrivateGrqIssueSlugs.ts`:
  - `no private GRQ issue-tracker slugs or repo pointers in src/ or test/` —
    scans the real trees; would fail against the pre-fix comments, passes after
    the rewording.
  - `findPrivateGrqRefs` unit cases: flags a `GRQ#` slug, an org-qualified
    `stSoftwareAU/GRQ#` slug, and a "GRQ repo" pointer; returns empty for
    self-contained prose (including the `GRQ-22` mnemonic) and for empty input.
- Re-ran the touched suites: `test/config/DiscoveryWorkerEnvelope.ts`,
  `test/config/Grq22WorkerCap.ts`, `test/config/WorkerThreadCapConfig.ts` (31
  passed) and `test/creature/LoadFromObservability.ts` — all green with the
  reworded comments.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-ms0rcyne-9a4a87`<!-- vibe-worker-issue-3454 -->