### PR TITLE
🟡 Reword private repo references in archived PR summaries and investigations (Issue #3455)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.9.37",
+  "version": "5.9.38",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/investigations/issue-2515-forward-only-apply-audit.md
+++ b/docs/archive/investigations/issue-2515-forward-only-apply-audit.md
@@ -93,4 +93,4 @@ flowchart LR
 
 - Builds on #2511 (save-side assertion in `exportJSON`) and #2514 (load-side
   throw in `loadFrom`).
-- Closes the producer-side audit requested in stSoftwareAU/GRQ#2109.
+- Closes the producer-side audit requested in the downstream production repo.

--- a/docs/archive/pr-summaries/pr-summary-3018.md
+++ b/docs/archive/pr-summaries/pr-summary-3018.md
@@ -1,10 +1,9 @@
 ## Summary
 
 The docs understated the size of the live production creature. Several spots
-claimed "~500 hidden neurons", but the production genome
-([GRQ-cluster/network.json](https://github.com/stSoftwareAU/GRQ-cluster/blob/main/network.json))
-is far larger. This PR refreshes those statistics to match the actual deployed
-creature. Closes #3018.
+claimed "~500 hidden neurons", but the production genome (the production
+`network.json` snapshot) is far larger. This PR refreshes those statistics to
+match the actual deployed creature. Closes #3018.
 
 Measured directly from the production `network.json` (semantic version 4.0.0,
 forward-only):
@@ -36,8 +35,8 @@ were left unchanged.
 This is a documentation-only change (no TypeScript modified), so there is no UI
 to screenshot and no runtime behaviour to benchmark. Verification:
 
-- Production statistics derived by parsing the live `network.json` fetched from
-  `stSoftwareAU/GRQ-cluster`:
+- Production statistics derived by parsing the live production `network.json`
+  snapshot:
   `input: 2461, output: 1, neurons: 1673 (1669 hidden, 3 constant, 1 output), synapses: 21689`.
 - `./quality.sh --lint-only` passes cleanly (formatting, linting, bash check).
 - `markdownlint-cli2` reports 0 errors.

--- a/docs/archive/pr-summaries/pr-summary-3400.md
+++ b/docs/archive/pr-summaries/pr-summary-3400.md
@@ -14,7 +14,7 @@ Key outcome: **no NEAT-AI default change is warranted** — the production
 settings are already at (or validated against) the score-per-hour optimum on
 production-scale data, and no swept configuration improves score-per-hour
 without regressing the final score. The evidence-backed recommendation is to
-keep the current settings; a cross-repo GRQ issue (stSoftwareAU/GRQ#3472)
+keep the current settings; a cross-repo issue in the downstream production repo
 carries the one action that must run in the production backprop environment.
 
 ### What changed
@@ -80,8 +80,8 @@ Every combination of `trainingSampleRate ∈ {0.1, 1.0}` ×
 {0.05, 0.5}` reached the **identical final best score
 (-1.115e+31)** — these knobs only act under backprop training
 (`trainPerGen ≥ 1`), which is non-deterministic and cannot be measured by the
-in-repo harness. That measurement is handed to GRQ (stSoftwareAU/GRQ#3472) with
-the reusable tool.
+in-repo harness. That measurement is handed to the downstream production repo
+via a cross-repo issue with the reusable tool.
 
 Full evidence: `docs/evidence/sweep-3400-time-boxed.{md,json}`,
 `docs/evidence/sweep-3400-population.{md,json}`,
@@ -91,10 +91,10 @@ Full evidence: `docs/evidence/sweep-3400-time-boxed.{md,json}`,
 
 - **NEAT-AI defaults: no change** — current settings are at/validated against
   the score-per-hour optimum; changing one would be an unbacked regression risk.
-- **GRQ:** keep `learn.sh` `populationSize=20` and the sampler 20→50 ramp
-  (validated); run the in-situ backprop sweep for `trainingSampleRate` /
-  `sparseRatio` — filed as stSoftwareAU/GRQ#3472 referencing this issue with the
-  evidence.
+- **Downstream production repo:** keep `learn.sh` `populationSize=20` and the
+  sampler 20→50 ramp (validated); run the in-situ backprop sweep for
+  `trainingSampleRate` / `sparseRatio` — filed as a cross-repo issue in the
+  downstream production repo referencing this issue with the evidence.
 
 ## Test Plan
 

--- a/docs/archive/pr-summaries/pr-summary-3410.md
+++ b/docs/archive/pr-summaries/pr-summary-3410.md
@@ -26,7 +26,7 @@ post-#3403): with the limit read correctly, the CRITICAL response no longer
 fires spuriously early **and** genuinely fires when the heap approaches the real
 limit, so cache eviction / proactive GC actually run before the V8 OOM abort
 rather than being wasted on a false alarm. The change does not depend on
-reducing `popSize` (GRQ#3472 keeps population = 20).
+reducing `popSize` (the downstream production repo keeps population = 20).
 
 ### What changed
 
@@ -105,5 +105,6 @@ All 33 pre-existing `MemoryMonitor` tests remain unchanged and pass, plus
 Defect #2 (the misread limit) is the well-defined library root cause and is
 fully fixed here. Correcting it also makes the CRITICAL response meaningful,
 which is the library-side containment for defect #1's residual heap growth. The
-downstream GRQ containment (bounded exit-133 retry, low-memory heap-budget
-tuning) is tracked separately in stSoftwareAU/GRQ#3508.
+downstream production containment (bounded exit-133 retry, low-memory
+heap-budget tuning) is tracked separately in a cross-repo issue in the
+downstream production repo.

--- a/docs/archive/pr-summaries/pr-summary-3412.md
+++ b/docs/archive/pr-summaries/pr-summary-3412.md
@@ -90,6 +90,6 @@ DIRECTORY_MISSING`, `path` = the deleted dir) is thrown — **not** an
 
 - **Repository isolation / Deno-native:** the fix lives entirely inside this
   repo and uses Deno-native `Deno.errors.NotFound`; no Node tooling introduced.
-- **Scope:** the upstream deletion itself is tracked separately in
-  `stSoftwareAU/GRQ#3518`; this change only makes the surfacing loud and clear
-  as the issue requested.
+- **Scope:** the upstream deletion itself is tracked separately in a cross-repo
+  issue in the downstream production repo; this change only makes the surfacing
+  loud and clear as the issue requested.

--- a/docs/archive/pr-summaries/pr-summary-3417.md
+++ b/docs/archive/pr-summaries/pr-summary-3417.md
@@ -7,23 +7,23 @@ Dependency bumps on host Mac-Ultra-M2 were rejected because `bump-deps.sh`'s
 with the unattended launchd/cron PATH, which lacks `~/.deno/bin` (the official
 installer location). The bump was reverted and PR #3416 shipped without it.
 
-The root cause is worker-side and tracked separately as
-`stSoftwareAU/VibeCoding#3532`. This PR adds a **local defence-in-depth layer**:
-when `command -v deno` fails, `bump-deps.sh` now probes the known install
-locations — `~/.deno/bin/deno`, `/opt/homebrew/bin/deno`, `/usr/local/bin/deno`
-(first match wins) — and prepends the winner's directory to `PATH` so every
-later `deno` call resolves. When no candidate exists it still **fails loud**
-with the existing `ERROR: deno is required` message and exit 1, so the worker
-reverts per VibeCoding#1613 — no silent skip.
+The root cause is worker-side and tracked separately in the orchestration repo's
+tracking issue. This PR adds a **local defence-in-depth layer**: when
+`command -v deno` fails, `bump-deps.sh` now probes the known install locations —
+`~/.deno/bin/deno`, `/opt/homebrew/bin/deno`, `/usr/local/bin/deno` (first match
+wins) — and prepends the winner's directory to `PATH` so every later `deno` call
+resolves. When no candidate exists it still **fails loud** with the existing
+`ERROR: deno is required` message and exit 1, so the worker reverts per the
+orchestration repo's dependency-bump contract — no silent skip.
 
 The fallback list is overridable via `BUMP_DEPS_DENO_FALLBACKS` (a
 colon-separated test seam) that defaults to the three canonical locations.
 
 Closes #3417.
 
-> Note: the verify-and-close step in the issue depends on VibeCoding#3532
-> landing on an affected host; this PR delivers the hardening half, which does
-> not depend on the worker fix.
+> Note: the verify-and-close step in the issue depends on the orchestration
+> repo's worker fix landing on an affected host; this PR delivers the hardening
+> half, which does not depend on the worker fix.
 
 ## Deno regression avoided
 

--- a/docs/archive/pr-summaries/pr-summary-3455.md
+++ b/docs/archive/pr-summaries/pr-summary-3455.md
@@ -1,74 +1,74 @@
-# Reword private repo references in archived PR summaries and investigations
+# Reword private-repo references in archived PR summaries and investigations
 
 ## Summary
 
-Archived documentation directly pointed public readers at private `stSoftwareAU`
-repositories (`GRQ`, `GRQ-cluster`, `VibeCoding`). A public repository must be
-fully self-contained: archived or not, these files ship in every public clone,
-and each private issue slug or blob link 404s for anyone outside the
-organisation. This PR rewords each private-repo pointer to concept level while
-preserving the archived narrative's meaning. Closes #3455.
+Archived documentation directly named or linked the **private** `stSoftwareAU`
+repositories `GRQ`, `GRQ-cluster` and `VibeCoding` — via a `GRQ-cluster`
+`network.json` blob link, issue-tracker slugs (`GRQ#3472`,
+`stSoftwareAU/GRQ#3508`, `stSoftwareAU/GRQ#3518`,
+`stSoftwareAU/VibeCoding#3532`, `stSoftwareAU/GRQ#2109`), and org-qualified repo
+names. A public repository must be fully self-contained: those links 404 for
+public readers and the slugs point at issues they cannot open. Each reference is
+reworded to concept level — "the downstream production repo", "the orchestration
+repo's tracking issue", "the production `network.json` snapshot" — so the
+archived narrative keeps its meaning without pointing at private targets. Closes
+#3455.
 
-Reworded references (all private issue slugs and org-qualified repo links
-removed):
+Bare host/log/preset **mnemonics** (`GRQ-21`, `grq-3397`, `GRQ-side`,
+`GRQ-3-rocket.log`) are intentionally kept — they name a concept, not a private
+target, consistent with the #3454 decision. The public `stSoftwareAU/NEAT-AI`
+issue link in the investigation doc is untouched.
 
-- `docs/archive/pr-summaries/pr-summary-3018.md` — dropped the
-  `github.com/stSoftwareAU/GRQ-cluster/blob/main/network.json` link and the
-  `stSoftwareAU/GRQ-cluster` source pointer in favour of "the production
-  `network.json` snapshot".
+Files reworded:
+
+- `docs/archive/pr-summaries/pr-summary-3018.md` — dropped the `GRQ-cluster`
+  `network.json` blob link and the `stSoftwareAU/GRQ-cluster` slug in favour of
+  "the production `network.json` snapshot".
 - `docs/archive/pr-summaries/pr-summary-3400.md` — three `stSoftwareAU/GRQ#3472`
-  slugs → "a cross-repo issue in the downstream production repo".
+  slugs and the surrounding `GRQ` repo pointers → "the downstream production
+  repo".
 - `docs/archive/pr-summaries/pr-summary-3410.md` — `GRQ#3472` and
-  `stSoftwareAU/GRQ#3508` → "the downstream production repo".
+  `stSoftwareAU/GRQ#3508` → concept-level downstream-repo wording.
 - `docs/archive/pr-summaries/pr-summary-3412.md` — `stSoftwareAU/GRQ#3518` → "a
   cross-repo issue in the downstream production repo".
 - `docs/archive/pr-summaries/pr-summary-3417.md` —
-  `stSoftwareAU/VibeCoding#3532` (and the sibling `VibeCoding#1613` /
-  `VibeCoding#3532` pointers on the same page) → "the orchestration repo's
-  tracking issue" / "the orchestration repo's dependency-bump contract".
+  `stSoftwareAU/VibeCoding#3532` (plus the same-class `VibeCoding#1613` /
+  `VibeCoding#3532` slugs on nearby lines) → "the orchestration repo's tracking
+  issue" / "the orchestration repo's dependency-bump contract".
 - `docs/archive/investigations/issue-2515-forward-only-apply-audit.md` —
-  `stSoftwareAU/GRQ#2109` → "the downstream production repo".
-
-Bare host/cluster/log **mnemonics** without a `#` slug or org-qualified path
-(`GRQ-23`, `GRQ-cluster`, `GRQ-3`) are left as narrative, consistent with the
-scope of the private-repo-reference audit and the prior #3454 decision.
-
-The audit-narrative summaries `pr-summary-3452.md` and `pr-summary-3454.md`
-necessarily embed the private-repo patterns to record _what_ they removed, so
-they are exempted from the new guard (they are the audit, not offenders).
-
-```mermaid
-flowchart LR
-    A["Archived doc names<br/>GRQ#NNNN / stSoftwareAU/GRQ-cluster"] --> B["Reword to<br/>concept level"]
-    B --> C["docs/archive stays<br/>self-contained"]
-    C --> D["Test asserts no private<br/>slug or link in archive"]
-```
+  `stSoftwareAU/GRQ#2109` → "a cross-repo issue in the downstream production
+  repo".
 
 ## Evidence
 
-Documentation-and-test change only (no TypeScript runtime behaviour, no UI to
-screenshot). Verification via the new detector test and the quality gate:
+Documentation-only change plus a guard test — no web interface to screenshot and
+no runtime behaviour to benchmark. Verification is the new guard test and the
+existing docs quality gates.
 
-- `deno test test/docs/ArchiveDocsNoPrivateRepoSlugs.ts` — the archive-scan test
-  fails against the unfixed docs (six offender files) and passes after the
-  reword.
-- `markdownlint-cli2` over `docs/archive/**/*.md` — 0 errors.
-- `deno fmt` / `deno lint` on the changed files — clean.
+```mermaid
+flowchart LR
+    A["Archived doc names/links<br/>private GRQ / GRQ-cluster / VibeCoding"]
+      --> B["Reword to concept level<br/>(downstream production repo)"]
+    B --> C["ArchiveDocsNoPrivateRepoReference<br/>guard: 0 private-repo refs"]
+    C --> D["Public reader: self-contained,<br/>no 404s"]
+```
+
+- The new guard `findPrivateRepoRefs` reports zero hits across all six reworded
+  docs; it flags issue slugs (`GRQ#\d+`, `VibeCoding#\d+`), org-qualified
+  private repo names, and private-repo links, while ignoring bare mnemonics and
+  the public `stSoftwareAU/NEAT-AI` repo.
+- `deno fmt --check`, `deno lint`, and `deno check` pass on the changed files.
 
 ## Test Plan
 
-Added `test/docs/ArchiveDocsNoPrivateRepoSlugs.ts`:
-
-- `no private stSoftwareAU repo slugs or links in docs/archive (#3455)` — walks
-  the real `docs/archive/` tree and asserts no file (outside the audit-narrative
-  allowlist) carries a private issue slug or org-qualified repo link. This is
-  the regression test that reproduces the finding: it fails against the unfixed
-  archive and passes after this PR.
-- `findPrivateRepoRefs` unit cases — flags a bare `GRQ#` slug, an org-qualified
-  `stSoftwareAU/GRQ#` slug, a `VibeCoding#` slug, a `stSoftwareAU/GRQ-cluster`
-  path, and a `GRQ-cluster` blob link; returns empty for concept-level prose
-  (including bare `GRQ-cluster` / `GRQ-23` mnemonics) and for empty input.
-
-Registered the new detector in `test/docs/NoPrivateGrqIssueSlugs.ts`'s
-`DETECTOR_TESTS` allowlist so its own `GRQ#` fixtures are not flagged by the
-#3454 `src/`/`test/` scan.
+- Added `test/docs/ArchiveDocsNoPrivateRepoReference.ts`:
+  - Six per-doc guards asserting each reworded archive file has no private-repo
+    reference.
+  - `findPrivateRepoRefs` unit cases — flags a bare `GRQ#` slug, an
+    org-qualified `GRQ#` slug, a `VibeCoding#` slug, an org-qualified private
+    repo name, and a private-repo blob URL; returns empty for bare mnemonics,
+    the public `NEAT-AI` repo, concept-level prose, and empty input.
+- Registered the new file in the `DETECTOR_TESTS` carve-out of
+  `test/docs/NoPrivateGrqIssueSlugs.ts` so its literal `GRQ#`/`stSoftwareAU/GRQ`
+  fixtures are not treated as offenders.
+- `deno test --allow-read test/docs/*.ts` — 136 passed, 0 failed.

--- a/docs/archive/pr-summaries/pr-summary-3455.md
+++ b/docs/archive/pr-summaries/pr-summary-3455.md
@@ -1,0 +1,74 @@
+# Reword private repo references in archived PR summaries and investigations
+
+## Summary
+
+Archived documentation directly pointed public readers at private `stSoftwareAU`
+repositories (`GRQ`, `GRQ-cluster`, `VibeCoding`). A public repository must be
+fully self-contained: archived or not, these files ship in every public clone,
+and each private issue slug or blob link 404s for anyone outside the
+organisation. This PR rewords each private-repo pointer to concept level while
+preserving the archived narrative's meaning. Closes #3455.
+
+Reworded references (all private issue slugs and org-qualified repo links
+removed):
+
+- `docs/archive/pr-summaries/pr-summary-3018.md` — dropped the
+  `github.com/stSoftwareAU/GRQ-cluster/blob/main/network.json` link and the
+  `stSoftwareAU/GRQ-cluster` source pointer in favour of "the production
+  `network.json` snapshot".
+- `docs/archive/pr-summaries/pr-summary-3400.md` — three `stSoftwareAU/GRQ#3472`
+  slugs → "a cross-repo issue in the downstream production repo".
+- `docs/archive/pr-summaries/pr-summary-3410.md` — `GRQ#3472` and
+  `stSoftwareAU/GRQ#3508` → "the downstream production repo".
+- `docs/archive/pr-summaries/pr-summary-3412.md` — `stSoftwareAU/GRQ#3518` → "a
+  cross-repo issue in the downstream production repo".
+- `docs/archive/pr-summaries/pr-summary-3417.md` —
+  `stSoftwareAU/VibeCoding#3532` (and the sibling `VibeCoding#1613` /
+  `VibeCoding#3532` pointers on the same page) → "the orchestration repo's
+  tracking issue" / "the orchestration repo's dependency-bump contract".
+- `docs/archive/investigations/issue-2515-forward-only-apply-audit.md` —
+  `stSoftwareAU/GRQ#2109` → "the downstream production repo".
+
+Bare host/cluster/log **mnemonics** without a `#` slug or org-qualified path
+(`GRQ-23`, `GRQ-cluster`, `GRQ-3`) are left as narrative, consistent with the
+scope of the private-repo-reference audit and the prior #3454 decision.
+
+The audit-narrative summaries `pr-summary-3452.md` and `pr-summary-3454.md`
+necessarily embed the private-repo patterns to record _what_ they removed, so
+they are exempted from the new guard (they are the audit, not offenders).
+
+```mermaid
+flowchart LR
+    A["Archived doc names<br/>GRQ#NNNN / stSoftwareAU/GRQ-cluster"] --> B["Reword to<br/>concept level"]
+    B --> C["docs/archive stays<br/>self-contained"]
+    C --> D["Test asserts no private<br/>slug or link in archive"]
+```
+
+## Evidence
+
+Documentation-and-test change only (no TypeScript runtime behaviour, no UI to
+screenshot). Verification via the new detector test and the quality gate:
+
+- `deno test test/docs/ArchiveDocsNoPrivateRepoSlugs.ts` — the archive-scan test
+  fails against the unfixed docs (six offender files) and passes after the
+  reword.
+- `markdownlint-cli2` over `docs/archive/**/*.md` — 0 errors.
+- `deno fmt` / `deno lint` on the changed files — clean.
+
+## Test Plan
+
+Added `test/docs/ArchiveDocsNoPrivateRepoSlugs.ts`:
+
+- `no private stSoftwareAU repo slugs or links in docs/archive (#3455)` — walks
+  the real `docs/archive/` tree and asserts no file (outside the audit-narrative
+  allowlist) carries a private issue slug or org-qualified repo link. This is
+  the regression test that reproduces the finding: it fails against the unfixed
+  archive and passes after this PR.
+- `findPrivateRepoRefs` unit cases — flags a bare `GRQ#` slug, an org-qualified
+  `stSoftwareAU/GRQ#` slug, a `VibeCoding#` slug, a `stSoftwareAU/GRQ-cluster`
+  path, and a `GRQ-cluster` blob link; returns empty for concept-level prose
+  (including bare `GRQ-cluster` / `GRQ-23` mnemonics) and for empty input.
+
+Registered the new detector in `test/docs/NoPrivateGrqIssueSlugs.ts`'s
+`DETECTOR_TESTS` allowlist so its own `GRQ#` fixtures are not flagged by the
+#3454 `src/`/`test/` scan.

--- a/test/docs/ArchiveDocsNoPrivateRepoReference.ts
+++ b/test/docs/ArchiveDocsNoPrivateRepoReference.ts
@@ -1,0 +1,139 @@
+/**
+ * Issue #3455 — archived documentation must stay self-contained for public
+ * readers and must not link or slug the private `stSoftwareAU` repositories
+ * `GRQ`, `GRQ-cluster` or `VibeCoding`.
+ *
+ * Archived PR summaries and investigations ship in every public clone. A line
+ * that links a private repo (the link 404s) or carries a private issue-tracker
+ * slug (`GRQ#3472`, `stSoftwareAU/VibeCoding#3532`) points readers at issues
+ * and files they cannot open. The archived narrative keeps its meaning when the
+ * reference is reworded to concept level (e.g. "the downstream production
+ * repo"), so this guard walks the previously-offending archived docs and fails
+ * if any reintroduces a private-repo link or slug. It exercises behaviour (doc
+ * content), not the source text of any function.
+ *
+ * Bare host/log/preset **mnemonics** with no issue slug or org prefix
+ * (`GRQ-21`, `GRQ-side`, the lower-case `grq-3397` fixture) are intentionally
+ * NOT flagged — they name a concept, not a private target, consistent with the
+ * #3454 decision to keep such mnemonics. The public `stSoftwareAU/NEAT-AI` repo
+ * is likewise not flagged.
+ */
+
+import { assertEquals } from "@std/assert";
+import { fromFileUrl } from "@std/path";
+
+/** Archived docs reworded by #3455; each must stay free of private-repo refs. */
+const ARCHIVE_DOCS = [
+  "../../docs/archive/pr-summaries/pr-summary-3018.md",
+  "../../docs/archive/pr-summaries/pr-summary-3400.md",
+  "../../docs/archive/pr-summaries/pr-summary-3410.md",
+  "../../docs/archive/pr-summaries/pr-summary-3412.md",
+  "../../docs/archive/pr-summaries/pr-summary-3417.md",
+  "../../docs/archive/investigations/issue-2515-forward-only-apply-audit.md",
+];
+
+/**
+ * Match a reference to a private `stSoftwareAU` repository:
+ *
+ * - an issue-tracker slug — `GRQ#3472`, `stSoftwareAU/VibeCoding#3532`;
+ * - an org-qualified private repo name — `stSoftwareAU/GRQ`,
+ *   `stSoftwareAU/GRQ-cluster`, `stSoftwareAU/VibeCoding` (this also covers a
+ *   `github.com/stSoftwareAU/GRQ-cluster/...` link).
+ *
+ * The public `stSoftwareAU/NEAT-AI` repo and bare mnemonics (`GRQ-21`,
+ * `grq-3397`) do not match.
+ */
+const PRIVATE_REPO_PATTERN =
+  /(?:^|[^A-Za-z0-9])(?:GRQ|VibeCoding)#\d+|stSoftwareAU\/(?:GRQ|VibeCoding)/;
+
+/**
+ * Return every 1-indexed line number carrying a private-repo issue slug or an
+ * org-qualified private-repo reference.
+ *
+ * @param source raw Markdown source
+ * @returns 1-indexed line numbers with a private-repo reference
+ */
+export function findPrivateRepoRefs(source: string): number[] {
+  const hits: number[] = [];
+  const lines = source.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    if (PRIVATE_REPO_PATTERN.test(lines[i])) {
+      hits.push(i + 1);
+    }
+  }
+  return hits;
+}
+
+for (const rel of ARCHIVE_DOCS) {
+  Deno.test(`archived doc ${rel} has no private-repo reference (#3455)`, async () => {
+    const path = fromFileUrl(new URL(rel, import.meta.url));
+    const source = await Deno.readTextFile(path);
+    const hits = findPrivateRepoRefs(source);
+    assertEquals(
+      hits,
+      [],
+      `${rel} references a private stSoftwareAU repository on line(s) ` +
+        `${hits.join(", ")}. Reword to concept level (e.g. "the downstream ` +
+        `production repo") so the archived doc stays verifiable by public ` +
+        `readers.`,
+    );
+  });
+}
+
+Deno.test("findPrivateRepoRefs flags a bare GRQ# issue slug", () => {
+  const src = [
+    "Intro line.",
+    "reducing popSize (GRQ#3472 keeps population = 20).",
+    "Closing line.",
+  ].join("\n");
+  assertEquals(findPrivateRepoRefs(src), [2]);
+});
+
+Deno.test("findPrivateRepoRefs flags an org-qualified GRQ# slug", () => {
+  const src = "handed to the repo (stSoftwareAU/GRQ#3472) with the tool.\n";
+  assertEquals(findPrivateRepoRefs(src), [1]);
+});
+
+Deno.test("findPrivateRepoRefs flags a VibeCoding# slug", () => {
+  const src = "tracked separately as stSoftwareAU/VibeCoding#3532 upstream.\n";
+  assertEquals(findPrivateRepoRefs(src), [1]);
+});
+
+Deno.test("findPrivateRepoRefs flags an org-qualified private repo name", () => {
+  const src = "Statistics parsed from stSoftwareAU/GRQ-cluster network.json.\n";
+  assertEquals(findPrivateRepoRefs(src), [1]);
+});
+
+Deno.test("findPrivateRepoRefs flags a private-repo blob URL", () => {
+  const src =
+    "([network.json](https://github.com/stSoftwareAU/GRQ-cluster/blob/main/network.json))\n";
+  assertEquals(findPrivateRepoRefs(src), [1]);
+});
+
+Deno.test("findPrivateRepoRefs ignores bare host/log/preset mnemonics", () => {
+  const src = [
+    "On GRQ-21 the 4373 MB V8 limit was misread.",
+    "The production-scale grq-3397 topology (seed 3396).",
+    "The downstream GRQ-side defences become defence-in-depth.",
+    "GRQ-3-rocket.log signature (output-0 self-loops).",
+  ].join("\n");
+  assertEquals(findPrivateRepoRefs(src), []);
+});
+
+Deno.test("findPrivateRepoRefs ignores the public NEAT-AI repo", () => {
+  const src =
+    "See https://github.com/stSoftwareAU/NEAT-AI/issues/2575 for context.\n";
+  assertEquals(findPrivateRepoRefs(src), []);
+});
+
+Deno.test("findPrivateRepoRefs returns empty for concept-level prose", () => {
+  const src = [
+    "A cross-repo issue was raised in the downstream production repo.",
+    "The orchestration repo's tracking issue carries the worker fix.",
+  ].join("\n");
+  assertEquals(findPrivateRepoRefs(src), []);
+});
+
+Deno.test("findPrivateRepoRefs returns empty for empty input", () => {
+  assertEquals(findPrivateRepoRefs(""), []);
+});

--- a/test/docs/ArchiveDocsNoPrivateRepoSlugs.ts
+++ b/test/docs/ArchiveDocsNoPrivateRepoSlugs.ts
@@ -1,0 +1,128 @@
+/**
+ * Issue #3455 — archived documentation must stay self-contained for public
+ * readers.
+ *
+ * A public repository is fully self-contained for the public. Archived PR
+ * summaries and investigations ship in every public clone, so a line that
+ * points at a private `stSoftwareAU` repository — an issue-tracker slug
+ * (`GRQ#3472`, `stSoftwareAU/VibeCoding#3532`) or an org-qualified repo path /
+ * blob link (`stSoftwareAU/GRQ-cluster`,
+ * `github.com/stSoftwareAU/GRQ-cluster/...`) — sends the reader to a page they
+ * cannot open. The archived narrative keeps its meaning when reworded to
+ * concept level (e.g. "the downstream production repo", "the orchestration
+ * repo's tracking issue").
+ *
+ * This test walks the real `docs/archive/` tree and fails if any Markdown file
+ * reintroduces a private-repo slug or link. It exercises behaviour (committed
+ * file content), not the source text of any function.
+ */
+
+import { assertEquals } from "@std/assert";
+import { basename, fromFileUrl } from "@std/path";
+import { walk } from "@std/fs";
+
+const ARCHIVE_DIR = fromFileUrl(new URL("../../docs/archive", import.meta.url));
+
+/**
+ * Audit-narrative PR summaries that document the private-repo-reference cleanup
+ * itself. They must embed the forbidden slugs/paths verbatim to record *what*
+ * was removed, so scanning them would be a self-referential false positive —
+ * they are the audit, not offenders. Any new summary that necessarily cites the
+ * private-repo patterns it removes belongs here.
+ */
+const AUDIT_NARRATIVE_DOCS = new Set([
+  "pr-summary-3452.md",
+  "pr-summary-3454.md",
+  "pr-summary-3455.md",
+]);
+
+/**
+ * Match a private `stSoftwareAU` issue-tracker slug (`GRQ#3472`,
+ * `VibeCoding#3532`) or an org-qualified private repo path / blob link
+ * (`stSoftwareAU/GRQ-cluster`, `github.com/stSoftwareAU/GRQ-cluster/...`).
+ */
+const PRIVATE_REPO_PATTERN =
+  /GRQ#\d+|VibeCoding#\d+|stSoftwareAU\/GRQ-cluster|github\.com\/stSoftwareAU\/(?:GRQ|VibeCoding)/;
+
+/**
+ * Return every 1-indexed line number carrying a private-repo issue slug or
+ * org-qualified repo path/link.
+ *
+ * @param source raw Markdown source
+ * @returns 1-indexed line numbers with a private-repo reference
+ */
+export function findPrivateRepoRefs(source: string): number[] {
+  const hits: number[] = [];
+  const lines = source.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    if (PRIVATE_REPO_PATTERN.test(lines[i])) {
+      hits.push(i + 1);
+    }
+  }
+  return hits;
+}
+
+Deno.test("no private stSoftwareAU repo slugs or links in docs/archive (#3455)", async () => {
+  const offenders: string[] = [];
+  for await (
+    const entry of walk(ARCHIVE_DIR, { exts: [".md"], includeDirs: false })
+  ) {
+    if (AUDIT_NARRATIVE_DOCS.has(basename(entry.path))) continue;
+    const source = await Deno.readTextFile(entry.path);
+    const hits = findPrivateRepoRefs(source);
+    if (hits.length > 0) {
+      offenders.push(`${entry.path}:${hits.join(",")}`);
+    }
+  }
+  assertEquals(
+    offenders,
+    [],
+    `Found private stSoftwareAU repo slugs or links in archived docs:\n` +
+      `${offenders.join("\n")}\n` +
+      `Reword to concept level (e.g. "the downstream production repo") so the ` +
+      `archive stays verifiable by public readers.`,
+  );
+});
+
+Deno.test("findPrivateRepoRefs flags a bare GRQ# issue slug", () => {
+  const src = [
+    "Intro line.",
+    "reducing `popSize` (GRQ#3472 keeps population = 20).",
+    "Closing line.",
+  ].join("\n");
+  assertEquals(findPrivateRepoRefs(src), [2]);
+});
+
+Deno.test("findPrivateRepoRefs flags an org-qualified GRQ# slug", () => {
+  const src = "handed to GRQ (stSoftwareAU/GRQ#3472) with the reusable tool.\n";
+  assertEquals(findPrivateRepoRefs(src), [1]);
+});
+
+Deno.test("findPrivateRepoRefs flags a VibeCoding# slug", () => {
+  const src = "tracked separately as `stSoftwareAU/VibeCoding#3532`.\n";
+  assertEquals(findPrivateRepoRefs(src), [1]);
+});
+
+Deno.test("findPrivateRepoRefs flags an org-qualified GRQ-cluster path", () => {
+  const src = "statistics derived from `stSoftwareAU/GRQ-cluster`.\n";
+  assertEquals(findPrivateRepoRefs(src), [1]);
+});
+
+Deno.test("findPrivateRepoRefs flags a GRQ-cluster blob link", () => {
+  const src =
+    "([net](https://github.com/stSoftwareAU/GRQ-cluster/blob/main/network.json))\n";
+  assertEquals(findPrivateRepoRefs(src), [1]);
+});
+
+Deno.test("findPrivateRepoRefs returns empty for concept-level prose", () => {
+  const src = [
+    "The production `network.json` snapshot is far larger than the docs claimed.",
+    "A cross-repo issue in the downstream production repo carries the action.",
+    "The GRQ-23 host snapshot and GRQ-cluster mnemonics stay as narrative.",
+  ].join("\n");
+  assertEquals(findPrivateRepoRefs(src), []);
+});
+
+Deno.test("findPrivateRepoRefs returns empty for empty input", () => {
+  assertEquals(findPrivateRepoRefs(""), []);
+});

--- a/test/docs/ArchivedDocsNoPrivateRepoReference.ts
+++ b/test/docs/ArchivedDocsNoPrivateRepoReference.ts
@@ -1,0 +1,127 @@
+/**
+ * Issue #3455 — archived documentation must stay self-contained for public
+ * readers and must not name or link the private `stSoftwareAU` repositories
+ * `GRQ`, `GRQ-cluster`, `GRQ-logs` or `VibeCoding`.
+ *
+ * A public repository is fully self-contained for the public. Archived PR
+ * summaries and investigations ship in every public clone, so a `GRQ#NNNN` /
+ * `VibeCoding#NNNN` issue-tracker slug, an `stSoftwareAU/<private-repo>` slug,
+ * or a `github.com/stSoftwareAU/<private-repo>` link points a public reader at
+ * an issue or file they cannot open. The archived narrative keeps its meaning
+ * when reworded to concept level.
+ *
+ * This test reads the real archived docs named in the audit and fails if any
+ * reintroduces a private-repo issue slug, org-qualified slug or link. It
+ * exercises behaviour (committed doc content), not the source text of any
+ * function. The public `stSoftwareAU/NEAT-AI` repository is deliberately not
+ * matched, and bare `GRQ-cluster` production mnemonics (no `#`, no
+ * `stSoftwareAU/` prefix) are out of scope per the #3454 convention.
+ */
+
+import { assertEquals } from "@std/assert";
+import { fromFileUrl } from "@std/path";
+
+/** Archived docs named in the #3455 private-repo-reference audit. */
+const ARCHIVED_DOCS = [
+  "../../docs/archive/pr-summaries/pr-summary-3018.md",
+  "../../docs/archive/pr-summaries/pr-summary-3400.md",
+  "../../docs/archive/pr-summaries/pr-summary-3410.md",
+  "../../docs/archive/pr-summaries/pr-summary-3412.md",
+  "../../docs/archive/pr-summaries/pr-summary-3417.md",
+  "../../docs/archive/investigations/issue-2515-forward-only-apply-audit.md",
+];
+
+/**
+ * Match a private `stSoftwareAU` repository reference:
+ *   - an issue-tracker slug (`GRQ#3472`, `VibeCoding#3532`),
+ *   - an org-qualified slug or link (`stSoftwareAU/GRQ-cluster`,
+ *     `github.com/stSoftwareAU/VibeCoding/...`).
+ *
+ * Case-sensitive on the upper-case repo tokens so the lower-case in-tree
+ * `grq-3397` scale-preset fixture is never a false positive. The public
+ * `NEAT-AI` repository is intentionally absent from the alternation.
+ */
+const PRIVATE_REPO_PATTERN =
+  /(?:GRQ|VibeCoding)#\d+|stSoftwareAU\/(?:GRQ-cluster|GRQ-logs|GRQ|VibeCoding)/;
+
+/**
+ * Return every 1-indexed line number carrying a private `stSoftwareAU`
+ * repository issue slug, org-qualified slug or link.
+ *
+ * @param source raw Markdown source
+ * @returns 1-indexed line numbers with a private-repo reference
+ */
+export function findPrivateRepoReferences(source: string): number[] {
+  const hits: number[] = [];
+  const lines = source.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    if (PRIVATE_REPO_PATTERN.test(lines[i])) {
+      hits.push(i + 1);
+    }
+  }
+  return hits;
+}
+
+for (const rel of ARCHIVED_DOCS) {
+  Deno.test(`archived doc ${rel} has no private repo reference (#3455)`, async () => {
+    const path = fromFileUrl(new URL(rel, import.meta.url));
+    const source = await Deno.readTextFile(path);
+    const hits = findPrivateRepoReferences(source);
+    assertEquals(
+      hits,
+      [],
+      `${rel} references a private stSoftwareAU repository on line(s) ` +
+        `${hits.join(", ")}. Reword to concept level so the archived doc ` +
+        `stays verifiable by public readers.`,
+    );
+  });
+}
+
+Deno.test("findPrivateRepoReferences flags a GRQ issue slug", () => {
+  const src = [
+    "Intro line.",
+    "handed to the production repo (stSoftwareAU/GRQ#3472) with the tool.",
+    "Closing line.",
+  ].join("\n");
+  assertEquals(findPrivateRepoReferences(src), [2]);
+});
+
+Deno.test("findPrivateRepoReferences flags a bare GRQ# slug", () => {
+  const src = "reducing popSize (GRQ#3472 keeps population = 20).\n";
+  assertEquals(findPrivateRepoReferences(src), [1]);
+});
+
+Deno.test("findPrivateRepoReferences flags a VibeCoding# slug", () => {
+  const src = "tracked separately as stSoftwareAU/VibeCoding#3532 upstream.\n";
+  assertEquals(findPrivateRepoReferences(src), [1]);
+});
+
+Deno.test("findPrivateRepoReferences flags a private-repo blob link", () => {
+  const src =
+    "see https://github.com/stSoftwareAU/GRQ-cluster/blob/main/network.json here.\n";
+  assertEquals(findPrivateRepoReferences(src), [1]);
+});
+
+Deno.test("findPrivateRepoReferences ignores the public NEAT-AI repo", () => {
+  const src =
+    "Filed at https://github.com/stSoftwareAU/NEAT-AI/issues/2575 (public).\n";
+  assertEquals(findPrivateRepoReferences(src), []);
+});
+
+Deno.test("findPrivateRepoReferences ignores the lower-case grq-3397 fixture", () => {
+  const src =
+    "The synthetic `grq-3397` scale preset reproduces the dimensions.\n";
+  assertEquals(findPrivateRepoReferences(src), []);
+});
+
+Deno.test("findPrivateRepoReferences returns empty for concept-level prose", () => {
+  const src = [
+    "A cross-repo issue in the downstream production repo carries the action.",
+    "The production `network.json` snapshot is far larger than the old claim.",
+  ].join("\n");
+  assertEquals(findPrivateRepoReferences(src), []);
+});
+
+Deno.test("findPrivateRepoReferences returns empty for empty input", () => {
+  assertEquals(findPrivateRepoReferences(""), []);
+});

--- a/test/docs/NoPrivateGrqIssueSlugs.ts
+++ b/test/docs/NoPrivateGrqIssueSlugs.ts
@@ -33,6 +33,8 @@ const DETECTOR_TESTS = new Set(
     new URL("./LiveDocsNoPrivateGrqReference.ts", import.meta.url).href,
     new URL("./CrossSpeciesBaselineNoPrivateRepo.ts", import.meta.url).href,
     new URL("./ArchiveDocsNoPrivateRepoSlugs.ts", import.meta.url).href,
+    new URL("./ArchiveDocsNoPrivateRepoReference.ts", import.meta.url).href,
+    new URL("./ArchivedDocsNoPrivateRepoReference.ts", import.meta.url).href,
   ].map(fromFileUrl),
 );
 

--- a/test/docs/NoPrivateGrqIssueSlugs.ts
+++ b/test/docs/NoPrivateGrqIssueSlugs.ts
@@ -32,6 +32,7 @@ const DETECTOR_TESTS = new Set(
     import.meta.url,
     new URL("./LiveDocsNoPrivateGrqReference.ts", import.meta.url).href,
     new URL("./CrossSpeciesBaselineNoPrivateRepo.ts", import.meta.url).href,
+    new URL("./ArchiveDocsNoPrivateRepoSlugs.ts", import.meta.url).href,
   ].map(fromFileUrl),
 );
 


### PR DESCRIPTION
# Reword private-repo references in archived PR summaries and investigations

## Summary

Archived documentation directly named or linked the **private** `stSoftwareAU`
repositories `GRQ`, `GRQ-cluster` and `VibeCoding` — via a `GRQ-cluster`
`network.json` blob link, issue-tracker slugs (`GRQ#3472`,
`stSoftwareAU/GRQ#3508`, `stSoftwareAU/GRQ#3518`,
`stSoftwareAU/VibeCoding#3532`, `stSoftwareAU/GRQ#2109`), and org-qualified repo
names. A public repository must be fully self-contained: those links 404 for
public readers and the slugs point at issues they cannot open. Each reference is
reworded to concept level — "the downstream production repo", "the orchestration
repo's tracking issue", "the production `network.json` snapshot" — so the
archived narrative keeps its meaning without pointing at private targets. Closes
#3455.

Bare host/log/preset **mnemonics** (`GRQ-21`, `grq-3397`, `GRQ-side`,
`GRQ-3-rocket.log`) are intentionally kept — they name a concept, not a private
target, consistent with the #3454 decision. The public `stSoftwareAU/NEAT-AI`
issue link in the investigation doc is untouched.

Files reworded:

- `docs/archive/pr-summaries/pr-summary-3018.md` — dropped the `GRQ-cluster`
  `network.json` blob link and the `stSoftwareAU/GRQ-cluster` slug in favour of
  "the production `network.json` snapshot".
- `docs/archive/pr-summaries/pr-summary-3400.md` — three `stSoftwareAU/GRQ#3472`
  slugs and the surrounding `GRQ` repo pointers → "the downstream production
  repo".
- `docs/archive/pr-summaries/pr-summary-3410.md` — `GRQ#3472` and
  `stSoftwareAU/GRQ#3508` → concept-level downstream-repo wording.
- `docs/archive/pr-summaries/pr-summary-3412.md` — `stSoftwareAU/GRQ#3518` → "a
  cross-repo issue in the downstream production repo".
- `docs/archive/pr-summaries/pr-summary-3417.md` —
  `stSoftwareAU/VibeCoding#3532` (plus the same-class `VibeCoding#1613` /
  `VibeCoding#3532` slugs on nearby lines) → "the orchestration repo's tracking
  issue" / "the orchestration repo's dependency-bump contract".
- `docs/archive/investigations/issue-2515-forward-only-apply-audit.md` —
  `stSoftwareAU/GRQ#2109` → "a cross-repo issue in the downstream production
  repo".

## Evidence

Documentation-only change plus a guard test — no web interface to screenshot and
no runtime behaviour to benchmark. Verification is the new guard test and the
existing docs quality gates.

```mermaid
flowchart LR
    A["Archived doc names/links<br/>private GRQ / GRQ-cluster / VibeCoding"]
      --> B["Reword to concept level<br/>(downstream production repo)"]
    B --> C["ArchiveDocsNoPrivateRepoReference<br/>guard: 0 private-repo refs"]
    C --> D["Public reader: self-contained,<br/>no 404s"]
```

- The new guard `findPrivateRepoRefs` reports zero hits across all six reworded
  docs; it flags issue slugs (`GRQ#\d+`, `VibeCoding#\d+`), org-qualified
  private repo names, and private-repo links, while ignoring bare mnemonics and
  the public `stSoftwareAU/NEAT-AI` repo.
- `deno fmt --check`, `deno lint`, and `deno check` pass on the changed files.

## Test Plan

- Added `test/docs/ArchiveDocsNoPrivateRepoReference.ts`:
  - Six per-doc guards asserting each reworded archive file has no private-repo
    reference.
  - `findPrivateRepoRefs` unit cases — flags a bare `GRQ#` slug, an
    org-qualified `GRQ#` slug, a `VibeCoding#` slug, an org-qualified private
    repo name, and a private-repo blob URL; returns empty for bare mnemonics,
    the public `NEAT-AI` repo, concept-level prose, and empty input.
- Registered the new file in the `DETECTOR_TESTS` carve-out of
  `test/docs/NoPrivateGrqIssueSlugs.ts` so its literal `GRQ#`/`stSoftwareAU/GRQ`
  fixtures are not treated as offenders.
- `deno test --allow-read test/docs/*.ts` — 136 passed, 0 failed.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-ms0vdotz-327cb9`<!-- vibe-worker-issue-3455 -->