### PR TITLE
Gate Mutator per-creature diagnostic shallowClone behind debug flag (#3472)

### DIFF
--- a/bench/MutatorDiagnosticClone.ts
+++ b/bench/MutatorDiagnosticClone.ts
@@ -1,0 +1,50 @@
+/**
+ * Issue #3472 — Cost of the per-creature diagnostic `shallowClone()` that
+ * `Mutator.mutate()` used to take unconditionally on the happy path.
+ *
+ * `mutate()` runs once per generation on the **main thread** over the whole
+ * new population. Before this change every creature that passed the mutation
+ * gate was deep-cloned purely to seed the producer-gate diagnostic dump — an
+ * O(neurons+synapses) allocation consumed **only** on the rare compile-failure
+ * path. At production scale (~1,500 neurons, ~20,000 synapses — see
+ * `CreatureUtils.ts`) that is ~1,500 fresh `Neuron` allocations plus ~19,000
+ * synapse copies per mutated creature, per generation.
+ *
+ * This benchmark isolates that eliminated clone: `Creature.shallowClone()` at
+ * production scale is exactly the main-thread work and allocation the happy
+ * path no longer performs (no score, MCMC off, `DEBUG` off). Multiply the
+ * per-creature figure by the population size for the per-generation saving.
+ *
+ * Run with:
+ *   deno bench --allow-read --allow-write bench/MutatorDiagnosticClone.ts
+ */
+import { Creature } from "@creature";
+
+/**
+ * Build a sparse, production-scale creature (~1,500 neurons / ~19k synapses).
+ * A deep chain of small fully-connected layers keeps the neuron/synapse ratio
+ * near an evolved network's (~13 synapses per neuron) rather than the dense
+ * quadratic blow-up of a few wide layers.
+ */
+function buildProductionScaleCreature(): Creature {
+  const layers = [];
+  for (let i = 0; i < 113; i++) layers.push({ count: 13 });
+  return new Creature(13, 3, { layers });
+}
+
+const creature = buildProductionScaleCreature();
+
+console.log("=== Production-scale creature ===");
+console.log(
+  `neurons=${creature.neurons.length} synapses=${creature.synapses.length}`,
+);
+
+// The per-creature clone eliminated from the happy path of Mutator.mutate().
+Deno.bench({
+  name:
+    "diagnostic shallowClone (production scale ~1500 neurons / ~19k synapses)",
+  fn() {
+    const clone = creature.shallowClone();
+    if (clone.neurons.length === 0) throw new Error("Empty clone");
+  },
+});

--- a/docs/archive/pr-summaries/pr-summary-3472.md
+++ b/docs/archive/pr-summaries/pr-summary-3472.md
@@ -1,0 +1,101 @@
+# Gate Mutator per-creature diagnostic `shallowClone` behind the debug flag
+
+## Summary
+
+`Mutator.mutate()` runs once per generation on the **main thread** over the
+whole new population. It previously deep-cloned **every** creature that passed
+the mutation gate via `creature.shallowClone()` purely to seed the producer-gate
+diagnostic dump — an `O(neurons+synapses)` allocation per mutated creature, per
+generation. That snapshot is consumed **only** on the rare compile-failure path
+(`repairAfterMutation` reads it inside `if (!compileResult.ok)`); the MCMC/repair
+revert path uses `mcmcSnapshot ?? original`, never this clone.
+
+The fix reuses whichever pre-mutation snapshot was **already** allocated
+(`score`/`memetic` → `original`; MCMC → `mcmcSnapshot`) and only clones
+specifically for diagnostics when none exists **and** per-creature `DEBUG` is on:
+
+```ts
+const diagnosticPreMutationSnapshot: Creature | undefined = original ??
+  mcmcSnapshot ??
+  (creature.DEBUG ? creature.shallowClone() : undefined);
+```
+
+For the common new-offspring case (no score, MCMC off, debug off) the clone is
+**eliminated entirely**. The failure-path dump still receives a correct
+pre-mutation snapshot when one exists or when `DEBUG` is on. `Closes #3472`.
+
+### Decision flow
+
+```mermaid
+flowchart TD
+    A[creature passes mutation gate] --> B{score or memetic?}
+    B -- yes --> C["original = shallowClone()"]
+    B -- no --> D[original = undefined]
+    C --> E{MCMC enabled?}
+    D --> E
+    E -- yes --> F["mcmcSnapshot = original ?? shallowClone()"]
+    E -- no --> G[mcmcSnapshot = undefined]
+    F --> H
+    G --> H["diagnosticSnapshot = original ?? mcmcSnapshot ?? (DEBUG ? shallowClone() : undefined)"]
+    H --> I{happy path:<br/>no score, MCMC off, DEBUG off}
+    I -- yes --> J[No clone — allocation eliminated]
+    I -- no --> K[Reuse existing snapshot or debug clone]
+```
+
+## Evidence
+
+Backend-only change — no UI to screenshot. Evidence is benchmarks + tests.
+
+### Production-scale cost of the eliminated clone (`bench/MutatorDiagnosticClone.ts`)
+
+Isolates the per-creature diagnostic clone the happy path no longer performs, on
+a sparse production-scale creature matching the issue (~1,500 neurons /
+~20,000 synapses):
+
+```
+=== Production-scale creature ===
+neurons=1485 synapses=19136
+| benchmark                                                                | time/iter (avg) |  iter/s |     (min … max)     |
+| diagnostic shallowClone (production scale ~1500 neurons / ~19k synapses)  |        951.2 µs |   1,051 | (695.9 µs … 3.8 ms) |
+```
+
+**~0.95 ms per mutated creature, per generation is removed from the main
+thread**, along with ~1,485 fresh `Neuron` allocations + ~19,136 synapse copies
+each time. For a 500-creature population that is roughly **475 ms/generation**
+of main-thread work and ~750k neuron allocations avoided.
+
+### End-to-end per-generation mutation timing (`bench/MutationTimingPerGeneration.ts`)
+
+No regression — these creatures are on the happy path (no score, MCMC off,
+`DEBUG` off), so the clone is removed. End-to-end time is dominated by `fix()`
+plus the WASM compile probe, so the removal sits within measurement noise here;
+the isolated bench above is where the saving is visible.
+
+| population | before (unconditional clone) | after (gated) |
+| --- | --- | --- |
+| 100 small (5→5→3) | 34.2 ms | 34.1 ms |
+| 500 small (5→5→3) | 158.3 ms | 157.1 ms |
+| 100 medium (10→20→5) | 181.9 ms | 186.0 ms |
+| 500 medium (10→20→5) | 921.4 ms | 930.1 ms |
+| 100 large (20→50→10) | 909.2 ms | 902.8 ms |
+| 500 large (20→50→10) | 4.6 s | 4.6 s |
+
+No evolution-quality regression: the happy path never read the eliminated clone,
+and the revert/repair path (`mcmcSnapshot ?? original`) is unchanged.
+
+## Test Plan
+
+- **New** `test/NEAT/MutatorDiagnosticSnapshotGate.ts`:
+  - Diagnostics **off** (no score/memetic, MCMC off, `DEBUG` off): spies on
+    `Creature.prototype.shallowClone` and asserts it is **never called** by
+    `mutator.mutate()` — a reintroduced unconditional clone fails immediately.
+  - Diagnostics **on** (`creature.DEBUG = true`): forces a compile failure via
+    the producer-gate test seam and asserts the diagnostic dump still contains a
+    correct `preMutationCreature` snapshot.
+- **Regression guards (unchanged, still green):**
+  `test/wasm/ProducerGateDiagnosticDumps.ts` and
+  `test/NEAT/MutatorBatchRepair.ts` cover the `repairAfterMutation` failure-path
+  dump contents and revert/repair semantics; `test/NEAT/MutatorMCMCAcceptance.ts`
+  covers the MCMC snapshot path.
+- Full `test/NEAT/` + `test/wasm/` suites pass; `./quality.sh --lint-only` and
+  `--check-only` pass clean.

--- a/docs/archive/pr-summaries/pr-summary-3472.md
+++ b/docs/archive/pr-summaries/pr-summary-3472.md
@@ -7,12 +7,13 @@ whole new population. It previously deep-cloned **every** creature that passed
 the mutation gate via `creature.shallowClone()` purely to seed the producer-gate
 diagnostic dump — an `O(neurons+synapses)` allocation per mutated creature, per
 generation. That snapshot is consumed **only** on the rare compile-failure path
-(`repairAfterMutation` reads it inside `if (!compileResult.ok)`); the MCMC/repair
-revert path uses `mcmcSnapshot ?? original`, never this clone.
+(`repairAfterMutation` reads it inside `if (!compileResult.ok)`); the
+MCMC/repair revert path uses `mcmcSnapshot ?? original`, never this clone.
 
 The fix reuses whichever pre-mutation snapshot was **already** allocated
 (`score`/`memetic` → `original`; MCMC → `mcmcSnapshot`) and only clones
-specifically for diagnostics when none exists **and** per-creature `DEBUG` is on:
+specifically for diagnostics when none exists **and** per-creature `DEBUG` is
+on:
 
 ```ts
 const diagnosticPreMutationSnapshot: Creature | undefined = original ??
@@ -49,8 +50,8 @@ Backend-only change — no UI to screenshot. Evidence is benchmarks + tests.
 ### Production-scale cost of the eliminated clone (`bench/MutatorDiagnosticClone.ts`)
 
 Isolates the per-creature diagnostic clone the happy path no longer performs, on
-a sparse production-scale creature matching the issue (~1,500 neurons /
-~20,000 synapses):
+a sparse production-scale creature matching the issue (~1,500 neurons / ~20,000
+synapses):
 
 ```
 === Production-scale creature ===
@@ -71,14 +72,14 @@ No regression — these creatures are on the happy path (no score, MCMC off,
 plus the WASM compile probe, so the removal sits within measurement noise here;
 the isolated bench above is where the saving is visible.
 
-| population | before (unconditional clone) | after (gated) |
-| --- | --- | --- |
-| 100 small (5→5→3) | 34.2 ms | 34.1 ms |
-| 500 small (5→5→3) | 158.3 ms | 157.1 ms |
-| 100 medium (10→20→5) | 181.9 ms | 186.0 ms |
-| 500 medium (10→20→5) | 921.4 ms | 930.1 ms |
-| 100 large (20→50→10) | 909.2 ms | 902.8 ms |
-| 500 large (20→50→10) | 4.6 s | 4.6 s |
+| population           | before (unconditional clone) | after (gated) |
+| -------------------- | ---------------------------- | ------------- |
+| 100 small (5→5→3)    | 34.2 ms                      | 34.1 ms       |
+| 500 small (5→5→3)    | 158.3 ms                     | 157.1 ms      |
+| 100 medium (10→20→5) | 181.9 ms                     | 186.0 ms      |
+| 500 medium (10→20→5) | 921.4 ms                     | 930.1 ms      |
+| 100 large (20→50→10) | 909.2 ms                     | 902.8 ms      |
+| 500 large (20→50→10) | 4.6 s                        | 4.6 s         |
 
 No evolution-quality regression: the happy path never read the eliminated clone,
 and the revert/repair path (`mcmcSnapshot ?? original`) is unchanged.
@@ -95,7 +96,7 @@ and the revert/repair path (`mcmcSnapshot ?? original`) is unchanged.
 - **Regression guards (unchanged, still green):**
   `test/wasm/ProducerGateDiagnosticDumps.ts` and
   `test/NEAT/MutatorBatchRepair.ts` cover the `repairAfterMutation` failure-path
-  dump contents and revert/repair semantics; `test/NEAT/MutatorMCMCAcceptance.ts`
-  covers the MCMC snapshot path.
+  dump contents and revert/repair semantics;
+  `test/NEAT/MutatorMCMCAcceptance.ts` covers the MCMC snapshot path.
 - Full `test/NEAT/` + `test/wasm/` suites pass; `./quality.sh --lint-only` and
   `--check-only` pass clean.

--- a/src/NEAT/Mutator.ts
+++ b/src/NEAT/Mutator.ts
@@ -332,11 +332,17 @@ export class Mutator {
 
         let changed = false;
 
-        // Issue #2672: Capture a pre-mutation snapshot exclusively for the
-        // producer-gate diagnostic dump. The MCMC/original snapshots are
-        // only populated under specific conditions; we always need this one
-        // when the gate later rejects so the dump can replay the failure.
-        const diagnosticPreMutationSnapshot = creature.shallowClone();
+        // Issue #2672 / #3472: Provide a pre-mutation snapshot for the
+        // producer-gate diagnostic dump *without* an extra clone on the happy
+        // path. Reuse whichever pre-mutation snapshot was already allocated
+        // (score/memetic → `original`; MCMC → `mcmcSnapshot`). Only clone
+        // specifically for diagnostics when none exists AND per-creature debug
+        // is enabled. For the common new-offspring case (no score, MCMC off,
+        // debug off) this makes no clone at all, removing an
+        // O(neurons+synapses) allocation per mutated creature per generation.
+        const diagnosticPreMutationSnapshot: Creature | undefined = original ??
+          mcmcSnapshot ??
+          (creature.DEBUG ? creature.shallowClone() : undefined);
 
         // Issue #2200: Track whether any topology mutations were applied.
         // Topology mutations are always accepted; M-H only applies to

--- a/test/NEAT/MutatorDiagnosticSnapshotGate.ts
+++ b/test/NEAT/MutatorDiagnosticSnapshotGate.ts
@@ -1,0 +1,195 @@
+/**
+ * Issue #3472 — Gate the Mutator per-creature diagnostic `shallowClone()`
+ * behind the debug flag.
+ *
+ * `Mutator.mutate()` previously deep-cloned every creature that passed the
+ * mutation gate purely to seed the producer-gate diagnostic dump — an
+ * O(neurons+synapses) allocation per mutated creature, per generation, on the
+ * main thread. The snapshot is consumed **only** on the rare compile-failure
+ * path. These tests lock in the two halves of the fix:
+ *
+ *  1. Happy path, diagnostics OFF (no score/memetic, MCMC off, `DEBUG` off):
+ *     `Creature.shallowClone` must never be called by `mutate()`.
+ *  2. Compile failure, diagnostics ON (`creature.DEBUG = true`): the diagnostic
+ *     dump must still carry a correct pre-mutation snapshot.
+ */
+
+import { assert, assertEquals } from "@std/assert";
+import { Creature } from "@creature";
+import { CreatureUtil } from "@architecture/CreatureUtils.ts";
+import { createNeatConfig } from "@config/NeatConfig.ts";
+import { Mutation } from "@neat/Mutation.ts";
+import { Mutator } from "@neat/Mutator.ts";
+import {
+  __setProducerCompileGateProbeForTesting,
+} from "@wasm/ProducerCompileGuard.ts";
+import { DIAGNOSTICS_DIR } from "@utils/Diagnostics.ts";
+import {
+  createSeededRng,
+  setRandomNumberGenerator,
+} from "@utils/RandomNumberGenerator.ts";
+import { initWasmForTests } from "../_initWasm.ts";
+
+const REJECT_PROBE = () => ({
+  ok: false as const,
+  trapMessage: "test-forced trap (issue #3472)",
+});
+
+/** Snapshot existing `.diagnostics/` file names so we only inspect our own. */
+function snapshotExisting(): Set<string> {
+  const seen = new Set<string>();
+  try {
+    for (const entry of Deno.readDirSync(DIAGNOSTICS_DIR)) {
+      seen.add(entry.name);
+    }
+  } catch {
+    // Directory does not exist yet — first run.
+  }
+  return seen;
+}
+
+function findContextDump(
+  prefix: string,
+  existing: Set<string>,
+): Record<string, unknown> | undefined {
+  try {
+    for (const entry of Deno.readDirSync(DIAGNOSTICS_DIR)) {
+      if (existing.has(entry.name)) continue;
+      if (!entry.name.startsWith(prefix)) continue;
+      if (!entry.name.includes("-context-")) continue;
+      return JSON.parse(
+        Deno.readTextFileSync(`${DIAGNOSTICS_DIR}/${entry.name}`),
+      );
+    }
+  } catch {
+    // ignore
+  }
+  return undefined;
+}
+
+function cleanupByPrefix(prefix: string, existing: Set<string>): void {
+  try {
+    for (const entry of Deno.readDirSync(DIAGNOSTICS_DIR)) {
+      if (existing.has(entry.name)) continue;
+      if (entry.name.startsWith(prefix)) {
+        try {
+          Deno.removeSync(`${DIAGNOSTICS_DIR}/${entry.name}`);
+        } catch {
+          // best effort
+        }
+      }
+    }
+  } catch {
+    // ignore
+  }
+}
+
+Deno.test(
+  "Issue #3472: happy path with diagnostics off makes no shallowClone in mutate()",
+  async () => {
+    await initWasmForTests();
+
+    const config = createNeatConfig({
+      populationSize: 10,
+      mutationRate: 1.0,
+      mutationAmount: 1,
+      mutation: [Mutation.MOD_WEIGHT],
+      log: 0,
+    });
+    // Deterministic RNG so mutation selection is stable.
+    setRandomNumberGenerator(createSeededRng(20260726));
+    const mutator = new Mutator(config);
+
+    // New-offspring style creatures: no score, no memetic, MCMC off, DEBUG off.
+    const creatures: Creature[] = [];
+    for (let i = 0; i < 5; i++) {
+      const c = new Creature(3, 2, { layers: [{ count: 4 }] });
+      c.DEBUG = false;
+      assertEquals(c.score, undefined, "creature must have no score");
+      assertEquals(c.memetic, undefined, "creature must have no memetic data");
+      creatures.push(c);
+    }
+
+    const originalShallowClone = Creature.prototype.shallowClone;
+    let shallowCloneCalls = 0;
+    Creature.prototype.shallowClone = function (
+      this: Creature,
+    ): Creature {
+      shallowCloneCalls++;
+      return originalShallowClone.call(this);
+    };
+
+    try {
+      mutator.mutate(creatures);
+    } finally {
+      Creature.prototype.shallowClone = originalShallowClone;
+    }
+
+    assertEquals(
+      shallowCloneCalls,
+      0,
+      "mutate() must not shallowClone on the happy path when diagnostics are off",
+    );
+
+    // Sanity: creatures remain structurally valid after mutation.
+    for (const creature of creatures) {
+      assertEquals(creature.input, 3);
+      assertEquals(creature.output, 2);
+    }
+  },
+);
+
+Deno.test(
+  "Issue #3472: with DEBUG on, compile failure still records the pre-mutation snapshot",
+  async () => {
+    await initWasmForTests();
+
+    const existing = snapshotExisting();
+    const restore = __setProducerCompileGateProbeForTesting(REJECT_PROBE);
+    try {
+      const creature = new Creature(2, 1, {
+        layers: [{ count: 2, squash: "TANH" }],
+      });
+      creature.fix();
+      CreatureUtil.makeUUID(creature);
+      // Diagnostics ON — the gated clone should be taken for this creature.
+      creature.DEBUG = true;
+
+      const mutator = new Mutator(
+        createNeatConfig({
+          feedbackLoop: false,
+          mutationRate: 1,
+          mutationAmount: 1,
+          mutation: [Mutation.MOD_WEIGHT],
+          log: 0,
+        }),
+      );
+      setRandomNumberGenerator(createSeededRng(20260727));
+
+      // Full mutate() path: gate forces a compile failure, which must write a
+      // diagnostic dump seeded from the gated pre-mutation snapshot.
+      mutator.mutate([creature]);
+
+      const context = findContextDump(
+        `mutator-wasm-compile-trap-${Mutation.MOD_WEIGHT.name}-`,
+        existing,
+      );
+      assert(
+        context !== undefined,
+        "expected a diagnostic context dump for the forced compile failure",
+      );
+      assertEquals(
+        context.mutationName,
+        Mutation.MOD_WEIGHT.name,
+        "context.mutationName must record the applied operator",
+      );
+      assert(
+        context.preMutationCreature,
+        "context.preMutationCreature must capture the gated pre-mutation snapshot when DEBUG is on",
+      );
+    } finally {
+      restore();
+      cleanupByPrefix("mutator-wasm-compile-trap-", existing);
+    }
+  },
+);


### PR DESCRIPTION
# Gate Mutator per-creature diagnostic `shallowClone` behind the debug flag

## Summary

`Mutator.mutate()` runs once per generation on the **main thread** over the
whole new population. It previously deep-cloned **every** creature that passed
the mutation gate via `creature.shallowClone()` purely to seed the producer-gate
diagnostic dump — an `O(neurons+synapses)` allocation per mutated creature, per
generation. That snapshot is consumed **only** on the rare compile-failure path
(`repairAfterMutation` reads it inside `if (!compileResult.ok)`); the MCMC/repair
revert path uses `mcmcSnapshot ?? original`, never this clone.

The fix reuses whichever pre-mutation snapshot was **already** allocated
(`score`/`memetic` → `original`; MCMC → `mcmcSnapshot`) and only clones
specifically for diagnostics when none exists **and** per-creature `DEBUG` is on:

```ts
const diagnosticPreMutationSnapshot: Creature | undefined = original ??
  mcmcSnapshot ??
  (creature.DEBUG ? creature.shallowClone() : undefined);
```

For the common new-offspring case (no score, MCMC off, debug off) the clone is
**eliminated entirely**. The failure-path dump still receives a correct
pre-mutation snapshot when one exists or when `DEBUG` is on. `Closes #3472`.

### Decision flow

```mermaid
flowchart TD
    A[creature passes mutation gate] --> B{score or memetic?}
    B -- yes --> C["original = shallowClone()"]
    B -- no --> D[original = undefined]
    C --> E{MCMC enabled?}
    D --> E
    E -- yes --> F["mcmcSnapshot = original ?? shallowClone()"]
    E -- no --> G[mcmcSnapshot = undefined]
    F --> H
    G --> H["diagnosticSnapshot = original ?? mcmcSnapshot ?? (DEBUG ? shallowClone() : undefined)"]
    H --> I{happy path:<br/>no score, MCMC off, DEBUG off}
    I -- yes --> J[No clone — allocation eliminated]
    I -- no --> K[Reuse existing snapshot or debug clone]
```

## Evidence

Backend-only change — no UI to screenshot. Evidence is benchmarks + tests.

### Production-scale cost of the eliminated clone (`bench/MutatorDiagnosticClone.ts`)

Isolates the per-creature diagnostic clone the happy path no longer performs, on
a sparse production-scale creature matching the issue (~1,500 neurons /
~20,000 synapses):

```
=== Production-scale creature ===
neurons=1485 synapses=19136
| benchmark                                                                | time/iter (avg) |  iter/s |     (min … max)     |
| diagnostic shallowClone (production scale ~1500 neurons / ~19k synapses)  |        951.2 µs |   1,051 | (695.9 µs … 3.8 ms) |
```

**~0.95 ms per mutated creature, per generation is removed from the main
thread**, along with ~1,485 fresh `Neuron` allocations + ~19,136 synapse copies
each time. For a 500-creature population that is roughly **475 ms/generation**
of main-thread work and ~750k neuron allocations avoided.

### End-to-end per-generation mutation timing (`bench/MutationTimingPerGeneration.ts`)

No regression — these creatures are on the happy path (no score, MCMC off,
`DEBUG` off), so the clone is removed. End-to-end time is dominated by `fix()`
plus the WASM compile probe, so the removal sits within measurement noise here;
the isolated bench above is where the saving is visible.

| population | before (unconditional clone) | after (gated) |
| --- | --- | --- |
| 100 small (5→5→3) | 34.2 ms | 34.1 ms |
| 500 small (5→5→3) | 158.3 ms | 157.1 ms |
| 100 medium (10→20→5) | 181.9 ms | 186.0 ms |
| 500 medium (10→20→5) | 921.4 ms | 930.1 ms |
| 100 large (20→50→10) | 909.2 ms | 902.8 ms |
| 500 large (20→50→10) | 4.6 s | 4.6 s |

No evolution-quality regression: the happy path never read the eliminated clone,
and the revert/repair path (`mcmcSnapshot ?? original`) is unchanged.

## Test Plan

- **New** `test/NEAT/MutatorDiagnosticSnapshotGate.ts`:
  - Diagnostics **off** (no score/memetic, MCMC off, `DEBUG` off): spies on
    `Creature.prototype.shallowClone` and asserts it is **never called** by
    `mutator.mutate()` — a reintroduced unconditional clone fails immediately.
  - Diagnostics **on** (`creature.DEBUG = true`): forces a compile failure via
    the producer-gate test seam and asserts the diagnostic dump still contains a
    correct `preMutationCreature` snapshot.
- **Regression guards (unchanged, still green):**
  `test/wasm/ProducerGateDiagnosticDumps.ts` and
  `test/NEAT/MutatorBatchRepair.ts` cover the `repairAfterMutation` failure-path
  dump contents and revert/repair semantics; `test/NEAT/MutatorMCMCAcceptance.ts`
  covers the MCMC snapshot path.
- Full `test/NEAT/` + `test/wasm/` suites pass; `./quality.sh --lint-only` and
  `--check-only` pass clean.



## Milestone
This PR is part of the **#3470 Please suggest performance or memory efficiency improvements** milestone and targets the `milestone/3470-please-suggest-performance-or-memory-efficien` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-ms16818a-a9036c`<!-- vibe-worker-issue-3472 -->