### PR TITLE
Reword incidental GRQ-cluster mentions to concept level (#3456)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,16 +26,17 @@ adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - **Issue #3422:** Every `evolve*` result now carries a run-level `statistics`
-  block for throughput tuning, so GRQ-cluster's `result.json` is self-contained
-  enough to compare configurations across the fleet. It records the configured
-  `populationSize` (plus the final actual size when adaptive population sizing
-  is enabled), host `hardware` descriptors (CPU cores, total memory, host id), a
-  JSON-safe echo of the caller's `requestedOptions` (see the #3427 note under
-  Changed for how non-serialisable options are handled), and an `improvement`
-  milestone summary — the generation / elapsed time / creatures scored at which
-  the run reached 25/50/75/90% of its total score improvement (no per-generation
-  series). New public type exports: `EvolveRunStatistics`, `HardwareDescriptor`,
-  `OptionsEcho`, `ImprovementSummary`, `ImprovementMilestone`.
+  block for throughput tuning, so the production run's `result.json` is
+  self-contained enough to compare configurations across the fleet. It records
+  the configured `populationSize` (plus the final actual size when adaptive
+  population sizing is enabled), host `hardware` descriptors (CPU cores, total
+  memory, host id), a JSON-safe echo of the caller's `requestedOptions` (see the
+  #3427 note under Changed for how non-serialisable options are handled), and an
+  `improvement` milestone summary — the generation / elapsed time / creatures
+  scored at which the run reached 25/50/75/90% of its total score improvement
+  (no per-generation series). New public type exports: `EvolveRunStatistics`,
+  `HardwareDescriptor`, `OptionsEcho`, `ImprovementSummary`,
+  `ImprovementMilestone`.
 - **Issue #3412:** New `DatasetError` typed error (exported from the public
   barrel) makes a vanished training dataset fail loud and clear. When the
   dataset directory or a `.bin` file is deleted out from under a running
@@ -91,7 +92,7 @@ adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).
 - **Issue #3427:** The `requestedOptions` echo (Issue #3422) no longer records
   non-serialisable options with a `"[function]"` / `"[unserialisable]"` marker —
   such entries are now dropped entirely, since the markers carry no tuning value
-  and are pure noise in every GRQ-cluster snapshot. The one exception is
+  and are pure noise in every production snapshot. The one exception is
   `creatures`: instead of dropping the seed-creature array it is echoed as its
   **count** (a number, e.g. `"creatures": 12`; an empty seed array echoes as
   `0`), because seed size can matter when comparing runs. The

--- a/bench/ProductionLearnSamplerProfile.ts
+++ b/bench/ProductionLearnSamplerProfile.ts
@@ -3,7 +3,7 @@
  *
  * Profiles exactly what `worker/learn.sh` (one `src/Learn.ts` run,
  * populationSize=20) and `worker/sampler.sh` (5 `Learn.ts` loops) drive, on
- * the GRQ-cluster production topology captured in the production `network.json`:
+ * the production cluster's `network.json`-scale topology:
  *
  *   1,666 neurons, ~21,513 synapses, 2,461 inputs
  *
@@ -36,7 +36,7 @@ import {
 } from "../test/propagate/large/ProductionScaleCreature.ts";
 
 // ──────────────────────────────────────────────────────────────────
-// Production topology from the GRQ-cluster `network.json` (Issue #3397)
+// Production topology at the production `network.json` scale (Issue #3397)
 // ──────────────────────────────────────────────────────────────────
 
 /** Inputs of the production model. */

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.9.38",
+  "version": "5.9.39",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-3456.md
+++ b/docs/archive/pr-summaries/pr-summary-3456.md
@@ -58,7 +58,7 @@ quality gate:
 flowchart LR
     A["Comment / README / CHANGELOG<br/>names private GRQ-cluster<br/>network.json / result.json"]
     A --> B["Reword to concept level:<br/>production cluster / production run"]
-    B --> C["Public reader no longer<br/>pointed at unseeable files"]
+    B --> C["Public reader no longer<br/>pointed at inaccessible files"]
 ```
 
 ## Test Plan

--- a/docs/archive/pr-summaries/pr-summary-3456.md
+++ b/docs/archive/pr-summaries/pr-summary-3456.md
@@ -1,0 +1,69 @@
+## Summary
+
+Reworded the incidental code-comment, fixture-README, and CHANGELOG mentions of
+the **private** `GRQ-cluster` repository to concept level, so a public reader is
+no longer pointed at files they cannot see (check 3 of the
+`private-repo-reference` audit). Only naming changed — no behaviour, no fixture,
+and no scale-preset identifier (`grq-cluster` / `grq-3397` string literals) was
+touched. Closes #3456.
+
+The private repo name plus its `network.json` / `result.json` file references
+were replaced with equivalent concept-level wording ("the production cluster's
+`network.json`-scale topology", "the production run's `result.json`", "every
+production snapshot").
+
+### Reworded locations (exactly the audit-enumerated mentions)
+
+| File                                                       | Change                                                                                                                                                           |
+| ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `bench/ProductionLearnSamplerProfile.ts` (6, 39)           | "GRQ-cluster production topology … production `network.json`" → concept level                                                                                    |
+| `src/creature/ScorerUtilisationTotals.ts` (12)             | "GRQ-cluster `result.json`" → "the production run's `result.json`"                                                                                               |
+| `test/architecture/FitnessBatchPathUsed.ts` (12)           | "GRQ-cluster `result.json`" → "the production run's `result.json`"                                                                                               |
+| `test/bench/ProductionScaleEvolveDirProfile.ts` (43)       | "GRQ-cluster production `network.json`" → "the production cluster's `network.json`-scale topology"                                                               |
+| `test/breed/SyntheticLocationE2E.ts` (6)                   | "GRQ-cluster `network.json`" → "the production cluster's `network.json` shape"                                                                                   |
+| `test/breed/fixtures/synthetic-alignment/README.md` (13)   | "GRQ-cluster `network.json` shape" → "the production cluster's `network.json` shape"                                                                             |
+| `test/propagate/large/ProductionScaleCreature.ts` (53, 84) | "GRQ-cluster production `network.json`" → "the production cluster's `network.json`-scale topology" (both copies of the same private-file reference in this file) |
+| `CHANGELOG.md` (29, 94)                                    | "GRQ-cluster's `result.json`" / "every GRQ-cluster snapshot" → "the production run's `result.json`" / "every production snapshot"                                |
+
+### Deliberately left in scope-respecting places
+
+- Lower-case code identifiers — the `scale: "grq-cluster"` / `"grq-3397"` preset
+  names, the `grq-cluster.json` fixture filename — are behaviour, not prose, and
+  are unchanged.
+- Bare cluster/host **mnemonics** that are not private-file references (e.g.
+  "GRQ-cluster dimensions/target" in
+  `test/bench/ProductionScaleEvolveDirProfile.ts`, and the `GRQ`/`GRQ logs`
+  mnemonics in `CHANGELOG.md` lines 193/286) stay as narrative, consistent with
+  the existing mnemonics carve-out. The audit did not flag these.
+- The `test/docs/*NoPrivateRepoReference*` audit tests intentionally contain the
+  `GRQ-cluster` string as detection fixtures and are untouched.
+
+## Evidence
+
+Documentation/comment-only change — no web interface to screenshot. A broad
+source-scan regression test was **not** added: it would over-reach the audit's
+precise scope (the same files legitimately retain lower-case preset identifiers
+and mnemonic references), and the repo guidelines explicitly discourage tests
+that grep source text for patterns. Correctness is covered by the existing
+quality gate:
+
+- `./quality.sh --lint-only` — format + lint clean (2210 files formatted, 1855
+  linted).
+- `./quality.sh --check-only` — `deno check` type-checks the whole tree cleanly,
+  confirming every edited comment block still compiles.
+- `deno test test/bench/ProductionScaleEvolveDirProfile.ts` — 2 passed / 0
+  failed, confirming the edited test file still runs.
+
+```mermaid
+flowchart LR
+    A["Comment / README / CHANGELOG<br/>names private GRQ-cluster<br/>network.json / result.json"]
+    A --> B["Reword to concept level:<br/>production cluster / production run"]
+    B --> C["Public reader no longer<br/>pointed at unseeable files"]
+```
+
+## Test Plan
+
+- Re-ran `test/bench/ProductionScaleEvolveDirProfile.ts` (one of the edited
+  files) — both structural tests pass.
+- `./quality.sh --lint-only` and `./quality.sh --check-only` pass cleanly with
+  the changes.

--- a/src/creature/ScorerUtilisationTotals.ts
+++ b/src/creature/ScorerUtilisationTotals.ts
@@ -9,7 +9,7 @@
  * and every creature quietly fell back to the slow worker path looked
  * identical to a healthy run. These aggregates split that count by backend and
  * add an explicit batch-fallback tally so the split is visible in the run
- * result (and therefore in the GRQ-cluster `result.json`).
+ * result (and therefore in the production run's `result.json`).
  *
  * All values are raw counts summed across every generation of the run.
  */

--- a/test/architecture/FitnessBatchPathUsed.ts
+++ b/test/architecture/FitnessBatchPathUsed.ts
@@ -9,7 +9,7 @@
  * all-`forwardOnly` population through several generations, accumulating each
  * generation's per-backend counts into the run-level
  * {@link ScorerUtilisationTotals} — the exact telemetry surfaced on the
- * `evolve*` result and in the GRQ-cluster `result.json`.
+ * `evolve*` result and in the production run's `result.json`.
  *
  * It fails if the batch path silently stops being used (regression to
  * per-creature scoring): `batchScorerInvocations` would drop below the

--- a/test/bench/ProductionScaleEvolveDirProfile.ts
+++ b/test/bench/ProductionScaleEvolveDirProfile.ts
@@ -40,8 +40,8 @@ Deno.test("Production-scale creature has GRQ-cluster dimensions", () => {
 });
 
 Deno.test("Production learn/sampler creature matches network.json dimensions (grq-3397)", () => {
-  // Issue #3397: the `grq-3397` preset reproduces the GRQ-cluster production
-  // `network.json` topology used by worker/learn.sh — 1,666 neurons,
+  // Issue #3397: the `grq-3397` preset reproduces the production cluster's
+  // `network.json`-scale topology used by worker/learn.sh — 1,666 neurons,
   // ~21,513 synapses, 2,461 inputs — so the profiling report's command is
   // reproducible against the real production dimensions.
   const rng = createSeededRng(3396);

--- a/test/breed/SyntheticLocationE2E.ts
+++ b/test/breed/SyntheticLocationE2E.ts
@@ -3,7 +3,7 @@
  * `createCompatibleFatherFromCreatures` by Issue #2614.
  *
  * Loads two production-shape, genetically incompatible parent fixtures
- * (mother modelled on the GRQ-cluster `network.json`, father modelled on the
+ * (mother modelled on the production cluster's `network.json` shape, father modelled on the
  * GRQ-teams Europa creature) and proves that:
  *
  *  1. Real-UUID overlap is below the configured `syntheticAlignmentThreshold`.

--- a/test/breed/fixtures/synthetic-alignment/README.md
+++ b/test/breed/fixtures/synthetic-alignment/README.md
@@ -10,9 +10,9 @@ the end-to-end regression for the synthetic-UUID alignment fallback wired into
 The fixtures are inspired by the production cross-island breed problem first
 reported in Issue #2609:
 
-- `parent-mother.json` — modelled on the GRQ-cluster `network.json` shape
-  (cascading layered topology, fan-in to a deep hidden neuron, a shortcut hidden
-  neuron from `input-0` directly to `output-1`).
+- `parent-mother.json` — modelled on the production cluster's `network.json`
+  shape (cascading layered topology, fan-in to a deep hidden neuron, a shortcut
+  hidden neuron from `input-0` directly to `output-1`).
 - `parent-father.json` — modelled on the GRQ-teams Europa creature shape (same
   overall layered topology, deliberately disjoint hidden-neuron real UUIDs).
 

--- a/test/propagate/large/ProductionScaleCreature.ts
+++ b/test/propagate/large/ProductionScaleCreature.ts
@@ -50,7 +50,7 @@ export const AGGREGATE_SQUASHES = ["IF", "MAXIMUM", "MINIMUM"];
  * - `"grq-cluster"`: ~1,500 neurons, ~20,000 synapses (GRQ production scale,
  *   matching dimensions from `performance.csv`). Issue #2306.
  * - `"grq-3397"`: 1,666 neurons, ~21,513 synapses at 2,461 inputs — the
- *   GRQ-cluster production `network.json` topology used by `worker/learn.sh`.
+ *   production cluster's `network.json`-scale topology used by `worker/learn.sh`.
  *   Issue #3397.
  */
 export interface CreatureScaleOptions {
@@ -81,7 +81,7 @@ const SCALE_CONFIGS: Record<string, ScaleConfig> = {
     interLayerMin: 10,
     interLayerRange: 12,
   },
-  // Issue #3397: matches the GRQ-cluster production `network.json` used by
+  // Issue #3397: matches the production cluster's `network.json`-scale topology used by
   // `worker/learn.sh` — ~1,666 neurons, ~21,513 synapses, 2,461 inputs.
   // Used by the production learn/sampler profiling report so the reproducible
   // profiling command exercises the real production topology.


### PR DESCRIPTION
## Summary

Reworded the incidental code-comment, fixture-README, and CHANGELOG mentions of
the **private** `GRQ-cluster` repository to concept level, so a public reader is
no longer pointed at files they cannot see (check 3 of the
`private-repo-reference` audit). Only naming changed — no behaviour, no fixture,
and no scale-preset identifier (`grq-cluster` / `grq-3397` string literals) was
touched. Closes #3456.

The private repo name plus its `network.json` / `result.json` file references
were replaced with equivalent concept-level wording ("the production cluster's
`network.json`-scale topology", "the production run's `result.json`", "every
production snapshot").

### Reworded locations (exactly the audit-enumerated mentions)

| File                                                       | Change                                                                                                                                                           |
| ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `bench/ProductionLearnSamplerProfile.ts` (6, 39)           | "GRQ-cluster production topology … production `network.json`" → concept level                                                                                    |
| `src/creature/ScorerUtilisationTotals.ts` (12)             | "GRQ-cluster `result.json`" → "the production run's `result.json`"                                                                                               |
| `test/architecture/FitnessBatchPathUsed.ts` (12)           | "GRQ-cluster `result.json`" → "the production run's `result.json`"                                                                                               |
| `test/bench/ProductionScaleEvolveDirProfile.ts` (43)       | "GRQ-cluster production `network.json`" → "the production cluster's `network.json`-scale topology"                                                               |
| `test/breed/SyntheticLocationE2E.ts` (6)                   | "GRQ-cluster `network.json`" → "the production cluster's `network.json` shape"                                                                                   |
| `test/breed/fixtures/synthetic-alignment/README.md` (13)   | "GRQ-cluster `network.json` shape" → "the production cluster's `network.json` shape"                                                                             |
| `test/propagate/large/ProductionScaleCreature.ts` (53, 84) | "GRQ-cluster production `network.json`" → "the production cluster's `network.json`-scale topology" (both copies of the same private-file reference in this file) |
| `CHANGELOG.md` (29, 94)                                    | "GRQ-cluster's `result.json`" / "every GRQ-cluster snapshot" → "the production run's `result.json`" / "every production snapshot"                                |

### Deliberately left in scope-respecting places

- Lower-case code identifiers — the `scale: "grq-cluster"` / `"grq-3397"` preset
  names, the `grq-cluster.json` fixture filename — are behaviour, not prose, and
  are unchanged.
- Bare cluster/host **mnemonics** that are not private-file references (e.g.
  "GRQ-cluster dimensions/target" in
  `test/bench/ProductionScaleEvolveDirProfile.ts`, and the `GRQ`/`GRQ logs`
  mnemonics in `CHANGELOG.md` lines 193/286) stay as narrative, consistent with
  the existing mnemonics carve-out. The audit did not flag these.
- The `test/docs/*NoPrivateRepoReference*` audit tests intentionally contain the
  `GRQ-cluster` string as detection fixtures and are untouched.

## Evidence

Documentation/comment-only change — no web interface to screenshot. A broad
source-scan regression test was **not** added: it would over-reach the audit's
precise scope (the same files legitimately retain lower-case preset identifiers
and mnemonic references), and the repo guidelines explicitly discourage tests
that grep source text for patterns. Correctness is covered by the existing
quality gate:

- `./quality.sh --lint-only` — format + lint clean (2210 files formatted, 1855
  linted).
- `./quality.sh --check-only` — `deno check` type-checks the whole tree cleanly,
  confirming every edited comment block still compiles.
- `deno test test/bench/ProductionScaleEvolveDirProfile.ts` — 2 passed / 0
  failed, confirming the edited test file still runs.

```mermaid
flowchart LR
    A["Comment / README / CHANGELOG<br/>names private GRQ-cluster<br/>network.json / result.json"]
    A --> B["Reword to concept level:<br/>production cluster / production run"]
    B --> C["Public reader no longer<br/>pointed at unseeable files"]
```

## Test Plan

- Re-ran `test/bench/ProductionScaleEvolveDirProfile.ts` (one of the edited
  files) — both structural tests pass.
- `./quality.sh --lint-only` and `./quality.sh --check-only` pass cleanly with
  the changes.
