### PR TITLE
Reword private GRQ references in live docs to concept level (#3453)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.9.34",
+  "version": "5.9.35",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/PROFILING_REPORT_3397.md
+++ b/docs/PROFILING_REPORT_3397.md
@@ -4,8 +4,8 @@ Sub-issue of #3396 — the foundational profiling deliverable that the other #33
 sub-issues derive their priorities from (same pattern as #3082 → milestone).
 
 This report profiles exactly what the two production scripts drive, on the
-GRQ-cluster production topology, and ranks the hotspots by their owning repo and
-the follow-up sub-issue that addresses each one. Every finding is framed against
+production topology, and ranks the hotspots by their owning repo and the
+follow-up sub-issue that addresses each one. Every finding is framed against
 **score improvement per wall-clock hour** inside the fixed learn/sampler
 time-boxes — not raw throughput.
 
@@ -16,8 +16,8 @@ time-boxes — not raw throughput.
 | `worker/learn.sh`   | one `src/Learn.ts` run | populationSize=20, trainingSampleRate=0.1, sparseRatio=0.05, random 6-bit evolution-mode flags, soft `--timeout ≈ 45 min` |
 | `worker/sampler.sh` | 5 `src/Learn.ts` loops | populations 20→50, rates 0.01→1.0, ~1 h target (only the final 100 % loop is checked in)                                  |
 
-**Production model** = GRQ-cluster `network.json`: **1,666 neurons, ~21,513
-synapses, 2,461 inputs (~3 MB)**.
+**Production model** = a production-scale network snapshot: **1,666 neurons,
+~21,513 synapses, 2,461 inputs (~3 MB)**.
 
 The synthetic `grq-3397` scale preset in
 `test/propagate/large/ProductionScaleCreature.ts` reproduces those exact
@@ -107,12 +107,11 @@ lives in this repo: `getEnvRustScorerConfig()` in
 - **In this profiling run:** JS/WASM lane. Evidence — `NEAT_AI_RUST_SCORER_*`
   was unset; the run logged 16 `wasmActivation` / `wasmCompilation`
   `MemoryMonitor` markers and **zero** `rust_scorer` markers.
-- **In production:** `GRQ/worker/learn.sh` selects the lane via
-  `shared/ensure_neat_ai_native_scorer.sh`, which exports
-  `NEAT_AI_RUST_SCORER_*` when the native binary is built — so production runs
-  the **native lane** when the scorer is present and falls back to JS/WASM
-  otherwise. The chosen lane is visible in the run's GRQ-logs output; if a
-  production log contradicts the lane assumed here, the native-lane routing
+- **In production:** the downstream production runner scripts select the lane by
+  exporting `NEAT_AI_RUST_SCORER_*` when the native binary is built — so
+  production runs the **native lane** when the scorer is present and falls back
+  to JS/WASM otherwise. The chosen lane is visible in the production run logs;
+  if a production log contradicts the lane assumed here, the native-lane routing
   below must be re-triaged.
 
 **Consequence for routing:** because production scores on the **native lane**,
@@ -122,15 +121,15 @@ duplicated in NEAT-AI (one root cause → one issue in the repo where it lives).
 
 ## 3. Hotspots ranked, classified, and routed to a follow-up
 
-|  # | Hotspot                                                                                | Evidence                                           | Owning repo                                                                     | Follow-up sub-issue                                                                                                              |
-| -: | -------------------------------------------------------------------------------------- | -------------------------------------------------- | ------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-|  1 | **Main-thread breeding** (70 %) — largest score-per-hour lever                         | 11,144.9 ms/gen                                    | **NEAT-AI**                                                                     | **#3399** — overlap next-gen breeding/mutation prep with in-flight scoring so the main-thread band stops gating generations/hour |
-|  2 | **Fitness / scoring lane** (11.3 % single-thread; parallelised in prod)                | 40.7 ms/activation, WASM in bench / native in prod | **NEAT-AI-core / NEAT-AI-scorer** (native lane) + **NEAT-AI** (pool scheduling) | **stSoftwareAU/NEAT-AI-core#285** for native-lane per-score cost; **#3399** for generation-end idle-worker time                  |
-|  3 | **De-duplication** (3.7 %, 561–691 ms/gen)                                             | Bloom-filter + Set on 1,666-neuron creatures       | **NEAT-AI** (main thread)                                                       | **#3399** (main-thread band; overlap/scheduling)                                                                                 |
-|  4 | **Mutation** (3.2 %)                                                                   | 504.0 ms/gen                                       | **NEAT-AI** (main thread)                                                       | **#3399** (overlap) / **#3400** (mutation rate is a tuned flag)                                                                  |
-|  5 | **resultProcessing + preWarm** (3.2 %)                                                 | 301.7 + 208.3 ms/gen                               | **NEAT-AI** (main thread)                                                       | **#3399**                                                                                                                        |
-|  6 | **Config lane** — population=20, trainingSampleRate=0.1, sparseRatio=0.05, 6-bit flags | GRQ script parameters + NEAT-AI defaults           | **GRQ** (script params) + **NEAT-AI** (defaults)                                | **#3400** — sweep flags & pop/rate for score-per-hour; raise cross-repo GRQ issue for winning script params                      |
-|  7 | **Serialisation / checkpoint I/O** — 58 ms/creature round-trip                         | per-generation write cost                          | **NEAT-AI**                                                                     | tracked as a minor cost; the #3398 harness records it. No dedicated sub-issue — below the breeding/scoring levers                |
+|  # | Hotspot                                                                                | Evidence                                               | Owning repo                                                                     | Follow-up sub-issue                                                                                                              |
+| -: | -------------------------------------------------------------------------------------- | ------------------------------------------------------ | ------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+|  1 | **Main-thread breeding** (70 %) — largest score-per-hour lever                         | 11,144.9 ms/gen                                        | **NEAT-AI**                                                                     | **#3399** — overlap next-gen breeding/mutation prep with in-flight scoring so the main-thread band stops gating generations/hour |
+|  2 | **Fitness / scoring lane** (11.3 % single-thread; parallelised in prod)                | 40.7 ms/activation, WASM in bench / native in prod     | **NEAT-AI-core / NEAT-AI-scorer** (native lane) + **NEAT-AI** (pool scheduling) | **stSoftwareAU/NEAT-AI-core#285** for native-lane per-score cost; **#3399** for generation-end idle-worker time                  |
+|  3 | **De-duplication** (3.7 %, 561–691 ms/gen)                                             | Bloom-filter + Set on 1,666-neuron creatures           | **NEAT-AI** (main thread)                                                       | **#3399** (main-thread band; overlap/scheduling)                                                                                 |
+|  4 | **Mutation** (3.2 %)                                                                   | 504.0 ms/gen                                           | **NEAT-AI** (main thread)                                                       | **#3399** (overlap) / **#3400** (mutation rate is a tuned flag)                                                                  |
+|  5 | **resultProcessing + preWarm** (3.2 %)                                                 | 301.7 + 208.3 ms/gen                                   | **NEAT-AI** (main thread)                                                       | **#3399**                                                                                                                        |
+|  6 | **Config lane** — population=20, trainingSampleRate=0.1, sparseRatio=0.05, 6-bit flags | downstream runner script parameters + NEAT-AI defaults | **downstream runner** (script params) + **NEAT-AI** (defaults)                  | **#3400** — sweep flags & pop/rate for score-per-hour; raise the winning script params with the downstream runner owners         |
+|  7 | **Serialisation / checkpoint I/O** — 58 ms/creature round-trip                         | per-generation write cost                              | **NEAT-AI**                                                                     | tracked as a minor cost; the #3398 harness records it. No dedicated sub-issue — below the breeding/scoring levers                |
 
 The **#3398** score-per-hour harness is the evidence gate every row above
 depends on: it is where each follow-up demonstrates its before/after inside a
@@ -156,8 +155,8 @@ Priority order by score-per-hour impact within the fixed time-boxes:
 - ✅ Report committed with a reproducible profiling command over `bench/`
   production-scale data (`bench/ProductionLearnSamplerProfile.ts`).
 - ✅ Production scoring lane confirmed with evidence — env-gated, default WASM;
-  native in production via GRQ `ensure_neat_ai_native_scorer.sh`; this run was
-  WASM (0 `rust_scorer` markers, 16 WASM markers).
+  native in production via the downstream production runner scripts; this run
+  was WASM (0 `rust_scorer` markers, 16 WASM markers).
 - ✅ Hotspots ranked, each assigned an owning repo + follow-up issue (§3, §4).
 
 ## References

--- a/docs/VERSION_VISIBILITY.md
+++ b/docs/VERSION_VISIBILITY.md
@@ -7,8 +7,8 @@ version it actually loaded, once per process, at startup.
 
 Two pieces of context made this necessary:
 
-- The GRQ-logs / Develop trap-sample storm in May 2026 was eventually traced
-  back to GRQ (a downstream NEAT-AI consumer) workers pinned to `5.0.13`. That
+- A May 2026 production trap-sample storm was eventually traced back to a
+  downstream NEAT-AI consumer's workers pinned to `5.0.13`. That
   [JavaScript Registry (JSR)](https://jsr.io/) release predates the
   position-blind topology-hash collision fix from Pull Request (PR) #2678, which
   only landed in `5.0.14`+.
@@ -78,9 +78,9 @@ When `deno.json` `version` is bumped (typically by `bump-deps.sh` or the
 `update-package-version.yml` workflow), no extra change is needed in
 `src/utils/Version.ts` — `deno.json` is the single source of truth on the local
 load path, and JSR consumers derive the version from `import.meta.url` after
-publish. Downstream consumers (GRQ and sibling repos) need to refresh their
-`@stsoftware/neat-ai` pin to the new JSR version so they pick up the fix; verify
-the line in their logs after the restart.
+publish. Downstream consumers need to refresh their `@stsoftware/neat-ai` pin to
+the new JSR version so they pick up the fix; verify the line in their logs after
+the restart.
 
 ## Related documents
 

--- a/docs/archive/pr-summaries/pr-summary-3453.md
+++ b/docs/archive/pr-summaries/pr-summary-3453.md
@@ -1,0 +1,60 @@
+# Reword private GRQ references in live docs to concept level
+
+## Summary
+
+Live (non-archive) documentation named or linked the private `stSoftwareAU`
+repositories `GRQ`, `GRQ-cluster` and `GRQ-logs`. A public repository must be
+self-contained for public readers — a doc line that links a private repo 404s
+and its named file paths are unverifiable. This PR rewords every such reference
+to concept level, losing no information a public reader could act on. Closes
+#3453.
+
+Changes:
+
+- `docs/comparison/PROS_AND_CONS.md` — replaced the Markdown link to
+  `GRQ-cluster/network.json` with "a production-scale network snapshot"
+  (retaining the concrete ~1,700 neurons / ~22,000 synapses / 2,461 inputs
+  figures and the snapshot date).
+- `docs/PROFILING_REPORT_3397.md` — "GRQ-cluster production topology" →
+  "production topology"; "GRQ-cluster `network.json`" → "a production-scale
+  network snapshot"; `GRQ/worker/learn.sh` / `ensure_neat_ai_native_scorer.sh` →
+  "the downstream production runner scripts"; "GRQ-logs output" → "the
+  production run logs"; the "GRQ" table cells → "downstream runner".
+- `docs/VERSION_VISIBILITY.md` — "The GRQ-logs / Develop trap-sample storm" → "A
+  May 2026 production trap-sample storm", and "Downstream consumers (GRQ and
+  sibling repos)" → "Downstream consumers".
+
+The in-tree lower-case `grq-3397` synthetic scale-preset name (a fixture in
+`test/propagate/large/ProductionScaleCreature.ts`, not a private repo) is left
+untouched — it is verifiable by public readers.
+
+## Evidence
+
+Documentation-only change — no web interface to screenshot. Verification is via
+the new behavioural test that reads the real docs and asserts no upper-case
+`GRQ` private-repo token remains:
+
+```
+deno test --allow-read test/docs/LiveDocsNoPrivateGrqReference.ts
+ok | 8 passed | 0 failed
+```
+
+```mermaid
+flowchart LR
+    A["Live doc names GRQ /<br/>GRQ-cluster / GRQ-logs"] --> B["Reword to<br/>concept level"]
+    B --> C["Self-contained doc<br/>(no private-repo reference)"]
+    C --> D["Test asserts no<br/>upper-case GRQ token"]
+```
+
+## Test Plan
+
+- Added `test/docs/LiveDocsNoPrivateGrqReference.ts`:
+  - `findPrivateGrqReferences` unit tests — flags `GRQ-cluster` / `GRQ-logs`,
+    flags a bare `GRQ` repo name, ignores the lower-case `grq-3397` fixture,
+    returns empty for concept-level prose and for empty input.
+  - Per-doc regression tests over the three real live docs (`PROS_AND_CONS.md`,
+    `PROFILING_REPORT_3397.md`, `VERSION_VISIBILITY.md`) asserting no private
+    `GRQ*` reference. These fail against the unfixed docs and pass after the
+    reword.
+- `./quality.sh` run clean (lint, format, type-check, WASM sync, full test
+  suite).

--- a/docs/comparison/PROS_AND_CONS.md
+++ b/docs/comparison/PROS_AND_CONS.md
@@ -59,11 +59,10 @@ networks.
 2. **Slower convergence**: evolutionary search is slower than pure gradient
    descent.
 3. **Limited scalability**: struggles with very large networks, though "limited"
-   is relative — the live production creature
-   ([`GRQ-cluster/network.json`](https://github.com/stSoftwareAU/GRQ-cluster/blob/main/network.json),
-   snapshot 2026-06-16) carries ~1,700 hidden neurons and ~22,000 synapses
-   across 2,461 inputs, and keeps growing. The `discoveryDir` feature helps push
-   past this by finding structural improvements incrementally.
+   is relative — a production-scale network snapshot (~1,700 hidden neurons and
+   ~22,000 synapses across 2,461 inputs, captured 2026-06-16) keeps growing. The
+   `discoveryDir` feature helps push past this by finding structural
+   improvements incrementally.
 4. **Sequential processing**: less efficient for pure parallel computation than
    fixed architectures, though topology-aware parallel batch evaluation helps.
 5. **Limited unsupervised learning**: NEAT-AI (like standard NEAT) is typically

--- a/test/docs/LiveDocsNoPrivateGrqReference.ts
+++ b/test/docs/LiveDocsNoPrivateGrqReference.ts
@@ -1,0 +1,95 @@
+/**
+ * Issue #3453 — live (non-archive) documentation must stay self-contained for
+ * public readers and must not name or link the private `stSoftwareAU` repos
+ * `GRQ`, `GRQ-cluster` or `GRQ-logs`.
+ *
+ * A public repository is fully self-contained for the public: a doc line that
+ * names or links a private repository is dead weight to every public reader —
+ * the link 404s and the named file paths are unverifiable. This test walks the
+ * real docs and fails if any reintroduces a private `GRQ*` reference. It
+ * exercises behaviour (doc content), not the source text of any function.
+ *
+ * Detection is case-sensitive on the upper-case `GRQ` token so the in-tree
+ * synthetic `grq-3397` scale-preset name (a fixture, not a private repo) is not
+ * flagged.
+ */
+
+import { assertEquals } from "@std/assert";
+import { fromFileUrl } from "@std/path";
+
+/** Live docs that must not reference the private `GRQ*` repositories. */
+const LIVE_DOCS = [
+  "../../docs/comparison/PROS_AND_CONS.md",
+  "../../docs/PROFILING_REPORT_3397.md",
+  "../../docs/VERSION_VISIBILITY.md",
+];
+
+/**
+ * Return every line that names or links a private `GRQ*` repository
+ * (`GRQ`, `GRQ-cluster`, `GRQ-logs`). Matching is case-sensitive so the
+ * lower-case in-tree `grq-3397` fixture name is not a false positive.
+ *
+ * @param source raw Markdown source
+ * @returns 1-indexed line numbers carrying a private `GRQ*` reference
+ */
+export function findPrivateGrqReferences(source: string): number[] {
+  const pattern = /GRQ/;
+  const hits: number[] = [];
+  const lines = source.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    if (pattern.test(lines[i])) {
+      hits.push(i + 1);
+    }
+  }
+  return hits;
+}
+
+for (const rel of LIVE_DOCS) {
+  Deno.test(`live doc ${rel} has no private GRQ reference (#3453)`, async () => {
+    const path = fromFileUrl(new URL(rel, import.meta.url));
+    const source = await Deno.readTextFile(path);
+    const hits = findPrivateGrqReferences(source);
+    assertEquals(
+      hits,
+      [],
+      `${rel} references a private GRQ* repository on line(s) ` +
+        `${hits.join(", ")}. Reword to concept level so the doc stays ` +
+        `verifiable by public readers.`,
+    );
+  });
+}
+
+Deno.test("findPrivateGrqReferences flags GRQ-cluster and GRQ-logs", () => {
+  const src = [
+    "Intro line.",
+    "See the GRQ-cluster network snapshot.",
+    "Traced back through the GRQ-logs output.",
+    "Closing line.",
+  ].join("\n");
+  assertEquals(findPrivateGrqReferences(src), [2, 3]);
+});
+
+Deno.test("findPrivateGrqReferences flags a bare GRQ repo name", () => {
+  const src = "run the GRQ/worker/learn.sh script.\n";
+  assertEquals(findPrivateGrqReferences(src), [1]);
+});
+
+Deno.test("findPrivateGrqReferences ignores the lower-case grq-3397 fixture", () => {
+  const src = [
+    "The synthetic `grq-3397` scale preset reproduces the dimensions.",
+    "Re-running against the `grq-3397` generator must reproduce the line.",
+  ].join("\n");
+  assertEquals(findPrivateGrqReferences(src), []);
+});
+
+Deno.test("findPrivateGrqReferences returns empty for concept-level prose", () => {
+  const src = [
+    "A production-scale network snapshot (~1,670 neurons) keeps growing.",
+    "The downstream production runner scripts select the scoring lane.",
+  ].join("\n");
+  assertEquals(findPrivateGrqReferences(src), []);
+});
+
+Deno.test("findPrivateGrqReferences returns empty for empty input", () => {
+  assertEquals(findPrivateGrqReferences(""), []);
+});


### PR DESCRIPTION
# Reword private GRQ references in live docs to concept level

## Summary

Live (non-archive) documentation named or linked the private `stSoftwareAU`
repositories `GRQ`, `GRQ-cluster` and `GRQ-logs`. A public repository must be
self-contained for public readers — a doc line that links a private repo 404s
and its named file paths are unverifiable. This PR rewords every such reference
to concept level, losing no information a public reader could act on. Closes
#3453.

Changes:

- `docs/comparison/PROS_AND_CONS.md` — replaced the Markdown link to
  `GRQ-cluster/network.json` with "a production-scale network snapshot"
  (retaining the concrete ~1,700 neurons / ~22,000 synapses / 2,461 inputs
  figures and the snapshot date).
- `docs/PROFILING_REPORT_3397.md` — "GRQ-cluster production topology" →
  "production topology"; "GRQ-cluster `network.json`" → "a production-scale
  network snapshot"; `GRQ/worker/learn.sh` / `ensure_neat_ai_native_scorer.sh` →
  "the downstream production runner scripts"; "GRQ-logs output" → "the
  production run logs"; the "GRQ" table cells → "downstream runner".
- `docs/VERSION_VISIBILITY.md` — "The GRQ-logs / Develop trap-sample storm" → "A
  May 2026 production trap-sample storm", and "Downstream consumers (GRQ and
  sibling repos)" → "Downstream consumers".

The in-tree lower-case `grq-3397` synthetic scale-preset name (a fixture in
`test/propagate/large/ProductionScaleCreature.ts`, not a private repo) is left
untouched — it is verifiable by public readers.

## Evidence

Documentation-only change — no web interface to screenshot. Verification is via
the new behavioural test that reads the real docs and asserts no upper-case
`GRQ` private-repo token remains:

```
deno test --allow-read test/docs/LiveDocsNoPrivateGrqReference.ts
ok | 8 passed | 0 failed
```

```mermaid
flowchart LR
    A["Live doc names GRQ /<br/>GRQ-cluster / GRQ-logs"] --> B["Reword to<br/>concept level"]
    B --> C["Self-contained doc<br/>(no private-repo reference)"]
    C --> D["Test asserts no<br/>upper-case GRQ token"]
```

## Test Plan

- Added `test/docs/LiveDocsNoPrivateGrqReference.ts`:
  - `findPrivateGrqReferences` unit tests — flags `GRQ-cluster` / `GRQ-logs`,
    flags a bare `GRQ` repo name, ignores the lower-case `grq-3397` fixture,
    returns empty for concept-level prose and for empty input.
  - Per-doc regression tests over the three real live docs (`PROS_AND_CONS.md`,
    `PROFILING_REPORT_3397.md`, `VERSION_VISIBILITY.md`) asserting no private
    `GRQ*` reference. These fail against the unfixed docs and pass after the
    reword.
- `./quality.sh` run clean (lint, format, type-check, WASM sync, full test
  suite).



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-ms0mbagt-40dc73`<!-- vibe-worker-issue-3453 -->