### PR TITLE
Pool/skip per-neuron & per-link allocations in NeuronPropagation (#3477)

### DIFF
--- a/bench/ElasticFallbackTyped.ts
+++ b/bench/ElasticFallbackTyped.ts
@@ -1,0 +1,127 @@
+/**
+ * Issue #3477 - Benchmark: elastic-fallback per-link object allocation.
+ *
+ * The weight-based elastic fallback in `NeuronPropagation.propagate` previously
+ * repacked its pre-populated typed scratch buffers into `listLength`
+ * `{ activation, safeZoneFactor, weight }` objects (plus a backing array) on
+ * every call, only for the WASM shim to immediately unpack them back into typed
+ * arrays. `distributeElasticErrorTyped` feeds the typed buffers straight to the
+ * WASM ABI with a uniform scalar `safeZoneFactor`, allocating nothing per link.
+ *
+ * This is a same-process head-to-head: both entry points call the identical
+ * underlying WASM `distribute_elastic_error`, so the delta is purely the
+ * per-link object/array allocation. The ratio is independent of machine load.
+ *
+ * It also measures the raw allocated-bytes delta per 10k calls using
+ * `Deno.memoryUsage().heapUsed` with a forced GC, when `--v8-flags=--expose-gc`
+ * is supplied.
+ *
+ * Run with:
+ *   deno bench --allow-read --allow-env --allow-write --allow-ffi \
+ *     bench/ElasticFallbackTyped.ts
+ *   # allocation report:
+ *   deno run --allow-read --allow-env --allow-ffi --v8-flags=--expose-gc \
+ *     bench/ElasticFallbackTyped.ts --report
+ */
+
+import {
+  distributeElasticError,
+  distributeElasticErrorTyped,
+  type ElasticLink,
+} from "@propagate/ElasticDistribution.ts";
+import { ensureWasmActivation } from "@wasm/EnsureWasmActivation.ts";
+
+await ensureWasmActivation();
+
+function seededRandom(seed: number) {
+  let state = seed;
+  return () => {
+    state = (state * 1103515245 + 12345) & 0x7fffffff;
+    return (state / 0x7fffffff) * 2 - 1;
+  };
+}
+
+const random = seededRandom(3477);
+
+// Representative inbound fan-in sizes for aggregate neurons hitting the fallback.
+const FAN_INS = [8, 32, 128];
+
+for (const count of FAN_INS) {
+  const activations = new Float32Array(count);
+  const weights = new Float32Array(count);
+  for (let i = 0; i < count; i++) {
+    activations[i] = random() * 0.5;
+    weights[i] = random() * 0.5;
+  }
+  const error = 1.5;
+
+  // Old path: build a fresh ElasticLink[] object array on every call.
+  Deno.bench({
+    name: `Elastic fallback - object array (fan-in ${count})`,
+    group: `elastic-fallback-${count}`,
+    baseline: true,
+  }, () => {
+    const links: ElasticLink[] = new Array(count);
+    for (let i = 0; i < count; i++) {
+      links[i] = {
+        activation: activations[i],
+        safeZoneFactor: 1,
+        weight: weights[i],
+      };
+    }
+    const shares = distributeElasticError(error, links);
+    if (shares.length !== count) throw new Error("unreachable");
+  });
+
+  // New path: feed the typed buffers directly — no per-link allocation.
+  Deno.bench({
+    name: `Elastic fallback - typed buffers (fan-in ${count})`,
+    group: `elastic-fallback-${count}`,
+  }, () => {
+    const shares = distributeElasticErrorTyped(error, activations, weights, 1);
+    if (shares.length !== count) throw new Error("unreachable");
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Optional allocation report (requires --v8-flags=--expose-gc).
+// ---------------------------------------------------------------------------
+if (Deno.args.includes("--report")) {
+  const gc = (globalThis as { gc?: () => void }).gc;
+  const CALLS = 20_000;
+  const count = 64;
+  const activations = new Float32Array(count);
+  const weights = new Float32Array(count);
+  for (let i = 0; i < count; i++) {
+    activations[i] = random() * 0.5;
+    weights[i] = random() * 0.5;
+  }
+
+  const measure = (label: string, fn: () => void) => {
+    if (gc) gc();
+    const before = Deno.memoryUsage().heapUsed;
+    for (let i = 0; i < CALLS; i++) fn();
+    const after = Deno.memoryUsage().heapUsed;
+    const perCall = (after - before) / CALLS;
+    console.log(
+      `${label}: heapUsed +${((after - before) / 1024 / 1024).toFixed(2)} MB ` +
+        `over ${CALLS} calls (~${perCall.toFixed(0)} B/call, retained)`,
+    );
+  };
+
+  console.log(`\nAllocation report (fan-in ${count}, ${CALLS} calls):`);
+  measure("Object array   ", () => {
+    const links: ElasticLink[] = new Array(count);
+    for (let i = 0; i < count; i++) {
+      links[i] = {
+        activation: activations[i],
+        safeZoneFactor: 1,
+        weight: weights[i],
+      };
+    }
+    distributeElasticError(1.5, links);
+  });
+  measure("Typed buffers  ", () => {
+    distributeElasticErrorTyped(1.5, activations, weights, 1);
+  });
+}

--- a/bench/PropagateUpdatePooling.ts
+++ b/bench/PropagateUpdatePooling.ts
@@ -1,0 +1,214 @@
+/**
+ * Issue #3477 - Benchmark: pooled / inlined weight accumulation in
+ * `propagateUpdate`.
+ *
+ * `propagateUpdate` runs once per non-input neuron at the end of every training
+ * iteration (via `applyLearnings`). The old implementation allocated three
+ * growable `number[]` arrays per neuron (`currentWeights`, `candidateWeights`,
+ * `sourceActivations`) grown with `push()`. Issue #3477:
+ *   - Coordination disabled (`biasWeightCoordinationFactor >= 1`): candidates
+ *     are applied inline — zero scratch arrays.
+ *   - Coordination enabled (`< 1`): the three arrays are reused from the shared
+ *     `state.backpropBuffers` pool instead of being reallocated per neuron.
+ *
+ * This bench drives a full training step (activateAndTrace + propagate +
+ * applyLearnings) on a wide-fan-in production-scale creature, so `propagateUpdate`
+ * is exercised for every neuron every iteration. Run the same file on the
+ * pre-change and post-change trees for before/after evidence.
+ *
+ * Run with:
+ *   deno bench --allow-read --allow-env --allow-write --allow-ffi \
+ *     bench/PropagateUpdatePooling.ts
+ */
+
+import { Creature } from "@creature";
+import type { CreatureExport } from "@architecture/CreatureInterfaces.ts";
+import { createBackPropagationConfig } from "@propagate/BackPropagation.ts";
+import { SparseConfig } from "@propagate/sparse/SparseConfig.ts";
+
+function seededRandom(seed: number) {
+  let state = seed;
+  return () => {
+    state = (state * 1103515245 + 12345) & 0x7fffffff;
+    return (state / 0x7fffffff) * 2 - 1;
+  };
+}
+
+const random = seededRandom(3477);
+
+const SQUASH_NAMES = ["ReLU", "TANH", "LOGISTIC", "GELU", "LeakyReLU"];
+
+/**
+ * Build a densely connected feed-forward network so `propagateUpdate` sees a
+ * large per-neuron fan-in — the case the per-neuron array allocation hurt most.
+ */
+function buildNetwork(
+  inputCount: number,
+  outputCount: number,
+  hiddenLayers: number[],
+): CreatureExport {
+  const neurons: CreatureExport["neurons"] = [];
+  const synapses: CreatureExport["synapses"] = [];
+  const layerUUIDs: string[][] = [];
+
+  const inputUUIDs = Array.from({ length: inputCount }, (_, i) => `input-${i}`);
+  layerUUIDs.push(inputUUIDs);
+
+  for (let l = 0; l < hiddenLayers.length; l++) {
+    const uuids: string[] = [];
+    for (let i = 0; i < hiddenLayers[l]; i++) {
+      const uuid = `hidden-${l}-${i}`;
+      uuids.push(uuid);
+      neurons.push({
+        type: "hidden",
+        uuid,
+        squash:
+          SQUASH_NAMES[Math.floor(Math.abs(random()) * SQUASH_NAMES.length)],
+        bias: random() * 0.5,
+      });
+    }
+    layerUUIDs.push(uuids);
+  }
+
+  const outputUUIDs: string[] = [];
+  for (let i = 0; i < outputCount; i++) {
+    const uuid = `output-${i}`;
+    outputUUIDs.push(uuid);
+    neurons.push({
+      type: "output",
+      uuid,
+      squash: "IDENTITY",
+      bias: random() * 0.1,
+    });
+  }
+  layerUUIDs.push(outputUUIDs);
+
+  // Dense connectivity between adjacent layers → high fan-in per neuron.
+  for (let l = 0; l < layerUUIDs.length - 1; l++) {
+    for (const fromUUID of layerUUIDs[l]) {
+      for (const toUUID of layerUUIDs[l + 1]) {
+        synapses.push({ fromUUID, toUUID, weight: random() * 0.5 });
+      }
+    }
+  }
+
+  return { input: inputCount, output: outputCount, neurons, synapses };
+}
+
+const json = buildNetwork(12, 4, [80, 80, 60]);
+const totalNeurons = json.neurons.length + json.input;
+const totalSynapses = json.synapses.length;
+console.log(`Network: ${totalNeurons}N / ${totalSynapses}S (dense fan-in)`);
+
+const input = new Float32Array(
+  Array.from({ length: 12 }, () => random() * 0.5 + 0.5),
+);
+const target = new Float32Array(
+  Array.from({ length: 4 }, () => random() * 0.5),
+);
+
+function makeConfig(coordinationFactor: number) {
+  return createBackPropagationConfig({
+    generations: 5,
+    learningRate: 0.01,
+    plankConstant: 0.000_000_1,
+    maximumWeightAdjustmentScale: 1,
+    maximumBiasAdjustmentScale: 1,
+    disableRandomSamples: true,
+    batchSize: 8,
+    biasWeightCoordinationFactor: coordinationFactor,
+  });
+}
+
+// Coordination disabled — the pure-inline path (no scratch arrays).
+const disabledConfig = makeConfig(1);
+const disabledCreature = Creature.fromJSON(json);
+const disabledSparse = new SparseConfig(
+  disabledCreature.exportJSON(),
+  disabledConfig,
+);
+
+Deno.bench({
+  name:
+    `Training step - coordination disabled (${totalNeurons}N/${totalSynapses}S)`,
+  group: "training-step",
+  baseline: true,
+}, () => {
+  disabledCreature.activateAndTrace(input, false, disabledSparse);
+  disabledCreature.propagate(target, disabledConfig, disabledSparse);
+  disabledCreature.applyLearnings(disabledConfig, disabledSparse);
+});
+
+// Coordination enabled — the pooled-scratch path (default production setting).
+const enabledConfig = makeConfig(0.2);
+const enabledCreature = Creature.fromJSON(json);
+const enabledSparse = new SparseConfig(
+  enabledCreature.exportJSON(),
+  enabledConfig,
+);
+
+Deno.bench({
+  name:
+    `Training step - coordination enabled (${totalNeurons}N/${totalSynapses}S)`,
+  group: "training-step",
+}, () => {
+  enabledCreature.activateAndTrace(input, false, enabledSparse);
+  enabledCreature.propagate(target, enabledConfig, enabledSparse);
+  enabledCreature.applyLearnings(enabledConfig, enabledSparse);
+});
+
+// ---------------------------------------------------------------------------
+// Isolated allocation head-to-head for the coordination-disabled path: the old
+// code allocated three growable number[] per neuron (grown with push()); the new
+// code applies each candidate inline with no scratch arrays. Same-process ratio,
+// independent of machine load.
+// ---------------------------------------------------------------------------
+const NEURONS = 240;
+const FAN_IN = 52; // representative dense fan-in
+const scratchWeights = new Float64Array(NEURONS * FAN_IN);
+for (let i = 0; i < scratchWeights.length; i++) scratchWeights[i] = random();
+
+Deno.bench({
+  name:
+    `propagateUpdate accumulation - 3 arrays/neuron (${NEURONS}N x${FAN_IN})`,
+  group: "propagate-update-accumulation",
+  baseline: true,
+}, () => {
+  let sink = 0;
+  for (let n = 0; n < NEURONS; n++) {
+    const currentWeights: number[] = [];
+    const candidateWeights: number[] = [];
+    const sourceActivations: number[] = [];
+    const base = n * FAN_IN;
+    for (let i = 0; i < FAN_IN; i++) {
+      const w = scratchWeights[base + i];
+      currentWeights.push(w);
+      candidateWeights.push(w * 0.99);
+      sourceActivations.push(w * 0.5);
+    }
+    for (let i = 0; i < FAN_IN; i++) sink += candidateWeights[i];
+  }
+  if (!Number.isFinite(sink)) throw new Error("unreachable");
+});
+
+Deno.bench({
+  name:
+    `propagateUpdate accumulation - inline, no arrays (${NEURONS}N x${FAN_IN})`,
+  group: "propagate-update-accumulation",
+}, () => {
+  let sink = 0;
+  for (let n = 0; n < NEURONS; n++) {
+    const base = n * FAN_IN;
+    for (let i = 0; i < FAN_IN; i++) {
+      sink += scratchWeights[base + i] * 0.99;
+    }
+  }
+  if (!Number.isFinite(sink)) throw new Error("unreachable");
+});
+
+console.log("\n" + "=".repeat(70));
+console.log(
+  "Issue #3477: pooled / inlined propagateUpdate weight accumulation",
+);
+console.log("=".repeat(70));
+console.log("Lower is better.\n");

--- a/docs/archive/pr-summaries/pr-summary-3477.md
+++ b/docs/archive/pr-summaries/pr-summary-3477.md
@@ -1,0 +1,114 @@
+# Pool/skip per-neuron & per-link allocations in NeuronPropagation (#3477)
+
+## Summary
+
+`src/neuron/NeuronPropagation.ts` allocated fresh growable arrays and per-link
+objects on the hot training-update path. Issue #3477 removes both allocation
+sites without changing numerical output. Closes #3477.
+
+**(a) `propagateUpdate` — per-neuron weight-accumulation arrays.** The old code
+built three growable `number[]` arrays (`currentWeights`, `candidateWeights`,
+`sourceActivations`) per neuron, every training iteration, via `push()`.
+
+- **Coordination disabled** (`biasWeightCoordinationFactor >= 1`): candidate
+  weights are now applied **inline** — zero scratch arrays. `calculateBias`
+  reads only accumulated neuron state (not connection weights), so applying the
+  weights before the bias is order-independent.
+- **Coordination enabled** (`< 1`, the production default `0.2`): the three
+  arrays are reused from the shared `state.backpropBuffers` pool (sized to the
+  maximum fan-in) instead of being reallocated per neuron.
+  `coordinateBackpropUpdates` gained an optional `count` parameter so it works
+  correctly with over-sized pooled buffers.
+
+**(b) elastic fallback — per-link objects.** The weight-based fallback repacked
+its pre-populated typed scratch buffers into `listLength`
+`{ activation, safeZoneFactor, weight }` objects (plus a backing array) only for
+the WASM shim to immediately unpack them back into typed arrays. A new typed
+entry point `distributeElasticErrorTyped` feeds the already-populated
+`fusedActivations` / `fusedWeights` buffers straight into the WASM ABI with a
+uniform scalar `safeZoneFactor = 1`, allocating nothing per link. The result is
+numerically identical because `distributeElasticError` already truncated those
+values to `float32` before the WASM call.
+
+### Data flow
+
+```mermaid
+flowchart TD
+    A[propagateUpdate per neuron] --> B{coordination enabled?}
+    B -- "no (>= 1)" --> C[apply candidate weight inline<br/>no scratch arrays]
+    B -- "yes (< 1)" --> D[reuse pooled scratch from<br/>state.backpropBuffers]
+    D --> E[coordinateBackpropUpdates count]
+
+    F[propagate elastic fallback] --> G{usable safe zone?}
+    G -- yes --> H[fused perLinkError]
+    G -- no --> I[distributeElasticErrorTyped<br/>fusedActivations / fusedWeights views]
+    I --> J[WASM distribute_elastic_error]
+```
+
+## Evidence
+
+Backend/library change — no web UI to screenshot. Verified via tests (below) and
+benchmarks. The training-update path is WASM-bound end-to-end, so the eliminated
+JS allocations are best shown by isolated, same-process head-to-heads whose
+ratios are independent of machine load (parent #3470's stated production signal
+is GC pressure / heap growth, not wall-clock).
+
+**Part (a) — `propagateUpdate` accumulation**
+(`bench/PropagateUpdatePooling.ts`, group `propagate-update-accumulation`, 240
+neurons × 52 fan-in):
+
+| Pattern                         | time/iter | throughput    |
+| ------------------------------- | --------- | ------------- |
+| 3 arrays/neuron (old, `push()`) | 126.0 µs  | 7,936 iter/s  |
+| inline, no arrays (new)         | 15.0 µs   | 66,470 iter/s |
+
+**≈ 8.4× faster** in isolation; three per-neuron arrays eliminated.
+
+**Part (b) — elastic fallback** (`bench/ElasticFallbackTyped.ts`, real
+`distributeElasticError` vs `distributeElasticErrorTyped`; both call the same
+WASM `distribute_elastic_error`):
+
+| Fan-in | object array | typed buffers | speed-up |
+| ------ | ------------ | ------------- | -------- |
+| 8      | 1.4 µs       | 548 ns        | 2.64×    |
+| 32     | 1.8 µs       | 647 ns        | 2.80×    |
+| 128    | 3.4 µs       | 1.0 µs        | 3.24×    |
+
+Per-link objects + backing array eliminated; the gap widens with fan-in.
+
+**End-to-end training step** (`bench/PropagateUpdatePooling.ts`, group
+`training-step`, 236N/12,400S dense): both coordination-disabled and
+coordination-enabled steps are unchanged within run-to-run noise (≈ ±40% on a
+loaded host) — **no regression**; the WASM forward/backward pass over 12,400
+synapses dominates wall-clock, so the win here is reduced allocation / GC
+pressure rather than step latency.
+
+## Test Plan
+
+- **`test/propagate/ElasticDistributionTyped.ts`** (new) — asserts
+  `distributeElasticErrorTyped` matches `distributeElasticError` for non-zero
+  activations, the weight-based zero-activation fallback, the `plankConstant`
+  option, over-sized `subarray` views, and empty input.
+- **`test/propagate/PropagateUpdatePooling.ts`** (new) — for both coordination
+  modes, asserts training output is finite, weights change, and two back-to-back
+  creatures with mixed fan-in through the shared `state.backpropBuffers` pool
+  produce bit-identical output (the earliest deterministic detector for a
+  stale-buffer leak, per the issue's failure-detection notes).
+- **Regression suites re-run green:** `test/propagate/BackPropagation.ts`,
+  `TopologicalBackpropagation.ts`, `ElasticDistribution.ts`,
+  `WeightBasedElasticFallback.ts`, `ifPropagation.ts`,
+  `test/wasm/ElasticDistribution.ts`, `test/wasm/WasmBackpropagation.ts`,
+  `test/wasm/FusedErrorDistribution.ts`,
+  `test/propagate/BackpropCoordination.ts`,
+  `test/propagate/RecordElasticity.ts`,
+  `test/architecture/NoChangePropagate.ts`.
+- Full `./quality.sh` gate (lint, fmt, type-check, WASM sync, all tests).
+
+## Acceptance criteria
+
+- [x] No per-neuron array allocation on the coordination-disabled update path;
+      scratch buffers reused (pooled) on the coordination-enabled path.
+- [x] Elastic fallback feeds typed arrays directly with no per-link object
+      allocation.
+- [x] Numerical output unchanged (existing propagate suites pass).
+- [x] Before/after benchmark evidence via the `bench/` harness (#3398).

--- a/src/neuron/NeuronPropagation.ts
+++ b/src/neuron/NeuronPropagation.ts
@@ -17,7 +17,8 @@ import {
   adjustedBias,
   calculateBias,
 } from "@propagate/Bias.ts";
-import { distributeElasticError } from "@propagate/ElasticDistribution.ts";
+import { distributeElasticErrorTyped } from "@propagate/ElasticDistribution.ts";
+import { BackpropBuffers } from "@propagate/BackpropBuffers.ts";
 import type { SparseConfig } from "@propagate/sparse/SparseConfig.ts";
 import {
   accumulateWeight,
@@ -45,22 +46,55 @@ export function propagateUpdate(
 ): void {
   const state = neuron.creature.state;
   const toList = neuron.creature.inwardConnections(neuron.index);
+  const listLength = toList.length;
 
   const coordinationEnabled = config.biasWeightCoordinationFactor < 1;
 
-  const currentWeights: number[] = [];
-  const candidateWeights: number[] = [];
-  const sourceActivations: number[] = [];
+  if (!coordinationEnabled) {
+    // Issue #3477: Coordination disabled — apply each candidate weight inline.
+    // No per-neuron scratch arrays are needed: coordination never runs, so the
+    // current-weight and source-activation buffers are dead. `calculateBias`
+    // reads only accumulated neuron state (not connection weights), so applying
+    // the weights before the bias is order-independent.
+    for (let i = 0; i < listLength; i++) {
+      const c = toList[i];
+      const cs = state.connectionFor(c); // Issue #3089: cached state lookup
+      // Issue #2421: Clamp proactively so runaway gradients cannot escape.
+      c.weight = clampAndTrack(
+        calculateWeight(cs, c, config),
+        "training.weight",
+        "propagateUpdate",
+      );
+    }
+    neuron.bias = clampAndTrack(
+      calculateBias(neuron, config),
+      "training.bias",
+      "propagateUpdate",
+    );
+    return;
+  }
+
+  // Issue #3477: Coordination enabled — gather candidates into pooled scratch
+  // buffers (sized to the maximum fan-in) instead of allocating growable arrays
+  // per neuron.
+  let backpropBuffers = state.backpropBuffers;
+  if (backpropBuffers === undefined) {
+    backpropBuffers = new BackpropBuffers();
+    state.backpropBuffers = backpropBuffers;
+  }
+  const buf = backpropBuffers.acquire(listLength);
+  const currentWeights = buf.currentWeights;
+  const candidateWeights = buf.candidateWeights;
+  const sourceActivations = buf.sourceActivations;
+
   let minSynapseCount = Infinity;
-  for (let i = 0; i < toList.length; i++) {
+  for (let i = 0; i < listLength; i++) {
     const c = toList[i];
     const cs = state.connectionFor(c); // Issue #3089: cached state lookup
-    currentWeights.push(c.weight);
-    candidateWeights.push(calculateWeight(cs, c, config));
-    if (coordinationEnabled) {
-      sourceActivations.push(state.activations[c.from]);
-      if (cs.count < minSynapseCount) minSynapseCount = cs.count;
-    }
+    currentWeights[i] = c.weight;
+    candidateWeights[i] = calculateWeight(cs, c, config);
+    sourceActivations[i] = state.activations[c.from];
+    if (cs.count < minSynapseCount) minSynapseCount = cs.count;
   }
 
   const candidateBias = calculateBias(neuron, config);
@@ -70,9 +104,7 @@ export function propagateUpdate(
   // gradient signals are too noisy for coordination to help.
   // Require at least one full batch of samples.
   const MIN_SAMPLES_FOR_COORDINATION = Math.max(config.batchSize, 4);
-  if (
-    coordinationEnabled && minSynapseCount >= MIN_SAMPLES_FOR_COORDINATION
-  ) {
+  if (minSynapseCount >= MIN_SAMPLES_FOR_COORDINATION) {
     const coordinated = coordinateBackpropUpdates(
       neuron.bias,
       candidateBias,
@@ -80,11 +112,12 @@ export function propagateUpdate(
       candidateWeights,
       sourceActivations,
       config.biasWeightCoordinationFactor,
+      listLength, // Issue #3477: pooled buffers may exceed the fan-in
     );
 
     // Issue #2421: Clamp proactively after backprop computes candidates so
     // runaway gradient magnitudes cannot escape a single training step.
-    for (let i = 0; i < toList.length; i++) {
+    for (let i = 0; i < listLength; i++) {
       toList[i].weight = clampAndTrack(
         coordinated.weights[i],
         "training.weight",
@@ -97,7 +130,7 @@ export function propagateUpdate(
       "propagateUpdate/coordinated",
     );
   } else {
-    for (let i = 0; i < toList.length; i++) {
+    for (let i = 0; i < listLength; i++) {
       toList[i].weight = clampAndTrack(
         candidateWeights[i],
         "training.weight",
@@ -110,6 +143,8 @@ export function propagateUpdate(
       "propagateUpdate",
     );
   }
+
+  backpropBuffers.release(buf);
 }
 
 /**
@@ -287,17 +322,21 @@ export function propagate(
         // Fallback: ignore safe zones, use activation² only.
         // Include weight data for the weight-based fallback when activations
         // are near zero (Issue #1388).
-        const fallbackMeta = new Array(listLength);
-        for (let i = 0; i < listLength; i++) {
-          fallbackMeta[i] = {
-            activation: fusedActivations[i],
-            safeZoneFactor: 1,
-            weight: fromWeightCache[i],
-          };
-        }
-        perLinkError = distributeElasticError(error, fallbackMeta, {
-          plankConstant: config.plankConstant,
-        });
+        //
+        // Issue #3477: Feed the already-populated typed scratch buffers
+        // directly to the WASM ABI with a uniform safeZoneFactor of 1, instead
+        // of repacking them into `listLength` `ElasticLink` objects. The fused
+        // buffers already hold the exact float32 activation (`fusedActivations`)
+        // and synapse weight (`fusedWeights`) values the object path would have
+        // supplied — `distributeElasticError` truncates both to float32 anyway
+        // — so the result is numerically identical with no per-link allocation.
+        perLinkError = distributeElasticErrorTyped(
+          error,
+          fusedActivations.subarray(0, listLength),
+          fusedWeights.subarray(0, listLength),
+          1,
+          { plankConstant: config.plankConstant },
+        );
       }
 
       for (let indx = 0; indx < listLength; indx++) {

--- a/src/propagate/BackpropBuffers.ts
+++ b/src/propagate/BackpropBuffers.ts
@@ -39,6 +39,21 @@ export interface BackpropBufferSet {
    * replacing a `new Float64Array(listLength)` on every call.
    */
   errorShares: Float64Array;
+  /**
+   * Issue #3477: Current synapse weights scratch for the coordination-enabled
+   * `propagateUpdate` path, replacing a `number[]` grown by `push()` per neuron.
+   */
+  currentWeights: number[];
+  /**
+   * Issue #3477: Candidate synapse weights scratch for the coordination-enabled
+   * `propagateUpdate` path.
+   */
+  candidateWeights: number[];
+  /**
+   * Issue #3477: Source-neuron activations scratch for the coordination-enabled
+   * `propagateUpdate` path.
+   */
+  sourceActivations: number[];
   /** Current allocated capacity. */
   capacity: number;
 }
@@ -99,6 +114,9 @@ export class BackpropBuffers {
       fusedWeights: new Float32Array(capacity),
       indices: new Int32Array(capacity),
       errorShares: new Float64Array(capacity),
+      currentWeights: new Array<number>(capacity),
+      candidateWeights: new Array<number>(capacity),
+      sourceActivations: new Array<number>(capacity),
       capacity,
     };
   }
@@ -114,6 +132,9 @@ export class BackpropBuffers {
     buf.fusedWeights = new Float32Array(newCapacity);
     buf.indices = new Int32Array(newCapacity);
     buf.errorShares = new Float64Array(newCapacity);
+    buf.currentWeights = new Array<number>(newCapacity);
+    buf.candidateWeights = new Array<number>(newCapacity);
+    buf.sourceActivations = new Array<number>(newCapacity);
     buf.capacity = newCapacity;
     return buf;
   }

--- a/src/propagate/BackpropCoordination.ts
+++ b/src/propagate/BackpropCoordination.ts
@@ -49,7 +49,12 @@ const CANCELLATION_THRESHOLD = 0.95;
  * @param activations - Array of source neuron activations for each synapse
  * @param reductionFactor - How much of the opposing changes to
  *   keep (0..1). Default 0.2 matches fine-tuning coordination.
- * @returns Coordinated bias and weight values
+ * @param count - Number of synapses to process (Issue #3477). Defaults to
+ *   `currentWeights.length`. Pass an explicit count when the weight/activation
+ *   arrays are over-sized pooled scratch buffers whose backing length exceeds
+ *   the neuron's fan-in.
+ * @returns Coordinated bias and weight values (an array of exactly `count`
+ *   elements)
  */
 export function coordinateBackpropUpdates(
   currentBias: number,
@@ -58,17 +63,18 @@ export function coordinateBackpropUpdates(
   candidateWeights: readonly number[],
   activations: readonly number[],
   reductionFactor: number,
+  count: number = currentWeights.length,
 ): { bias: number; weights: number[] } {
   const biasDelta = candidateBias - currentBias;
   const biasChanged = biasDelta !== 0;
 
   // Compute weight deltas and the net effect on pre-activation value
-  const weightDeltas: number[] = [];
+  const weightDeltas: number[] = new Array<number>(count);
   let anyWeightChanged = false;
   let netWeightEffect = 0;
-  for (let i = 0; i < currentWeights.length; i++) {
+  for (let i = 0; i < count; i++) {
     const delta = candidateWeights[i] - currentWeights[i];
-    weightDeltas.push(delta);
+    weightDeltas[i] = delta;
     if (delta !== 0) {
       anyWeightChanged = true;
       // The actual effect of this weight change on the neuron's
@@ -81,7 +87,7 @@ export function coordinateBackpropUpdates(
   if (!biasChanged || !anyWeightChanged) {
     return {
       bias: candidateBias,
-      weights: candidateWeights.slice() as number[],
+      weights: sliceCandidates(candidateWeights, count),
     };
   }
 
@@ -107,11 +113,12 @@ export function coordinateBackpropUpdates(
       // Reduce both sides proportionally to eliminate cancellation
       // without creating asymmetry that could push the neuron in
       // the wrong direction during early training.
-      const adjustedWeights = currentWeights.map((w, i) => {
+      const adjustedWeights = new Array<number>(count);
+      for (let i = 0; i < count; i++) {
+        const w = currentWeights[i];
         const delta = weightDeltas[i];
-        if (delta === 0) return w;
-        return w + delta * reductionFactor;
-      });
+        adjustedWeights[i] = delta === 0 ? w : w + delta * reductionFactor;
+      }
       return {
         bias: currentBias + biasDelta * reductionFactor,
         weights: adjustedWeights,
@@ -123,6 +130,22 @@ export function coordinateBackpropUpdates(
   // risk significant cancellation — pass through unchanged.
   return {
     bias: candidateBias,
-    weights: candidateWeights.slice() as number[],
+    weights: sliceCandidates(candidateWeights, count),
   };
+}
+
+/**
+ * Issue #3477: Copy exactly `count` candidate weights into a fresh array.
+ * Replaces `candidateWeights.slice()` so pooled scratch buffers whose backing
+ * length exceeds the neuron's fan-in are truncated correctly.
+ */
+function sliceCandidates(
+  candidateWeights: readonly number[],
+  count: number,
+): number[] {
+  const out = new Array<number>(count);
+  for (let i = 0; i < count; i++) {
+    out[i] = candidateWeights[i];
+  }
+  return out;
 }

--- a/src/propagate/ElasticDistribution.ts
+++ b/src/propagate/ElasticDistribution.ts
@@ -83,3 +83,64 @@ export function distributeElasticError(
   }
   return shares;
 }
+
+/**
+ * Issue #3477 — typed-array-native entry point for elastic error distribution.
+ *
+ * The backward-pass fallback in `NeuronPropagation.propagate` already holds the
+ * upstream activations and synapse weights in pre-populated `Float32Array`
+ * scratch buffers. The `ElasticLink[]` API (`distributeElasticError`) forces
+ * those buffers to be repacked into `count` short-lived `{ activation,
+ * safeZoneFactor, weight }` objects only to have the WASM shim immediately
+ * unpack them back into typed arrays. This entry point skips that round-trip:
+ * it feeds the caller's typed views straight into the WASM ABI with a uniform
+ * scalar `safeZoneFactor` (the fallback always uses `1`), allocating nothing
+ * per link.
+ *
+ * The returned `Float32Array` is the raw WASM result — a fresh copy of linear
+ * memory (wasm-bindgen returns a new array), so it is safe to retain across
+ * subsequent WASM calls, exactly like `fusedErrorDistribution().perLinkError`.
+ *
+ * `activations` and `weights` must be views of equal length (`count`); a
+ * uniform `safeZoneFactor` is applied to every link. Throws `WasmError` when the
+ * WASM module is not loaded — there is no TS fallback.
+ */
+export function distributeElasticErrorTyped(
+  error: number,
+  activations: Float32Array,
+  weights: Float32Array,
+  safeZoneFactor: number,
+  options?: Readonly<{
+    plankConstant?: number;
+  }>,
+): Float32Array {
+  const count = activations.length;
+  if (count === 0) {
+    return new Float32Array(0);
+  }
+
+  const plankConstant = options?.plankConstant ?? 1e-12;
+
+  const fn = getDistributeElasticErrorFn();
+  if (!fn) {
+    throw new WasmError(
+      "distributeElasticErrorTyped requires the WASM module to be loaded. " +
+        "Ensure the NEAT-AI package is installed correctly.",
+      "MODULE_NOT_LOADED",
+    );
+  }
+
+  // Reusable scratch of uniform safe-zone factors. Grown on demand and refilled
+  // each call; only read during the synchronous WASM call below, so a single
+  // module-level buffer is safe even under recursive propagate().
+  if (safeZoneScratch.length < count) {
+    safeZoneScratch = new Float32Array(count);
+  }
+  const safeZoneFactors = safeZoneScratch.subarray(0, count);
+  safeZoneFactors.fill(safeZoneFactor);
+
+  return fn(error, activations, safeZoneFactors, weights, plankConstant);
+}
+
+/** Reusable uniform safe-zone-factor scratch for {@link distributeElasticErrorTyped}. */
+let safeZoneScratch = new Float32Array(0);

--- a/test/propagate/ElasticDistributionTyped.ts
+++ b/test/propagate/ElasticDistributionTyped.ts
@@ -1,0 +1,130 @@
+/**
+ * Issue #3477 — tests for the typed-array-native elastic distribution entry
+ * point `distributeElasticErrorTyped`.
+ *
+ * The typed entry point feeds already-populated `Float32Array` activation and
+ * weight buffers plus a uniform scalar `safeZoneFactor` straight into the WASM
+ * `distribute_elastic_error` function, bypassing the per-link `ElasticLink[]`
+ * object allocation used by `distributeElasticError`. For a uniform
+ * `safeZoneFactor` the two entry points must produce identical shares because
+ * both feed the same underlying WASM ABI.
+ *
+ * Australian English: behaviour, normalise.
+ */
+import { assertAlmostEquals, assertEquals } from "@std/assert";
+import {
+  distributeElasticError,
+  distributeElasticErrorTyped,
+} from "@propagate/ElasticDistribution.ts";
+import { ensureWasmActivation } from "@wasm/EnsureWasmActivation.ts";
+
+await ensureWasmActivation();
+
+// The WASM implementation operates in f32, so both entry points already agree
+// to f32 precision. Keep a tight tolerance to catch any real divergence.
+const F32_TOLERANCE = 1e-6;
+
+function assertSharesEqual(
+  typed: Float32Array,
+  object: number[],
+  message: string,
+) {
+  assertEquals(typed.length, object.length, `${message}: length`);
+  for (let i = 0; i < object.length; i++) {
+    assertAlmostEquals(
+      typed[i],
+      object[i],
+      F32_TOLERANCE,
+      `${message}: [${i}]`,
+    );
+  }
+}
+
+Deno.test("distributeElasticErrorTyped: matches object API with non-zero activations", () => {
+  const error = 5;
+  const activations = new Float32Array([0.2, -0.4, 0.9]);
+  const weights = new Float32Array([0.3, 0.7, -0.1]);
+
+  const typed = distributeElasticErrorTyped(error, activations, weights, 1);
+  const object = distributeElasticError(error, [
+    { activation: 0.2, safeZoneFactor: 1, weight: 0.3 },
+    { activation: -0.4, safeZoneFactor: 1, weight: 0.7 },
+    { activation: 0.9, safeZoneFactor: 1, weight: -0.1 },
+  ]);
+
+  assertSharesEqual(typed, object, "non-zero activations");
+  // Shares reconstruct the full error.
+  let sum = 0;
+  for (const s of typed) sum += s;
+  assertAlmostEquals(sum, error, 1e-4, "shares sum to error");
+});
+
+Deno.test("distributeElasticErrorTyped: weight-based fallback when activations are zero", () => {
+  // All activations zero exercises the weight² fallback inside WASM.
+  const error = 10;
+  const activations = new Float32Array([0, 0]);
+  const weights = new Float32Array([1, 3]);
+
+  const typed = distributeElasticErrorTyped(error, activations, weights, 1);
+
+  // Scores are 1² and 3² = 1 and 9 → shares 1 and 9.
+  assertAlmostEquals(typed[0], 1, 1e-4, "small weight share");
+  assertAlmostEquals(typed[1], 9, 1e-4, "large weight share");
+});
+
+Deno.test("distributeElasticErrorTyped: honours the plankConstant option", () => {
+  const error = 3;
+  const activations = new Float32Array([0.5, 0.5]);
+  const weights = new Float32Array([0.5, 0.5]);
+
+  const typed = distributeElasticErrorTyped(
+    error,
+    activations,
+    weights,
+    1,
+    { plankConstant: 1e-7 },
+  );
+  const object = distributeElasticError(
+    error,
+    [
+      { activation: 0.5, safeZoneFactor: 1, weight: 0.5 },
+      { activation: 0.5, safeZoneFactor: 1, weight: 0.5 },
+    ],
+    { plankConstant: 1e-7 },
+  );
+
+  assertSharesEqual(typed, object, "plankConstant option");
+});
+
+Deno.test("distributeElasticErrorTyped: subarray views are handled by length", () => {
+  // The caller passes over-sized pooled buffers via subarray(0, count); ensure
+  // the function respects the view length, not the backing buffer length.
+  const error = 5;
+  const backingActivations = new Float32Array([0.2, -0.4, 0.9, 99, 99]);
+  const backingWeights = new Float32Array([0.3, 0.7, -0.1, 99, 99]);
+  const count = 3;
+
+  const typed = distributeElasticErrorTyped(
+    error,
+    backingActivations.subarray(0, count),
+    backingWeights.subarray(0, count),
+    1,
+  );
+  const object = distributeElasticError(error, [
+    { activation: 0.2, safeZoneFactor: 1, weight: 0.3 },
+    { activation: -0.4, safeZoneFactor: 1, weight: 0.7 },
+    { activation: 0.9, safeZoneFactor: 1, weight: -0.1 },
+  ]);
+
+  assertSharesEqual(typed, object, "subarray view");
+});
+
+Deno.test("distributeElasticErrorTyped: empty input returns empty result", () => {
+  const typed = distributeElasticErrorTyped(
+    5,
+    new Float32Array(0),
+    new Float32Array(0),
+    1,
+  );
+  assertEquals(typed.length, 0);
+});

--- a/test/propagate/PropagateUpdatePooling.ts
+++ b/test/propagate/PropagateUpdatePooling.ts
@@ -1,0 +1,150 @@
+/**
+ * Issue #3477 — tests for pooled / inlined weight accumulation in
+ * `propagateUpdate`.
+ *
+ * `propagateUpdate` no longer allocates fresh growable arrays per neuron:
+ *   - Coordination disabled (`biasWeightCoordinationFactor >= 1`): each
+ *     candidate weight is applied inline with no scratch arrays.
+ *   - Coordination enabled (`< 1`): the current/candidate/source scratch
+ *     arrays are reused from the shared `state.backpropBuffers` pool, sized to
+ *     the maximum fan-in.
+ *
+ * These are "what" tests: they assert on training output (finite, changed,
+ * deterministic) — not on the allocation mechanism. A stale-buffer leak through
+ * the shared pool would surface as NaN weights or as non-deterministic output
+ * between two identical training runs; both are asserted here.
+ *
+ * Australian English: behaviour, neighbour.
+ */
+import { assert, assertEquals } from "@std/assert";
+import { Creature } from "@creature";
+import type { CreatureExport } from "@architecture/CreatureInterfaces.ts";
+import { createBackPropagationConfig } from "@propagate/BackPropagation.ts";
+import { SparseConfig } from "@propagate/sparse/SparseConfig.ts";
+
+/**
+ * Build a feed-forward creature that mixes a wide fan-in output neuron with
+ * narrow fan-in hidden neurons, so the shared buffer pool is grown by a large
+ * neuron and then reused by smaller ones within a single training pass.
+ */
+function buildMixedFanInCreature(): CreatureExport {
+  const neurons: CreatureExport["neurons"] = [];
+  const synapses: CreatureExport["synapses"] = [];
+
+  const inputCount = 6;
+  const hiddenUUIDs: string[] = [];
+  // Narrow-fan-in hidden neurons: each takes two inputs.
+  for (let i = 0; i < 8; i++) {
+    const uuid = `hidden-${i}`;
+    hiddenUUIDs.push(uuid);
+    neurons.push({ type: "hidden", uuid, squash: "TANH", bias: 0.1 * i - 0.3 });
+    synapses.push({
+      fromUUID: `input-${i % inputCount}`,
+      toUUID: uuid,
+      weight: 0.2 + i * 0.03,
+    });
+    synapses.push({
+      fromUUID: `input-${(i + 1) % inputCount}`,
+      toUUID: uuid,
+      weight: -0.15 + i * 0.02,
+    });
+  }
+
+  // Wide-fan-in output neuron: connects every hidden neuron and every input.
+  neurons.push({
+    type: "output",
+    uuid: "output-0",
+    squash: "IDENTITY",
+    bias: 0,
+  });
+  for (let i = 0; i < inputCount; i++) {
+    synapses.push({ fromUUID: `input-${i}`, toUUID: "output-0", weight: 0.1 });
+  }
+  for (const uuid of hiddenUUIDs) {
+    synapses.push({ fromUUID: uuid, toUUID: "output-0", weight: 0.05 });
+  }
+
+  return { input: inputCount, output: 1, neurons, synapses };
+}
+
+const INPUT = new Float32Array([0.9, -0.4, 0.6, 0.2, -0.8, 0.5]);
+const TARGET = new Float32Array([0.35]);
+
+function trainAndExport(
+  json: CreatureExport,
+  coordinationFactor: number,
+): CreatureExport {
+  const creature = Creature.fromJSON(json);
+  const config = createBackPropagationConfig({
+    generations: 1,
+    learningRate: 0.05,
+    plankConstant: 1e-7,
+    maximumWeightAdjustmentScale: 1,
+    maximumBiasAdjustmentScale: 1,
+    disableRandomSamples: true,
+    batchSize: 4,
+    biasWeightCoordinationFactor: coordinationFactor,
+  });
+  const sparseConfig = new SparseConfig(creature.exportJSON(), config);
+
+  for (let i = 0; i < 20; i++) {
+    creature.activateAndTrace(INPUT, false, sparseConfig);
+    creature.propagate(TARGET, config, sparseConfig);
+  }
+  creature.applyLearnings(config, sparseConfig);
+  return creature.exportJSON();
+}
+
+function allWeightsFinite(exported: CreatureExport): boolean {
+  return exported.synapses.every((s) => Number.isFinite(s.weight)) &&
+    exported.neurons.every((n) =>
+      n.bias === undefined || Number.isFinite(n.bias)
+    );
+}
+
+for (const factor of [1, 0.2]) {
+  const mode = factor >= 1 ? "coordination disabled" : "coordination enabled";
+
+  Deno.test(`propagateUpdate pooling (${mode}): produces finite weights`, () => {
+    const json = buildMixedFanInCreature();
+    const exported = trainAndExport(json, factor);
+    assert(
+      allWeightsFinite(exported),
+      "All weights and biases must remain finite after training",
+    );
+  });
+
+  Deno.test(`propagateUpdate pooling (${mode}): training changes weights`, () => {
+    const json = buildMixedFanInCreature();
+    const before = json.synapses.map((s) => s.weight);
+    const exported = trainAndExport(json, factor);
+    const changed = exported.synapses.some((s, i) =>
+      Math.abs((s.weight ?? 0) - (before[i] ?? 0)) > 1e-9
+    );
+    assert(changed, "Training must update at least one weight");
+  });
+
+  Deno.test(`propagateUpdate pooling (${mode}): deterministic through shared pool`, () => {
+    // Two back-to-back creatures with the same varied fan-in must produce
+    // bit-identical training output. Any stale value carried across neurons
+    // through the shared state.backpropBuffers pool would break equality.
+    const runA = trainAndExport(buildMixedFanInCreature(), factor);
+    const runB = trainAndExport(buildMixedFanInCreature(), factor);
+
+    assertEquals(runA.synapses.length, runB.synapses.length);
+    for (let i = 0; i < runA.synapses.length; i++) {
+      assertEquals(
+        runA.synapses[i].weight,
+        runB.synapses[i].weight,
+        `synapse ${i} weight must be deterministic`,
+      );
+    }
+    for (let i = 0; i < runA.neurons.length; i++) {
+      assertEquals(
+        runA.neurons[i].bias,
+        runB.neurons[i].bias,
+        `neuron ${i} bias must be deterministic`,
+      );
+    }
+  });
+}


### PR DESCRIPTION
# Pool/skip per-neuron & per-link allocations in NeuronPropagation (#3477)

## Summary

`src/neuron/NeuronPropagation.ts` allocated fresh growable arrays and per-link
objects on the hot training-update path. Issue #3477 removes both allocation
sites without changing numerical output. Closes #3477.

**(a) `propagateUpdate` — per-neuron weight-accumulation arrays.** The old code
built three growable `number[]` arrays (`currentWeights`, `candidateWeights`,
`sourceActivations`) per neuron, every training iteration, via `push()`.

- **Coordination disabled** (`biasWeightCoordinationFactor >= 1`): candidate
  weights are now applied **inline** — zero scratch arrays. `calculateBias`
  reads only accumulated neuron state (not connection weights), so applying the
  weights before the bias is order-independent.
- **Coordination enabled** (`< 1`, the production default `0.2`): the three
  arrays are reused from the shared `state.backpropBuffers` pool (sized to the
  maximum fan-in) instead of being reallocated per neuron.
  `coordinateBackpropUpdates` gained an optional `count` parameter so it works
  correctly with over-sized pooled buffers.

**(b) elastic fallback — per-link objects.** The weight-based fallback repacked
its pre-populated typed scratch buffers into `listLength`
`{ activation, safeZoneFactor, weight }` objects (plus a backing array) only for
the WASM shim to immediately unpack them back into typed arrays. A new typed
entry point `distributeElasticErrorTyped` feeds the already-populated
`fusedActivations` / `fusedWeights` buffers straight into the WASM ABI with a
uniform scalar `safeZoneFactor = 1`, allocating nothing per link. The result is
numerically identical because `distributeElasticError` already truncated those
values to `float32` before the WASM call.

### Data flow

```mermaid
flowchart TD
    A[propagateUpdate per neuron] --> B{coordination enabled?}
    B -- "no (>= 1)" --> C[apply candidate weight inline<br/>no scratch arrays]
    B -- "yes (< 1)" --> D[reuse pooled scratch from<br/>state.backpropBuffers]
    D --> E[coordinateBackpropUpdates count]

    F[propagate elastic fallback] --> G{usable safe zone?}
    G -- yes --> H[fused perLinkError]
    G -- no --> I[distributeElasticErrorTyped<br/>fusedActivations / fusedWeights views]
    I --> J[WASM distribute_elastic_error]
```

## Evidence

Backend/library change — no web UI to screenshot. Verified via tests (below) and
benchmarks. The training-update path is WASM-bound end-to-end, so the eliminated
JS allocations are best shown by isolated, same-process head-to-heads whose
ratios are independent of machine load (parent #3470's stated production signal
is GC pressure / heap growth, not wall-clock).

**Part (a) — `propagateUpdate` accumulation**
(`bench/PropagateUpdatePooling.ts`, group `propagate-update-accumulation`, 240
neurons × 52 fan-in):

| Pattern                         | time/iter | throughput    |
| ------------------------------- | --------- | ------------- |
| 3 arrays/neuron (old, `push()`) | 126.0 µs  | 7,936 iter/s  |
| inline, no arrays (new)         | 15.0 µs   | 66,470 iter/s |

**≈ 8.4× faster** in isolation; three per-neuron arrays eliminated.

**Part (b) — elastic fallback** (`bench/ElasticFallbackTyped.ts`, real
`distributeElasticError` vs `distributeElasticErrorTyped`; both call the same
WASM `distribute_elastic_error`):

| Fan-in | object array | typed buffers | speed-up |
| ------ | ------------ | ------------- | -------- |
| 8      | 1.4 µs       | 548 ns        | 2.64×    |
| 32     | 1.8 µs       | 647 ns        | 2.80×    |
| 128    | 3.4 µs       | 1.0 µs        | 3.24×    |

Per-link objects + backing array eliminated; the gap widens with fan-in.

**End-to-end training step** (`bench/PropagateUpdatePooling.ts`, group
`training-step`, 236N/12,400S dense): both coordination-disabled and
coordination-enabled steps are unchanged within run-to-run noise (≈ ±40% on a
loaded host) — **no regression**; the WASM forward/backward pass over 12,400
synapses dominates wall-clock, so the win here is reduced allocation / GC
pressure rather than step latency.

## Test Plan

- **`test/propagate/ElasticDistributionTyped.ts`** (new) — asserts
  `distributeElasticErrorTyped` matches `distributeElasticError` for non-zero
  activations, the weight-based zero-activation fallback, the `plankConstant`
  option, over-sized `subarray` views, and empty input.
- **`test/propagate/PropagateUpdatePooling.ts`** (new) — for both coordination
  modes, asserts training output is finite, weights change, and two back-to-back
  creatures with mixed fan-in through the shared `state.backpropBuffers` pool
  produce bit-identical output (the earliest deterministic detector for a
  stale-buffer leak, per the issue's failure-detection notes).
- **Regression suites re-run green:** `test/propagate/BackPropagation.ts`,
  `TopologicalBackpropagation.ts`, `ElasticDistribution.ts`,
  `WeightBasedElasticFallback.ts`, `ifPropagation.ts`,
  `test/wasm/ElasticDistribution.ts`, `test/wasm/WasmBackpropagation.ts`,
  `test/wasm/FusedErrorDistribution.ts`,
  `test/propagate/BackpropCoordination.ts`,
  `test/propagate/RecordElasticity.ts`,
  `test/architecture/NoChangePropagate.ts`.
- Full `./quality.sh` gate (lint, fmt, type-check, WASM sync, all tests).

## Acceptance criteria

- [x] No per-neuron array allocation on the coordination-disabled update path;
      scratch buffers reused (pooled) on the coordination-enabled path.
- [x] Elastic fallback feeds typed arrays directly with no per-link object
      allocation.
- [x] Numerical output unchanged (existing propagate suites pass).
- [x] Before/after benchmark evidence via the `bench/` harness (#3398).



## Milestone
This PR is part of the **#3470 Please suggest performance or memory efficiency improvements** milestone and targets the `milestone/3470-please-suggest-performance-or-memory-efficien` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-ms1c8tph-f75ed0`<!-- vibe-worker-issue-3477 -->