### PR TITLE
Reword incidental GRQ-cluster file mentions to concept level (Issue #3456)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,16 +26,17 @@ adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - **Issue #3422:** Every `evolve*` result now carries a run-level `statistics`
-  block for throughput tuning, so GRQ-cluster's `result.json` is self-contained
-  enough to compare configurations across the fleet. It records the configured
-  `populationSize` (plus the final actual size when adaptive population sizing
-  is enabled), host `hardware` descriptors (CPU cores, total memory, host id), a
-  JSON-safe echo of the caller's `requestedOptions` (see the #3427 note under
-  Changed for how non-serialisable options are handled), and an `improvement`
-  milestone summary — the generation / elapsed time / creatures scored at which
-  the run reached 25/50/75/90% of its total score improvement (no per-generation
-  series). New public type exports: `EvolveRunStatistics`, `HardwareDescriptor`,
-  `OptionsEcho`, `ImprovementSummary`, `ImprovementMilestone`.
+  block for throughput tuning, so the production cluster's `result.json` is
+  self-contained enough to compare configurations across the fleet. It records
+  the configured `populationSize` (plus the final actual size when adaptive
+  population sizing is enabled), host `hardware` descriptors (CPU cores, total
+  memory, host id), a JSON-safe echo of the caller's `requestedOptions` (see the
+  #3427 note under Changed for how non-serialisable options are handled), and an
+  `improvement` milestone summary — the generation / elapsed time / creatures
+  scored at which the run reached 25/50/75/90% of its total score improvement
+  (no per-generation series). New public type exports: `EvolveRunStatistics`,
+  `HardwareDescriptor`, `OptionsEcho`, `ImprovementSummary`,
+  `ImprovementMilestone`.
 - **Issue #3412:** New `DatasetError` typed error (exported from the public
   barrel) makes a vanished training dataset fail loud and clear. When the
   dataset directory or a `.bin` file is deleted out from under a running
@@ -91,7 +92,7 @@ adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).
 - **Issue #3427:** The `requestedOptions` echo (Issue #3422) no longer records
   non-serialisable options with a `"[function]"` / `"[unserialisable]"` marker —
   such entries are now dropped entirely, since the markers carry no tuning value
-  and are pure noise in every GRQ-cluster snapshot. The one exception is
+  and are pure noise in every production-cluster snapshot. The one exception is
   `creatures`: instead of dropping the seed-creature array it is echoed as its
   **count** (a number, e.g. `"creatures": 12`; an empty seed array echoes as
   `0`), because seed size can matter when comparing runs. The

--- a/bench/ProductionLearnSamplerProfile.ts
+++ b/bench/ProductionLearnSamplerProfile.ts
@@ -3,7 +3,7 @@
  *
  * Profiles exactly what `worker/learn.sh` (one `src/Learn.ts` run,
  * populationSize=20) and `worker/sampler.sh` (5 `Learn.ts` loops) drive, on
- * the GRQ-cluster production topology captured in the production `network.json`:
+ * the production cluster's topology captured in the production `network.json`:
  *
  *   1,666 neurons, ~21,513 synapses, 2,461 inputs
  *
@@ -36,7 +36,7 @@ import {
 } from "../test/propagate/large/ProductionScaleCreature.ts";
 
 // ──────────────────────────────────────────────────────────────────
-// Production topology from the GRQ-cluster `network.json` (Issue #3397)
+// Production topology from the production cluster's `network.json` (Issue #3397)
 // ──────────────────────────────────────────────────────────────────
 
 /** Inputs of the production model. */

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.9.38",
+  "version": "5.9.39",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-3456.md
+++ b/docs/archive/pr-summaries/pr-summary-3456.md
@@ -6,32 +6,32 @@ concept-level wording, so this public repository stays self-contained for public
 readers (check 3 of the `private-repo-reference` audit). No behaviour, fixtures,
 or public API changed — the change is comment/documentation only. Closes #3456.
 
-The private-repo name `GRQ-cluster` is replaced with "the production cluster's …"
-/ "production-cluster …" throughout the flagged comments, while the **functional**
-scale-preset string literals (`"grq-cluster"`, `"grq-3397"`) are deliberately
-left untouched — they are API values validated by `--scale` parsing and by
-`SCALE_CONFIGS`, and renaming them would be a behaviour change the issue
+The private-repo name `GRQ-cluster` is replaced with "the production cluster's
+…" / "production-cluster …" throughout the flagged comments, while the
+**functional** scale-preset string literals (`"grq-cluster"`, `"grq-3397"`) are
+deliberately left untouched — they are API values validated by `--scale` parsing
+and by `SCALE_CONFIGS`, and renaming them would be a behaviour change the issue
 explicitly excludes.
 
 ### Files reworded
 
-| File | What changed |
-| --- | --- |
-| `bench/ProductionLearnSamplerProfile.ts` | Header + section comment: "GRQ-cluster production topology" → "production cluster's topology". |
-| `src/creature/ScorerUtilisationTotals.ts` | Doc comment: "in the GRQ-cluster `result.json`" → "in the production cluster's `result.json`". |
-| `test/architecture/FitnessBatchPathUsed.ts` | Doc comment: same `result.json` reword. |
-| `test/bench/ProductionScaleEvolveDirProfile.ts` | Comments, test name, and assert messages: "GRQ-cluster" → "production-cluster". Preset literal `scale: "grq-cluster"` kept. |
-| `test/propagate/large/ProductionScaleCreature.ts` | Preset doc comments: "GRQ production" / "GRQ-cluster production `network.json`" → "production-cluster" / "production cluster's `network.json`". Literals kept. |
-| `test/breed/SyntheticLocationE2E.ts` | Doc comment: "GRQ-cluster `network.json`" → "production cluster's `network.json`". |
-| `test/breed/fixtures/synthetic-alignment/README.md` | Provenance note: same `network.json` reword. |
-| `CHANGELOG.md` | Unreleased entries (#3422, #3427): "GRQ-cluster" → "production cluster". |
+| File                                                | What changed                                                                                                                                                   |
+| --------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `bench/ProductionLearnSamplerProfile.ts`            | Header + section comment: "GRQ-cluster production topology" → "production cluster's topology".                                                                 |
+| `src/creature/ScorerUtilisationTotals.ts`           | Doc comment: "in the GRQ-cluster `result.json`" → "in the production cluster's `result.json`".                                                                 |
+| `test/architecture/FitnessBatchPathUsed.ts`         | Doc comment: same `result.json` reword.                                                                                                                        |
+| `test/bench/ProductionScaleEvolveDirProfile.ts`     | Comments, test name, and assert messages: "GRQ-cluster" → "production-cluster". Preset literal `scale: "grq-cluster"` kept.                                    |
+| `test/propagate/large/ProductionScaleCreature.ts`   | Preset doc comments: "GRQ production" / "GRQ-cluster production `network.json`" → "production-cluster" / "production cluster's `network.json`". Literals kept. |
+| `test/breed/SyntheticLocationE2E.ts`                | Doc comment: "GRQ-cluster `network.json`" → "production cluster's `network.json`".                                                                             |
+| `test/breed/fixtures/synthetic-alignment/README.md` | Provenance note: same `network.json` reword.                                                                                                                   |
+| `CHANGELOG.md`                                      | Unreleased entries (#3422, #3427): "GRQ-cluster" → "production cluster".                                                                                       |
 
 ### Out of scope (intentionally left)
 
 - Functional preset identifiers `"grq-cluster"` / `"grq-3397"` and the `--scale`
-  values in `bench/score_per_hour_harness.ts` / `bench/evolution_config_sweep.ts`
-  — these are code, not incidental name mentions; changing them is a behaviour
-  change the issue excludes.
+  values in `bench/score_per_hour_harness.ts` /
+  `bench/evolution_config_sweep.ts` — these are code, not incidental name
+  mentions; changing them is a behaviour change the issue excludes.
 - Unrelated `GRQ` mentions not enumerated by finding `BP-016c5410cfce` (e.g. the
   `GRQ-teams` name and `GRQ`-as-fleet mentions in `CHANGELOG.md:193,286`). These
   are a different name/class from `GRQ-cluster` and are left for their own

--- a/docs/archive/pr-summaries/pr-summary-3456.md
+++ b/docs/archive/pr-summaries/pr-summary-3456.md
@@ -1,0 +1,68 @@
+## Summary
+
+Reworded incidental code-comment and fixture-README mentions of the **private**
+`GRQ-cluster` repository (and its `network.json` / `result.json` files) to
+concept-level wording, so this public repository stays self-contained for public
+readers (check 3 of the `private-repo-reference` audit). No behaviour, fixtures,
+or public API changed — the change is comment/documentation only. Closes #3456.
+
+The private-repo name `GRQ-cluster` is replaced with "the production cluster's …"
+/ "production-cluster …" throughout the flagged comments, while the **functional**
+scale-preset string literals (`"grq-cluster"`, `"grq-3397"`) are deliberately
+left untouched — they are API values validated by `--scale` parsing and by
+`SCALE_CONFIGS`, and renaming them would be a behaviour change the issue
+explicitly excludes.
+
+### Files reworded
+
+| File | What changed |
+| --- | --- |
+| `bench/ProductionLearnSamplerProfile.ts` | Header + section comment: "GRQ-cluster production topology" → "production cluster's topology". |
+| `src/creature/ScorerUtilisationTotals.ts` | Doc comment: "in the GRQ-cluster `result.json`" → "in the production cluster's `result.json`". |
+| `test/architecture/FitnessBatchPathUsed.ts` | Doc comment: same `result.json` reword. |
+| `test/bench/ProductionScaleEvolveDirProfile.ts` | Comments, test name, and assert messages: "GRQ-cluster" → "production-cluster". Preset literal `scale: "grq-cluster"` kept. |
+| `test/propagate/large/ProductionScaleCreature.ts` | Preset doc comments: "GRQ production" / "GRQ-cluster production `network.json`" → "production-cluster" / "production cluster's `network.json`". Literals kept. |
+| `test/breed/SyntheticLocationE2E.ts` | Doc comment: "GRQ-cluster `network.json`" → "production cluster's `network.json`". |
+| `test/breed/fixtures/synthetic-alignment/README.md` | Provenance note: same `network.json` reword. |
+| `CHANGELOG.md` | Unreleased entries (#3422, #3427): "GRQ-cluster" → "production cluster". |
+
+### Out of scope (intentionally left)
+
+- Functional preset identifiers `"grq-cluster"` / `"grq-3397"` and the `--scale`
+  values in `bench/score_per_hour_harness.ts` / `bench/evolution_config_sweep.ts`
+  — these are code, not incidental name mentions; changing them is a behaviour
+  change the issue excludes.
+- Unrelated `GRQ` mentions not enumerated by finding `BP-016c5410cfce` (e.g. the
+  `GRQ-teams` name and `GRQ`-as-fleet mentions in `CHANGELOG.md:193,286`). These
+  are a different name/class from `GRQ-cluster` and are left for their own
+  finding to avoid scope creep.
+
+## Evidence
+
+Backend/comment-only change — no web interface to screenshot. Verification is
+the full quality gate:
+
+- `./quality.sh < /dev/null` → **exit 0**, `7889 passed | 0 failed | 4 ignored`.
+- `grep -n "GRQ-cluster" <touched files>` → no matches (the private-repo name is
+  gone from every flagged location; only functional `"grq-cluster"` literals
+  remain).
+
+```mermaid
+flowchart LR
+    A["Comment names private<br/>GRQ-cluster network.json / result.json"] -->|reword| B["Concept-level:<br/>production cluster's network.json / result.json"]
+    B --> C["Public repo self-contained<br/>(no dangling private-repo pointer)"]
+```
+
+## Test Plan
+
+No unit tests were added. This is a pure comment/documentation reword with **no
+behavioural surface** to assert on, and the project's testing policy
+(`AGENTS.md` → "How tests to avoid") explicitly forbids tests that grep source
+files for patterns or inspect comment content — such a test would be a forbidden
+"how" test that breaks on any refactor. Correctness is instead guaranteed by the
+existing suite continuing to pass unchanged:
+
+- Full `./quality.sh` run: `7889 passed | 0 failed` — including
+  `test/bench/ProductionScaleEvolveDirProfile.ts` (whose renamed test still
+  drives real creature generation and asserts on dimensions) and
+  `test/breed/SyntheticLocationE2E.ts`.

--- a/src/creature/ScorerUtilisationTotals.ts
+++ b/src/creature/ScorerUtilisationTotals.ts
@@ -9,7 +9,7 @@
  * and every creature quietly fell back to the slow worker path looked
  * identical to a healthy run. These aggregates split that count by backend and
  * add an explicit batch-fallback tally so the split is visible in the run
- * result (and therefore in the GRQ-cluster `result.json`).
+ * result (and therefore in the production cluster's `result.json`).
  *
  * All values are raw counts summed across every generation of the run.
  */

--- a/test/architecture/FitnessBatchPathUsed.ts
+++ b/test/architecture/FitnessBatchPathUsed.ts
@@ -9,7 +9,7 @@
  * all-`forwardOnly` population through several generations, accumulating each
  * generation's per-backend counts into the run-level
  * {@link ScorerUtilisationTotals} — the exact telemetry surfaced on the
- * `evolve*` result and in the GRQ-cluster `result.json`.
+ * `evolve*` result and in the production cluster's `result.json`.
  *
  * It fails if the batch path silently stops being used (regression to
  * per-creature scoring): `batchScorerInvocations` would drop below the

--- a/test/bench/ProductionScaleEvolveDirProfile.ts
+++ b/test/bench/ProductionScaleEvolveDirProfile.ts
@@ -2,7 +2,7 @@
  * Issue #2307 — Tests for production-scale creature generation.
  *
  * Validates that the `generateProductionCreature` helper produces a
- * creature with the expected GRQ-cluster dimensions. This test is
+ * creature with the expected production-cluster dimensions. This test is
  * purely structural (no WASM activation, no evolution) and runs fast.
  *
  * Phase timing field tests (fitnessMs, breedingMs, etc.) are covered
@@ -18,13 +18,13 @@ import {
   generateProductionCreature,
 } from "../../test/propagate/large/ProductionScaleCreature.ts";
 
-Deno.test("Production-scale creature has GRQ-cluster dimensions", () => {
+Deno.test("Production-scale creature has production-cluster dimensions", () => {
   const rng = createSeededRng(2307);
   const creature = generateProductionCreature(648, 2, rng, {
     scale: "grq-cluster",
   });
 
-  // GRQ-cluster target: ~1,500 neurons, ~20,000 synapses
+  // Production-cluster target: ~1,500 neurons, ~20,000 synapses
   assertGreater(
     creature.neurons.length,
     1_300,
@@ -35,12 +35,20 @@ Deno.test("Production-scale creature has GRQ-cluster dimensions", () => {
     15_000,
     "Should have at least 15,000 synapses for production scale",
   );
-  assertEquals(creature.input, 648, "Input count should match GRQ-cluster");
-  assertEquals(creature.output, 2, "Output count should match GRQ-cluster");
+  assertEquals(
+    creature.input,
+    648,
+    "Input count should match production-cluster scale",
+  );
+  assertEquals(
+    creature.output,
+    2,
+    "Output count should match production-cluster scale",
+  );
 });
 
 Deno.test("Production learn/sampler creature matches network.json dimensions (grq-3397)", () => {
-  // Issue #3397: the `grq-3397` preset reproduces the GRQ-cluster production
+  // Issue #3397: the `grq-3397` preset reproduces the production cluster's
   // `network.json` topology used by worker/learn.sh — 1,666 neurons,
   // ~21,513 synapses, 2,461 inputs — so the profiling report's command is
   // reproducible against the real production dimensions.

--- a/test/breed/SyntheticLocationE2E.ts
+++ b/test/breed/SyntheticLocationE2E.ts
@@ -3,7 +3,7 @@
  * `createCompatibleFatherFromCreatures` by Issue #2614.
  *
  * Loads two production-shape, genetically incompatible parent fixtures
- * (mother modelled on the GRQ-cluster `network.json`, father modelled on the
+ * (mother modelled on the production cluster's `network.json`, father modelled on the
  * GRQ-teams Europa creature) and proves that:
  *
  *  1. Real-UUID overlap is below the configured `syntheticAlignmentThreshold`.

--- a/test/breed/fixtures/synthetic-alignment/README.md
+++ b/test/breed/fixtures/synthetic-alignment/README.md
@@ -10,9 +10,9 @@ the end-to-end regression for the synthetic-UUID alignment fallback wired into
 The fixtures are inspired by the production cross-island breed problem first
 reported in Issue #2609:
 
-- `parent-mother.json` — modelled on the GRQ-cluster `network.json` shape
-  (cascading layered topology, fan-in to a deep hidden neuron, a shortcut hidden
-  neuron from `input-0` directly to `output-1`).
+- `parent-mother.json` — modelled on the production cluster's `network.json`
+  shape (cascading layered topology, fan-in to a deep hidden neuron, a shortcut
+  hidden neuron from `input-0` directly to `output-1`).
 - `parent-father.json` — modelled on the GRQ-teams Europa creature shape (same
   overall layered topology, deliberately disjoint hidden-neuron real UUIDs).
 

--- a/test/propagate/large/ProductionScaleCreature.ts
+++ b/test/propagate/large/ProductionScaleCreature.ts
@@ -47,10 +47,10 @@ export const AGGREGATE_SQUASHES = ["IF", "MAXIMUM", "MINIMUM"];
  * Scale presets for creature generation.
  *
  * - `"default"`: ~1,000 neurons, ~18,000 synapses (original test scale).
- * - `"grq-cluster"`: ~1,500 neurons, ~20,000 synapses (GRQ production scale,
+ * - `"grq-cluster"`: ~1,500 neurons, ~20,000 synapses (production-cluster scale,
  *   matching dimensions from `performance.csv`). Issue #2306.
  * - `"grq-3397"`: 1,666 neurons, ~21,513 synapses at 2,461 inputs — the
- *   GRQ-cluster production `network.json` topology used by `worker/learn.sh`.
+ *   production cluster's `network.json` topology used by `worker/learn.sh`.
  *   Issue #3397.
  */
 export interface CreatureScaleOptions {
@@ -81,7 +81,7 @@ const SCALE_CONFIGS: Record<string, ScaleConfig> = {
     interLayerMin: 10,
     interLayerRange: 12,
   },
-  // Issue #3397: matches the GRQ-cluster production `network.json` used by
+  // Issue #3397: matches the production cluster's `network.json` used by
   // `worker/learn.sh` — ~1,666 neurons, ~21,513 synapses, 2,461 inputs.
   // Used by the production learn/sampler profiling report so the reproducible
   // profiling command exercises the real production topology.


### PR DESCRIPTION
## Summary

Reworded incidental code-comment and fixture-README mentions of the **private**
`GRQ-cluster` repository (and its `network.json` / `result.json` files) to
concept-level wording, so this public repository stays self-contained for public
readers (check 3 of the `private-repo-reference` audit). No behaviour, fixtures,
or public API changed — the change is comment/documentation only. Closes #3456.

The private-repo name `GRQ-cluster` is replaced with "the production cluster's …"
/ "production-cluster …" throughout the flagged comments, while the **functional**
scale-preset string literals (`"grq-cluster"`, `"grq-3397"`) are deliberately
left untouched — they are API values validated by `--scale` parsing and by
`SCALE_CONFIGS`, and renaming them would be a behaviour change the issue
explicitly excludes.

### Files reworded

| File | What changed |
| --- | --- |
| `bench/ProductionLearnSamplerProfile.ts` | Header + section comment: "GRQ-cluster production topology" → "production cluster's topology". |
| `src/creature/ScorerUtilisationTotals.ts` | Doc comment: "in the GRQ-cluster `result.json`" → "in the production cluster's `result.json`". |
| `test/architecture/FitnessBatchPathUsed.ts` | Doc comment: same `result.json` reword. |
| `test/bench/ProductionScaleEvolveDirProfile.ts` | Comments, test name, and assert messages: "GRQ-cluster" → "production-cluster". Preset literal `scale: "grq-cluster"` kept. |
| `test/propagate/large/ProductionScaleCreature.ts` | Preset doc comments: "GRQ production" / "GRQ-cluster production `network.json`" → "production-cluster" / "production cluster's `network.json`". Literals kept. |
| `test/breed/SyntheticLocationE2E.ts` | Doc comment: "GRQ-cluster `network.json`" → "production cluster's `network.json`". |
| `test/breed/fixtures/synthetic-alignment/README.md` | Provenance note: same `network.json` reword. |
| `CHANGELOG.md` | Unreleased entries (#3422, #3427): "GRQ-cluster" → "production cluster". |

### Out of scope (intentionally left)

- Functional preset identifiers `"grq-cluster"` / `"grq-3397"` and the `--scale`
  values in `bench/score_per_hour_harness.ts` / `bench/evolution_config_sweep.ts`
  — these are code, not incidental name mentions; changing them is a behaviour
  change the issue excludes.
- Unrelated `GRQ` mentions not enumerated by finding `BP-016c5410cfce` (e.g. the
  `GRQ-teams` name and `GRQ`-as-fleet mentions in `CHANGELOG.md:193,286`). These
  are a different name/class from `GRQ-cluster` and are left for their own
  finding to avoid scope creep.

## Evidence

Backend/comment-only change — no web interface to screenshot. Verification is
the full quality gate:

- `./quality.sh < /dev/null` → **exit 0**, `7889 passed | 0 failed | 4 ignored`.
- `grep -n "GRQ-cluster" <touched files>` → no matches (the private-repo name is
  gone from every flagged location; only functional `"grq-cluster"` literals
  remain).

```mermaid
flowchart LR
    A["Comment names private<br/>GRQ-cluster network.json / result.json"] -->|reword| B["Concept-level:<br/>production cluster's network.json / result.json"]
    B --> C["Public repo self-contained<br/>(no dangling private-repo pointer)"]
```

## Test Plan

No unit tests were added. This is a pure comment/documentation reword with **no
behavioural surface** to assert on, and the project's testing policy
(`AGENTS.md` → "How tests to avoid") explicitly forbids tests that grep source
files for patterns or inspect comment content — such a test would be a forbidden
"how" test that breaks on any refactor. Correctness is instead guaranteed by the
existing suite continuing to pass unchanged:

- Full `./quality.sh` run: `7889 passed | 0 failed` — including
  `test/bench/ProductionScaleEvolveDirProfile.ts` (whose renamed test still
  drives real creature generation and asserts on dimensions) and
  `test/breed/SyntheticLocationE2E.ts`.



---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-ms0vdotz-327cb9`<!-- vibe-worker-issue-3456 -->