### PR TITLE
Cache topology-invariant structures & drop intermediate arrays in wasmTopologicalBackprop (#3479)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-3479.md
+++ b/docs/archive/pr-summaries/pr-summary-3479.md
@@ -24,9 +24,10 @@ element-by-element into a `DataView` in a second pass.
 
 ### What changed
 
-1. **New `TopologicalBackpropCache`** (`src/propagate/TopologicalBackpropCache.ts`)
-   holds all topology-invariant artefacts and a **reusable serialisation buffer**
-   with every topology-invariant field pre-written (header counts, per-neuron
+1. **New `TopologicalBackpropCache`**
+   (`src/propagate/TopologicalBackpropCache.ts`) holds all topology-invariant
+   artefacts and a **reusable serialisation buffer** with every
+   topology-invariant field pre-written (header counts, per-neuron
    type/range/squash, per-synapse endpoints/self-loop, inward mapping, inward
    indices, reverse order).
 2. **Generation-keyed invalidation.** A new
@@ -38,14 +39,15 @@ element-by-element into a `DataView` in a second pass.
    `creature.state.backpropTopologyCache`, mirroring the existing
    `stateGeneration` invalidation pattern.
 3. **Sparse-selection flags** (`propagateNeeded` / `updateNeeded`) depend on the
-   `SparseConfig`, not pure topology, so they are re-patched only when the active
-   sparse config reference changes (stable within a training pass).
+   `SparseConfig`, not pure topology, so they are re-patched only when the
+   active sparse config reference changes (stable within a training pass).
 4. **Direct-to-`DataView` per-sample writes.** Each sample recomputes only the
    five genuinely value-dependent regions (adjusted activation, adjusted bias,
    hint value, original weight, adjusted weight) and writes them straight into
    the reused buffer — the ~10 intermediate typed arrays and the redundant
    second read/write pass are gone. The dead `hasCustomPropagate` array was also
-   removed (custom-propagate fallback is driven by the WASM `Infinity` sentinel).
+   removed (custom-propagate fallback is driven by the WASM `Infinity`
+   sentinel).
 
 Numerical behaviour is unchanged: the buffer bytes handed to
 `propagate_topological` are identical to the previous implementation for a given
@@ -57,15 +59,15 @@ This is a backend/CLI performance change — no web interface to screenshot.
 
 ### Before / after benchmark (`bench/ProductionScaleBackprop.ts`)
 
-Production-scale creature: **1176 neurons (1164 hidden), 19500 synapses**.
-Apple M2 Ultra, Deno 2.9.3. Lower time is better.
+Production-scale creature: **1176 neurons (1164 hidden), 19500 synapses**. Apple
+M2 Ultra, Deno 2.9.3. Lower time is better.
 
-| Benchmark (production 1176N/19500S) | Before | After | Speed-up |
-| ----------------------------------- | ------ | ----- | -------- |
-| Propagate only                      | 7.2 ms | 3.7 ms | **1.95× faster** |
-| Full backprop (activate + propagate)| 8.4 ms | 4.7 ms | **1.79× faster** |
-| Propagate (error only)              | 6.4 ms | 2.9 ms | **2.21× faster** |
-| Propagate (full)                    | 6.8 ms | 3.7 ms | **1.84× faster** |
+| Benchmark (production 1176N/19500S)  | Before | After  | Speed-up         |
+| ------------------------------------ | ------ | ------ | ---------------- |
+| Propagate only                       | 7.2 ms | 3.7 ms | **1.95× faster** |
+| Full backprop (activate + propagate) | 8.4 ms | 4.7 ms | **1.79× faster** |
+| Propagate (error only)               | 6.4 ms | 2.9 ms | **2.21× faster** |
+| Propagate (full)                     | 6.8 ms | 3.7 ms | **1.84× faster** |
 
 The topology-invariant work (reverse topo-sort WASM call, inward-mapping
 construction, buffer template) now runs once per topology instead of once per

--- a/docs/archive/pr-summaries/pr-summary-3479.md
+++ b/docs/archive/pr-summaries/pr-summary-3479.md
@@ -1,0 +1,112 @@
+# PR Summary — Issue #3479
+
+## Summary
+
+Cache the topology-invariant structures and drop the intermediate typed arrays
+in `wasmTopologicalBackprop`. Closes #3479.
+
+`wasmTopologicalBackprop` is the single backprop entry point, invoked **once per
+training record** — millions of times across a training pass. Every call
+previously rebuilt structures that depend **only on topology** (which does not
+change during a training pass):
+
+- `TypedTopology.fromCreature(...).computeReverseTopologicalOrder()` — a full
+  typed-array snapshot plus a WASM call to recompute the reverse topological
+  `order`.
+- A nested `Map<number, Map<number, number>>` synapse lookup.
+- The inward-connection mapping (`inwardStarts` / `inwardCounts` /
+  `inwardIndicesList`), calling `inwardConnections(i)` for every neuron.
+- Per-neuron `squashTypes` / `neuronTypes` / `rangeLows` / `rangeHighs` and
+  per-synapse `synFrom` / `synTo` / `isSelfLoop`.
+
+It then filled ~10 intermediate typed arrays in one pass and re-read them
+element-by-element into a `DataView` in a second pass.
+
+### What changed
+
+1. **New `TopologicalBackpropCache`** (`src/propagate/TopologicalBackpropCache.ts`)
+   holds all topology-invariant artefacts and a **reusable serialisation buffer**
+   with every topology-invariant field pre-written (header counts, per-neuron
+   type/range/squash, per-synapse endpoints/self-loop, inward mapping, inward
+   indices, reverse order).
+2. **Generation-keyed invalidation.** A new
+   `Creature.topologyInvalidationGeneration` counter is bumped by
+   `invalidateScoreCache()` — the single chokepoint every structural change
+   (`clearCache` / `clearConnectionCaches`) and every squash change
+   (`Neuron.setSquash`) already routes through. The cache stores the generation
+   it was built for and rebuilds in O(1) when it differs. The cache lives on
+   `creature.state.backpropTopologyCache`, mirroring the existing
+   `stateGeneration` invalidation pattern.
+3. **Sparse-selection flags** (`propagateNeeded` / `updateNeeded`) depend on the
+   `SparseConfig`, not pure topology, so they are re-patched only when the active
+   sparse config reference changes (stable within a training pass).
+4. **Direct-to-`DataView` per-sample writes.** Each sample recomputes only the
+   five genuinely value-dependent regions (adjusted activation, adjusted bias,
+   hint value, original weight, adjusted weight) and writes them straight into
+   the reused buffer — the ~10 intermediate typed arrays and the redundant
+   second read/write pass are gone. The dead `hasCustomPropagate` array was also
+   removed (custom-propagate fallback is driven by the WASM `Infinity` sentinel).
+
+Numerical behaviour is unchanged: the buffer bytes handed to
+`propagate_topological` are identical to the previous implementation for a given
+topology + sample.
+
+## Evidence
+
+This is a backend/CLI performance change — no web interface to screenshot.
+
+### Before / after benchmark (`bench/ProductionScaleBackprop.ts`)
+
+Production-scale creature: **1176 neurons (1164 hidden), 19500 synapses**.
+Apple M2 Ultra, Deno 2.9.3. Lower time is better.
+
+| Benchmark (production 1176N/19500S) | Before | After | Speed-up |
+| ----------------------------------- | ------ | ----- | -------- |
+| Propagate only                      | 7.2 ms | 3.7 ms | **1.95× faster** |
+| Full backprop (activate + propagate)| 8.4 ms | 4.7 ms | **1.79× faster** |
+| Propagate (error only)              | 6.4 ms | 2.9 ms | **2.21× faster** |
+| Propagate (full)                    | 6.8 ms | 3.7 ms | **1.84× faster** |
+
+The topology-invariant work (reverse topo-sort WASM call, inward-mapping
+construction, buffer template) now runs once per topology instead of once per
+record, and the intermediate arrays plus the second serialisation pass are
+eliminated — roughly halving the per-record propagate cost.
+
+### Data flow
+
+```mermaid
+flowchart TD
+    A[wasmTopologicalBackprop per record] --> B{cache.generation ==<br/>topologyInvalidationGeneration?}
+    B -- "no (first call / after mutation)" --> C[TopologicalBackpropCache.build<br/>reverse order, inward map,<br/>buffer template — topology-invariant]
+    C --> D[applySparse:<br/>propagateNeeded / updateNeeded]
+    B -- "yes (reuse)" --> E{sparseConfig changed?}
+    E -- "yes" --> D
+    E -- "no" --> F
+    D --> F[writeSample:<br/>adj activation/bias, hint,<br/>orig/adj weight → DataView]
+    F --> G[propagate_topological WASM call]
+    G --> H[deserialise results into creature state]
+```
+
+## Test Plan
+
+Added to `test/propagate/WasmTopologicalBackprop.ts`:
+
+- **`topology cache reused across records, not rebuilt per sample`** — asserts
+  the same `backpropTopologyCache` object and unchanged
+  `topologyInvalidationGeneration` across multiple records on a fixed topology
+  (verifies the invariant structures are computed once per topology, not per
+  record).
+- **`cache invalidated after structural mutation matches uncached rebuild`** —
+  trains, applies a structural mutation (adds a synapse), trains again, and
+  asserts the output exactly matches a fresh control creature that received the
+  same mutation without a pre-existing cache. This is the earliest detector of
+  the stale-cache failure mode; it was confirmed to **fail** against a
+  deliberately broken invalidation and **pass** with the fix.
+
+Existing suites all pass unchanged (numerical output preserved):
+`test/propagate/WasmTopologicalBackprop.ts`,
+`test/propagate/TopologicalBackpropagation.ts`,
+`test/wasm/WasmBackpropagation.ts`, `test/propagate/BackpropConvergence.ts`,
+`test/propagate/BackpropBuffers.ts`,
+`test/propagate/BackpropBufferIntegration.ts`,
+`test/wasm/WasmPropagateTopologicalTrapGuard.ts`.

--- a/src/Creature.ts
+++ b/src/Creature.ts
@@ -182,6 +182,16 @@ export class Creature implements CreatureInternal {
   public topologyHash?: string;
 
   /**
+   * Issue #3479: Monotonic counter bumped whenever a structural or squash
+   * change invalidates the topology-invariant artefacts cached by the
+   * topological backprop path. Every such change routes through
+   * {@link invalidateScoreCache}, so the cache detects a stale topology in
+   * O(1) and rebuilds only when the structure (or a neuron's squash) actually
+   * changes — not on every training record.
+   */
+  public topologyInvalidationGeneration = 0;
+
+  /**
    * Issue #2258: Cached neuron topology key and UUID lookup array.
    * Stable across connection-only structural changes; cleared only
    * when neurons are added or removed.
@@ -382,6 +392,10 @@ export class Creature implements CreatureInternal {
   public invalidateScoreCache() {
     this.cachedScoreComponents = undefined;
     this.wasmEligibilityCache = undefined;
+    // Issue #3479: Every structural change (clearCache / clearConnectionCaches)
+    // and every squash change (Neuron.setSquash) routes through here, so this
+    // is the single chokepoint that invalidates the topological backprop cache.
+    this.topologyInvalidationGeneration++;
   }
 
   clearState() {

--- a/src/architecture/CreatureState.ts
+++ b/src/architecture/CreatureState.ts
@@ -11,6 +11,7 @@ import { assert } from "@std/assert";
 import type { Creature } from "@creature";
 import type { Synapse } from "@architecture/Synapse.ts";
 import type { BackpropBuffers } from "@propagate/BackpropBuffers.ts";
+import type { TopologicalBackpropCache } from "@propagate/TopologicalBackpropCache.ts";
 import { SynapseState } from "@propagate/SynapseState.ts";
 import { DenseNumberMap } from "@architecture/DenseNumberMap.ts";
 
@@ -158,6 +159,14 @@ export class CreatureState {
    * creatures that are only used for forward activation (evaluation).
    */
   backpropBuffers?: BackpropBuffers;
+
+  /**
+   * Issue #3479: Cached topology-invariant serialisation state for the
+   * topological backprop WASM call. Rebuilt when
+   * {@link Creature.topologyInvalidationGeneration} changes; reused across every
+   * training record for a fixed topology.
+   */
+  backpropTopologyCache?: TopologicalBackpropCache;
   public preparedNeurons = false;
 
   constructor(creature: Creature) {

--- a/src/propagate/TopologicalBackpropCache.ts
+++ b/src/propagate/TopologicalBackpropCache.ts
@@ -1,0 +1,345 @@
+/**
+ * Issue #3479 — topology-invariant cache for {@link wasmTopologicalBackprop}.
+ *
+ * `wasmTopologicalBackprop` runs once per training record — millions of times
+ * across a full training pass. Most of the work it did per call depended only
+ * on the creature's *topology*, which does not change while training a fixed
+ * structure: the reverse topological order (a WASM call), the inward-connection
+ * mapping, per-neuron type/range/squash data, per-synapse endpoints, and the
+ * serialisation buffer layout.
+ *
+ * This cache computes those artefacts once and reuses them, keyed by the
+ * creature's {@link Creature.topologyInvalidationGeneration} counter (bumped on
+ * any structural or squash change). The reusable byte buffer holds every
+ * topology-invariant field pre-written; each sample only patches the five
+ * genuinely value-dependent regions (adjusted activation/bias, hint value,
+ * original/adjusted weight) straight into the `DataView`, eliminating the
+ * intermediate typed arrays and the redundant second read/write pass.
+ *
+ * The sparse-selection flags (`propagateNeeded` / `updateNeeded`) depend on the
+ * {@link SparseConfig} rather than pure topology, so they are patched whenever
+ * the active sparse config changes — stable within a single training pass.
+ */
+
+import type { Creature } from "@creature";
+import type { BackPropagationConfig } from "@propagate/BackPropagation.ts";
+import type { SparseConfig } from "@propagate/sparse/SparseConfig.ts";
+import { adjustedBias } from "@propagate/Bias.ts";
+import { adjustedWeight } from "@propagate/Weight.ts";
+import { adjustedActivation } from "@neuron/NeuronPropagation.ts";
+import { TypedTopology } from "@architecture/TypedTopology.ts";
+
+/** Neuron type constants matching the Rust side. */
+const NEURON_TYPE_INPUT = 0;
+const NEURON_TYPE_HIDDEN = 1;
+const NEURON_TYPE_OUTPUT = 2;
+const NEURON_TYPE_CONSTANT = 3;
+
+/** Header size in bytes. */
+const HEADER_SIZE = 36;
+/** Per-neuron data size in bytes. */
+const NEURON_STRIDE = 24;
+/** Per-synapse data size in bytes. */
+const SYNAPSE_STRIDE = 20;
+/** Inward mapping size per neuron. */
+const INWARD_MAP_STRIDE = 8;
+
+// Header field offsets.
+const H_NEURON_COUNT = 0;
+const H_INPUT_COUNT = 4;
+const H_OUTPUT_COUNT = 8;
+const H_SYNAPSE_COUNT = 12;
+const H_ORDER_LEN = 16;
+const H_TOTAL_INWARD = 20;
+const H_PLANK = 24;
+const H_NORMALISE = 32;
+
+// Per-neuron field offsets within NEURON_STRIDE.
+const N_SQUASH = 0;
+const N_TYPE = 1;
+const N_PROPAGATE = 2;
+const N_UPDATE = 3;
+const N_HINT = 4;
+const N_RANGE_LOW = 8;
+const N_RANGE_HIGH = 12;
+const N_ADJ_ACTIVATION = 16;
+const N_ADJ_BIAS = 20;
+
+// Per-synapse field offsets within SYNAPSE_STRIDE.
+const S_FROM = 0;
+const S_TO = 4;
+const S_ORIG_WEIGHT = 8;
+const S_ADJ_WEIGHT = 12;
+const S_SELF_LOOP = 16;
+
+/**
+ * Cached, topology-invariant serialisation state for the topological backprop
+ * WASM call. Build once per topology generation via {@link build}; reuse across
+ * every training record.
+ */
+export class TopologicalBackpropCache {
+  /** Creature topology generation this cache was built for. */
+  generation: number;
+  /** Sparse config whose selection flags are currently patched into the buffer. */
+  sparseConfig: SparseConfig | undefined;
+
+  /** Reverse topological order (output-first); reused for the WASM buffer and TS fallbacks. */
+  readonly order: number[];
+  readonly neuronCount: number;
+  readonly synapseCount: number;
+  readonly outputCount: number;
+  readonly totalInward: number;
+
+  /** Reusable serialisation buffer with all topology-invariant fields pre-written. */
+  readonly bytes: Uint8Array;
+
+  private readonly view: DataView;
+  private readonly synapseBase: number;
+  private readonly expectedBase: number;
+
+  /**
+   * Per-sample adjusted activations, retained after the WASM call for the
+   * recursive `noChangePropagate` fallback (Issue #2416).
+   */
+  readonly adjActivations: Float32Array;
+
+  private constructor(
+    generation: number,
+    order: number[],
+    neuronCount: number,
+    synapseCount: number,
+    outputCount: number,
+    totalInward: number,
+    bytes: Uint8Array,
+    view: DataView,
+    synapseBase: number,
+    expectedBase: number,
+  ) {
+    this.generation = generation;
+    this.sparseConfig = undefined;
+    this.order = order;
+    this.neuronCount = neuronCount;
+    this.synapseCount = synapseCount;
+    this.outputCount = outputCount;
+    this.totalInward = totalInward;
+    this.bytes = bytes;
+    this.view = view;
+    this.synapseBase = synapseBase;
+    this.expectedBase = expectedBase;
+    this.adjActivations = new Float32Array(neuronCount);
+  }
+
+  /**
+   * Build the topology-invariant cache from a creature's current structure.
+   *
+   * Computes the reverse topological order, the inward-connection mapping, and
+   * writes every topology-invariant field (header counts, per-neuron
+   * type/range/squash, per-synapse endpoints/self-loop, inward mapping, inward
+   * indices, order) into a reusable byte buffer.
+   */
+  static build(
+    creature: Creature,
+    generation: number,
+  ): TopologicalBackpropCache {
+    const neurons = creature.neurons;
+    const neuronCount = neurons.length;
+    const inputCount = creature.input;
+    const outputCount = creature.output;
+    const allSynapses = creature.synapses;
+    const synapseCount = allSynapses.length;
+
+    // Reverse topological order via the WASM-backed topology ops.
+    const order = TypedTopology.fromCreature(creature)
+      .computeReverseTopologicalOrder();
+
+    // Synapse lookup: (from, to) → synapse index, used to resolve inward
+    // synapses to their global index in O(1).
+    const synapseLookup = new Map<number, Map<number, number>>();
+    for (let i = 0; i < synapseCount; i++) {
+      const s = allSynapses[i];
+      let fromMap = synapseLookup.get(s.from);
+      if (fromMap === undefined) {
+        fromMap = new Map<number, number>();
+        synapseLookup.set(s.from, fromMap);
+      }
+      fromMap.set(s.to, i);
+    }
+
+    // Inward connection mapping: for each neuron, the synapse indices that
+    // connect inward.
+    const inwardStarts = new Uint32Array(neuronCount);
+    const inwardCounts = new Uint32Array(neuronCount);
+    const inwardIndicesList: number[] = [];
+    for (let i = 0; i < neuronCount; i++) {
+      const inward = creature.inwardConnections(i);
+      inwardStarts[i] = inwardIndicesList.length;
+      inwardCounts[i] = inward.length;
+      for (const syn of inward) {
+        const synIdx = synapseLookup.get(syn.from)?.get(syn.to) ?? -1;
+        inwardIndicesList.push(synIdx);
+      }
+    }
+    const totalInward = inwardIndicesList.length;
+
+    // Byte-buffer layout.
+    const synapseBase = HEADER_SIZE + neuronCount * NEURON_STRIDE;
+    const inwardMapBase = synapseBase + synapseCount * SYNAPSE_STRIDE;
+    const inwardIndicesBase = inwardMapBase + neuronCount * INWARD_MAP_STRIDE;
+    const orderBase = inwardIndicesBase + totalInward * 4;
+    const expectedBase = orderBase + order.length * 4;
+    const totalSize = expectedBase + outputCount * 4;
+
+    const buffer = new ArrayBuffer(totalSize);
+    const view = new DataView(buffer);
+    const bytes = new Uint8Array(buffer);
+
+    // Header — topology-invariant counts. plankConstant / normaliseGradients
+    // are config-dependent and written per sample in writeSample().
+    view.setUint32(H_NEURON_COUNT, neuronCount, true);
+    view.setUint32(H_INPUT_COUNT, inputCount, true);
+    view.setUint32(H_OUTPUT_COUNT, outputCount, true);
+    view.setUint32(H_SYNAPSE_COUNT, synapseCount, true);
+    view.setUint32(H_ORDER_LEN, order.length, true);
+    view.setUint32(H_TOTAL_INWARD, totalInward, true);
+
+    // Per-neuron topology-invariant fields.
+    for (let i = 0; i < neuronCount; i++) {
+      const base = HEADER_SIZE + i * NEURON_STRIDE;
+      const n = neurons[i];
+      bytes[base + N_SQUASH] = n.cachedSquashType();
+
+      let neuronType: number;
+      let rangeLow: number;
+      let rangeHigh: number;
+      if (n.type === "input") {
+        neuronType = NEURON_TYPE_INPUT;
+        rangeLow = -Infinity;
+        rangeHigh = Infinity;
+      } else if (n.type === "constant") {
+        neuronType = NEURON_TYPE_CONSTANT;
+        rangeLow = -Infinity;
+        rangeHigh = Infinity;
+      } else {
+        neuronType = n.type === "output"
+          ? NEURON_TYPE_OUTPUT
+          : NEURON_TYPE_HIDDEN;
+        const squashMethod = n.findSquash();
+        rangeLow = squashMethod.range.low;
+        rangeHigh = squashMethod.range.high;
+      }
+
+      bytes[base + N_TYPE] = neuronType;
+      view.setFloat32(base + N_RANGE_LOW, rangeLow, true);
+      view.setFloat32(base + N_RANGE_HIGH, rangeHigh, true);
+    }
+
+    // Per-synapse topology-invariant fields.
+    for (let i = 0; i < synapseCount; i++) {
+      const base = synapseBase + i * SYNAPSE_STRIDE;
+      const s = allSynapses[i];
+      view.setUint32(base + S_FROM, s.from, true);
+      view.setUint32(base + S_TO, s.to, true);
+      bytes[base + S_SELF_LOOP] = s.from === s.to ? 1 : 0;
+    }
+
+    // Inward mapping (start, count) per neuron.
+    for (let i = 0; i < neuronCount; i++) {
+      const base = inwardMapBase + i * INWARD_MAP_STRIDE;
+      view.setUint32(base, inwardStarts[i], true);
+      view.setUint32(base + 4, inwardCounts[i], true);
+    }
+
+    // Inward indices.
+    for (let i = 0; i < totalInward; i++) {
+      view.setUint32(inwardIndicesBase + i * 4, inwardIndicesList[i], true);
+    }
+
+    // Reverse topological order.
+    for (let i = 0; i < order.length; i++) {
+      view.setUint32(orderBase + i * 4, order[i], true);
+    }
+
+    return new TopologicalBackpropCache(
+      generation,
+      order,
+      neuronCount,
+      synapseCount,
+      outputCount,
+      totalInward,
+      bytes,
+      view,
+      synapseBase,
+      expectedBase,
+    );
+  }
+
+  /**
+   * Patch the sparse-selection flags (`propagateNeeded` / `updateNeeded`) for a
+   * given {@link SparseConfig}. These depend on the sparse config, not pure
+   * topology, so they are refreshed whenever the active config changes.
+   */
+  applySparse(creature: Creature, sparseConfig: SparseConfig): void {
+    const neurons = creature.neurons;
+    const bytes = this.bytes;
+    for (let i = 0; i < this.neuronCount; i++) {
+      const base = HEADER_SIZE + i * NEURON_STRIDE;
+      const id = neurons[i].id;
+      bytes[base + N_PROPAGATE] = sparseConfig.propagateNeeded(id) ? 1 : 0;
+      bytes[base + N_UPDATE] = sparseConfig.updateNeeded(id) ? 1 : 0;
+    }
+    this.sparseConfig = sparseConfig;
+  }
+
+  /**
+   * Write the per-sample, value-dependent fields directly into the reusable
+   * buffer: the header config values, adjusted activation/bias and hint value
+   * per neuron, original/adjusted weight per synapse, and the expected outputs.
+   */
+  writeSample(
+    creature: Creature,
+    config: BackPropagationConfig,
+    expected: Float32Array,
+  ): void {
+    const neurons = creature.neurons;
+    const state = creature.state;
+    const view = this.view;
+    const bytes = this.bytes;
+    const adjActivations = this.adjActivations;
+
+    // Config-dependent header fields (stable within a pass, cheap to rewrite).
+    bytes[H_NORMALISE] = config.normaliseGradients ? 1 : 0;
+    view.setFloat64(H_PLANK, config.plankConstant, true);
+
+    for (let i = 0; i < this.neuronCount; i++) {
+      const base = HEADER_SIZE + i * NEURON_STRIDE;
+      const n = neurons[i];
+      const adjAct = adjustedActivation(n, config);
+      adjActivations[i] = adjAct;
+      view.setFloat32(base + N_ADJ_ACTIVATION, adjAct, true);
+
+      if (n.type !== "input" && n.type !== "constant") {
+        view.setFloat32(base + N_ADJ_BIAS, adjustedBias(n, config), true);
+        const ns = state.node(i);
+        view.setFloat32(base + N_HINT, ns.hintValue, true);
+      }
+    }
+
+    const allSynapses = creature.synapses;
+    const synapseBase = this.synapseBase;
+    for (let i = 0; i < this.synapseCount; i++) {
+      const base = synapseBase + i * SYNAPSE_STRIDE;
+      const s = allSynapses[i];
+      view.setFloat32(base + S_ORIG_WEIGHT, s.weight, true);
+      view.setFloat32(
+        base + S_ADJ_WEIGHT,
+        adjustedWeight(state, s, config),
+        true,
+      );
+    }
+
+    const expectedBase = this.expectedBase;
+    for (let i = 0; i < this.outputCount; i++) {
+      view.setFloat32(expectedBase + i * 4, expected[i], true);
+    }
+  }
+}

--- a/src/propagate/WasmTopologicalBackprop.ts
+++ b/src/propagate/WasmTopologicalBackprop.ts
@@ -9,30 +9,12 @@
 import type { Creature } from "@creature";
 import type { NeuronActivationInterface } from "@methods/activations/NeuronActivationInterface.ts";
 import type { BackPropagationConfig } from "@propagate/BackPropagation.ts";
-import { adjustedBias } from "@propagate/Bias.ts";
 import type { SparseConfig } from "@propagate/sparse/SparseConfig.ts";
-import { adjustedWeight } from "@propagate/Weight.ts";
-import { adjustedActivation } from "@neuron/NeuronPropagation.ts";
 import { BackpropBuffers } from "@propagate/BackpropBuffers.ts";
-import { TypedTopology } from "@architecture/TypedTopology.ts";
+import { TopologicalBackpropCache } from "@propagate/TopologicalBackpropCache.ts";
 import { wasmPropagateTopological } from "@wasm/WasmStandaloneFunctions.ts";
 import { getPropagateTopologicalFn } from "@wasm/WasmModuleLoader.ts";
 import { noChangePropagate } from "@architecture/NoChangePropagate.ts";
-
-/** Neuron type constants matching the Rust side. */
-const NEURON_TYPE_INPUT = 0;
-const NEURON_TYPE_HIDDEN = 1;
-const NEURON_TYPE_OUTPUT = 2;
-const NEURON_TYPE_CONSTANT = 3;
-
-/** Header size in bytes. */
-const HEADER_SIZE = 36;
-/** Per-neuron data size in bytes. */
-const NEURON_STRIDE = 24;
-/** Per-synapse data size in bytes. */
-const SYNAPSE_STRIDE = 20;
-/** Inward mapping size per neuron. */
-const INWARD_MAP_STRIDE = 8;
 
 /**
  * Attempt to run topological backpropagation via WASM.
@@ -64,229 +46,34 @@ export function wasmTopologicalBackprop(
 
   const neurons = creature.neurons;
   const neuronCount = neurons.length;
-  const inputCount = creature.input;
-  const outputCount = creature.output;
-  const allSynapses = creature.synapses;
-  const synapseCount = allSynapses.length;
+  const synapseCount = creature.synapses.length;
+  const state = creature.state;
 
-  // Get reverse topological order via the WASM-backed topology ops.
-  const order = TypedTopology.fromCreature(creature)
-    .computeReverseTopologicalOrder();
-
-  // Build synapse lookup: (from, to) → synapse index.
-  const synapseLookup = new Map<number, Map<number, number>>();
-  for (let i = 0; i < synapseCount; i++) {
-    const s = allSynapses[i];
-    let fromMap = synapseLookup.get(s.from);
-    if (fromMap === undefined) {
-      fromMap = new Map<number, number>();
-      synapseLookup.set(s.from, fromMap);
-    }
-    fromMap.set(s.to, i);
+  // Issue #3479: reuse the topology-invariant cache when the creature's
+  // structure (and squash functions) are unchanged. `topologyInvalidationGeneration`
+  // is bumped by every structural or squash change (via `invalidateScoreCache`),
+  // so a stale cache after a mutation is detected in O(1) and rebuilt — the
+  // reverse topo-sort, inward mapping and buffer template are otherwise reused
+  // across every training record.
+  const generation = creature.topologyInvalidationGeneration;
+  let cache = state.backpropTopologyCache;
+  if (cache === undefined || cache.generation !== generation) {
+    cache = TopologicalBackpropCache.build(creature, generation);
+    cache.applySparse(creature, sparseConfig);
+    state.backpropTopologyCache = cache;
+  } else if (cache.sparseConfig !== sparseConfig) {
+    // Sparse selection flags depend on the sparse config, not pure topology.
+    cache.applySparse(creature, sparseConfig);
   }
 
-  // Build inward connection mapping.
-  // For each neuron, store which synapse indices connect inward.
-  const inwardStarts = new Uint32Array(neuronCount);
-  const inwardCounts = new Uint32Array(neuronCount);
-  const inwardIndicesList: number[] = [];
-
-  // Check for special squash types that need TS fallback.
-  const hasCustomPropagate = new Uint8Array(neuronCount);
-
-  for (let i = 0; i < neuronCount; i++) {
-    const inward = creature.inwardConnections(i);
-    inwardStarts[i] = inwardIndicesList.length;
-    inwardCounts[i] = inward.length;
-
-    // Map synapses to their global indices using O(1) lookup.
-    for (const syn of inward) {
-      const synIdx = synapseLookup.get(syn.from)?.get(syn.to) ?? -1;
-      inwardIndicesList.push(synIdx);
-    }
-
-    // Check for custom propagate method (IF, MAXIMUM, MINIMUM).
-    const n = neurons[i];
-    if (n.type !== "input" && n.type !== "constant") {
-      const squashMethod = n.findSquash();
-      const propagateMethod = squashMethod as NeuronActivationInterface;
-      if (propagateMethod.propagate !== undefined) {
-        hasCustomPropagate[i] = 1;
-      }
-    }
-  }
-
-  const totalInward = inwardIndicesList.length;
-
-  // Pre-compute adjusted values for all neurons and synapses.
-  const adjActivations = new Float32Array(neuronCount);
-  const adjBiases = new Float32Array(neuronCount);
-  const hintValues = new Float32Array(neuronCount);
-  const rangeLows = new Float32Array(neuronCount);
-  const rangeHighs = new Float32Array(neuronCount);
-  const squashTypes = new Uint8Array(neuronCount);
-  const neuronTypes = new Uint8Array(neuronCount);
-  const propagateNeeded = new Uint8Array(neuronCount);
-  const updateNeeded = new Uint8Array(neuronCount);
-
-  for (let i = 0; i < neuronCount; i++) {
-    const n = neurons[i];
-    adjActivations[i] = adjustedActivation(n, config);
-    squashTypes[i] = n.cachedSquashType();
-
-    if (n.type === "input") {
-      neuronTypes[i] = NEURON_TYPE_INPUT;
-      rangeLows[i] = -Infinity;
-      rangeHighs[i] = Infinity;
-    } else if (n.type === "constant") {
-      neuronTypes[i] = NEURON_TYPE_CONSTANT;
-      rangeLows[i] = -Infinity;
-      rangeHighs[i] = Infinity;
-    } else if (n.type === "output") {
-      neuronTypes[i] = NEURON_TYPE_OUTPUT;
-      const squashMethod = n.findSquash();
-      rangeLows[i] = squashMethod.range.low;
-      rangeHighs[i] = squashMethod.range.high;
-    } else {
-      neuronTypes[i] = NEURON_TYPE_HIDDEN;
-      const squashMethod = n.findSquash();
-      rangeLows[i] = squashMethod.range.low;
-      rangeHighs[i] = squashMethod.range.high;
-    }
-
-    if (n.type !== "input" && n.type !== "constant") {
-      adjBiases[i] = adjustedBias(n, config);
-      const ns = creature.state.node(i);
-      hintValues[i] = ns.hintValue;
-    }
-
-    propagateNeeded[i] = sparseConfig.propagateNeeded(n.id) ? 1 : 0;
-    updateNeeded[i] = sparseConfig.updateNeeded(n.id) ? 1 : 0;
-  }
-
-  const adjWeights = new Float32Array(synapseCount);
-  const origWeights = new Float32Array(synapseCount);
-  const synFrom = new Uint32Array(synapseCount);
-  const synTo = new Uint32Array(synapseCount);
-  const isSelfLoop = new Uint8Array(synapseCount);
-
-  for (let i = 0; i < synapseCount; i++) {
-    const s = allSynapses[i];
-    synFrom[i] = s.from;
-    synTo[i] = s.to;
-    origWeights[i] = s.weight;
-    adjWeights[i] = adjustedWeight(creature.state, s, config);
-    isSelfLoop[i] = s.from === s.to ? 1 : 0;
-  }
-
-  // ---- Serialise to binary format ----
-  const totalSize = HEADER_SIZE +
-    neuronCount * NEURON_STRIDE +
-    synapseCount * SYNAPSE_STRIDE +
-    neuronCount * INWARD_MAP_STRIDE +
-    totalInward * 4 +
-    order.length * 4 +
-    outputCount * 4;
-
-  const buffer = new ArrayBuffer(totalSize);
-  const view = new DataView(buffer);
-  const bytes = new Uint8Array(buffer);
-  let offset = 0;
-
-  // Header
-  view.setUint32(offset, neuronCount, true);
-  offset += 4;
-  view.setUint32(offset, inputCount, true);
-  offset += 4;
-  view.setUint32(offset, outputCount, true);
-  offset += 4;
-  view.setUint32(offset, synapseCount, true);
-  offset += 4;
-  view.setUint32(offset, order.length, true);
-  offset += 4;
-  view.setUint32(offset, totalInward, true);
-  offset += 4;
-  view.setFloat64(offset, config.plankConstant, true);
-  offset += 8;
-  bytes[offset] = config.normaliseGradients ? 1 : 0;
-  offset += 1;
-  bytes[offset] = 0;
-  offset += 1; // padding
-  bytes[offset] = 0;
-  offset += 1; // padding
-  bytes[offset] = 0;
-  offset += 1; // padding
-
-  // Per-neuron data
-  for (let i = 0; i < neuronCount; i++) {
-    bytes[offset] = squashTypes[i];
-    offset += 1;
-    bytes[offset] = neuronTypes[i];
-    offset += 1;
-    bytes[offset] = propagateNeeded[i];
-    offset += 1;
-    bytes[offset] = updateNeeded[i];
-    offset += 1;
-    view.setFloat32(offset, hintValues[i], true);
-    offset += 4;
-    view.setFloat32(offset, rangeLows[i], true);
-    offset += 4;
-    view.setFloat32(offset, rangeHighs[i], true);
-    offset += 4;
-    view.setFloat32(offset, adjActivations[i], true);
-    offset += 4;
-    view.setFloat32(offset, adjBiases[i], true);
-    offset += 4;
-  }
-
-  // Per-synapse data
-  for (let i = 0; i < synapseCount; i++) {
-    view.setUint32(offset, synFrom[i], true);
-    offset += 4;
-    view.setUint32(offset, synTo[i], true);
-    offset += 4;
-    view.setFloat32(offset, origWeights[i], true);
-    offset += 4;
-    view.setFloat32(offset, adjWeights[i], true);
-    offset += 4;
-    bytes[offset] = isSelfLoop[i];
-    offset += 1;
-    bytes[offset] = 0;
-    offset += 1; // padding
-    bytes[offset] = 0;
-    offset += 1; // padding
-    bytes[offset] = 0;
-    offset += 1; // padding
-  }
-
-  // Inward mapping
-  for (let i = 0; i < neuronCount; i++) {
-    view.setUint32(offset, inwardStarts[i], true);
-    offset += 4;
-    view.setUint32(offset, inwardCounts[i], true);
-    offset += 4;
-  }
-
-  // Inward indices
-  for (let i = 0; i < totalInward; i++) {
-    view.setUint32(offset, inwardIndicesList[i], true);
-    offset += 4;
-  }
-
-  // Reverse topological order
-  for (let i = 0; i < order.length; i++) {
-    view.setUint32(offset, order[i], true);
-    offset += 4;
-  }
-
-  // Expected outputs
-  for (let i = 0; i < outputCount; i++) {
-    view.setFloat32(offset, expected[i], true);
-    offset += 4;
-  }
+  // Patch the per-sample value-dependent fields straight into the reused
+  // buffer, then hand it to WASM.
+  cache.writeSample(creature, config, expected);
+  const order = cache.order;
+  const adjActivations = cache.adjActivations;
 
   // ---- Call WASM ----
-  const result = wasmPropagateTopological(bytes);
+  const result = wasmPropagateTopological(cache.bytes);
   if (result === undefined) {
     return false;
   }
@@ -294,7 +81,6 @@ export function wasmTopologicalBackprop(
   // ---- Deserialise results ----
   const neuronResultStride = 7;
   const synapseResultStride = 7;
-  const state = creature.state;
 
   // Check if any neurons need the custom-propagate handler (IF/MAXIMUM/MINIMUM)
   // and collect any neurons that hit the WASM-side noChange path so that the
@@ -375,7 +161,7 @@ export function wasmTopologicalBackprop(
     const sbase = neuronCount * neuronResultStride + i * synapseResultStride;
     const countDelta = result[sbase];
     if (countDelta > 0) {
-      const syn = allSynapses[i];
+      const syn = creature.synapses[i];
       const cs = state.connectionFor(syn); // Issue #3089: cached state lookup
       cs.count += countDelta;
       cs.totalPositiveActivation += result[sbase + 1];

--- a/test/propagate/WasmTopologicalBackprop.ts
+++ b/test/propagate/WasmTopologicalBackprop.ts
@@ -231,6 +231,155 @@ Deno.test("WasmTopologicalBackprop - neuron state updated correctly", () => {
   );
 });
 
+Deno.test("WasmTopologicalBackprop - topology cache reused across records, not rebuilt per sample (Issue #3479)", () => {
+  const json: CreatureExport = {
+    input: 2,
+    output: 1,
+    neurons: [
+      { type: "hidden", uuid: "h1", squash: "TANH", bias: 0 },
+      { type: "hidden", uuid: "h2", squash: "TANH", bias: 0 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "h1", weight: 0.5 },
+      { fromUUID: "input-1", toUUID: "h1", weight: 0.3 },
+      { fromUUID: "h1", toUUID: "h2", weight: 0.4 },
+      { fromUUID: "h2", toUUID: "output-0", weight: 0.6 },
+    ],
+  };
+  const creature = Creature.fromJSON(json);
+  const config = createBackPropagationConfig({
+    generations: 1,
+    learningRate: 0.05,
+    plankConstant: 1e-7,
+    maximumWeightAdjustmentScale: 1,
+    maximumBiasAdjustmentScale: 1,
+    disableRandomSamples: true,
+    batchSize: 64,
+  });
+  const sparseConfig = new SparseConfig(json, config);
+  const input = new Float32Array([0.5, 0.8]);
+  const target = new Float32Array([0.4]);
+
+  creature.activateAndTrace(input, false, sparseConfig);
+  creature.propagate(target, config, sparseConfig);
+  const cacheAfterFirst = creature.state.backpropTopologyCache;
+  const generationAfterFirst = creature.topologyInvalidationGeneration;
+  assert(
+    cacheAfterFirst !== undefined,
+    "cache should be built on first record",
+  );
+
+  // Several more records on the unchanged topology must reuse the SAME cache
+  // object — the topology-invariant artefacts are computed once, not per record.
+  for (let i = 0; i < 5; i++) {
+    creature.activateAndTrace(input, false, sparseConfig);
+    creature.propagate(target, config, sparseConfig);
+    assertEquals(
+      creature.state.backpropTopologyCache,
+      cacheAfterFirst,
+      "topology cache must be reused across records without rebuilding",
+    );
+    assertEquals(
+      creature.topologyInvalidationGeneration,
+      generationAfterFirst,
+      "topology generation must not change while topology is fixed",
+    );
+  }
+});
+
+Deno.test("WasmTopologicalBackprop - cache invalidated after structural mutation matches uncached rebuild (Issue #3479)", () => {
+  const json: CreatureExport = {
+    input: 2,
+    output: 1,
+    neurons: [
+      { type: "hidden", uuid: "h1", squash: "TANH", bias: 0.1 },
+      { type: "hidden", uuid: "h2", squash: "TANH", bias: -0.2 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "h1", weight: 0.5 },
+      { fromUUID: "input-1", toUUID: "h1", weight: 0.3 },
+      { fromUUID: "h1", toUUID: "h2", weight: 0.4 },
+      { fromUUID: "h2", toUUID: "output-0", weight: 0.6 },
+    ],
+  };
+  const makeConfig = () =>
+    createBackPropagationConfig({
+      generations: 1,
+      learningRate: 0.05,
+      plankConstant: 1e-7,
+      maximumWeightAdjustmentScale: 1,
+      maximumBiasAdjustmentScale: 1,
+      disableRandomSamples: true,
+      batchSize: 64,
+    });
+
+  const input = new Float32Array([0.5, 0.8]);
+  const target = new Float32Array([0.4]);
+  const ITERATIONS = 30;
+
+  // Index of the new synapse endpoints — h1 → output-0 (a forward connection
+  // that does not yet exist).
+  const h1Index = 2; // input(2) → h1
+  const outputIndex = 4; // input(2) + h1 + h2 → output
+
+  // ---- Path A: build the cache on the original topology, THEN mutate. If the
+  // cache is not invalidated, training proceeds against a stale buffer. ----
+  const cachedConfig = makeConfig();
+  const cachedSparseBefore = new SparseConfig(json, cachedConfig);
+  const cachedCreature = Creature.fromJSON(json);
+  // One record on the original topology builds the topology cache.
+  cachedCreature.activateAndTrace(input, false, cachedSparseBefore);
+  cachedCreature.propagate(target, cachedConfig, cachedSparseBefore);
+  const generationBefore = cachedCreature.topologyInvalidationGeneration;
+
+  // Structural mutation: add a new synapse. This must bump the generation and
+  // force the cache to rebuild on the next record.
+  cachedCreature.connect(h1Index, outputIndex, 0.25);
+  assert(
+    cachedCreature.topologyInvalidationGeneration > generationBefore,
+    "structural mutation must bump the topology generation",
+  );
+  // Reset accumulated state so the mutated-topology training starts clean.
+  cachedCreature.clearState();
+
+  const cachedSparseAfter = new SparseConfig(
+    cachedCreature.exportJSON(),
+    cachedConfig,
+  );
+  for (let i = 0; i < ITERATIONS; i++) {
+    cachedCreature.activateAndTrace(input, false, cachedSparseAfter);
+    cachedCreature.propagate(target, cachedConfig, cachedSparseAfter);
+  }
+  cachedCreature.applyLearnings(cachedConfig, cachedSparseAfter);
+  const cachedResult = cachedCreature.activate(input);
+
+  // ---- Path B: fresh control that never held a pre-mutation cache. ----
+  const controlConfig = makeConfig();
+  const controlCreature = Creature.fromJSON(json);
+  controlCreature.connect(h1Index, outputIndex, 0.25);
+  controlCreature.clearState();
+  const controlSparse = new SparseConfig(
+    controlCreature.exportJSON(),
+    controlConfig,
+  );
+  for (let i = 0; i < ITERATIONS; i++) {
+    controlCreature.activateAndTrace(input, false, controlSparse);
+    controlCreature.propagate(target, controlConfig, controlSparse);
+  }
+  controlCreature.applyLearnings(controlConfig, controlSparse);
+  const controlResult = controlCreature.activate(input);
+
+  // Identical topology + identical training → identical output. A stale cache
+  // (missing the new synapse) would diverge here.
+  assertEquals(
+    cachedResult[0],
+    controlResult[0],
+    "cached-then-mutated path must match the uncached rebuild exactly",
+  );
+});
+
 Deno.test("WasmTopologicalBackprop - no error produces no change", () => {
   const json: CreatureExport = {
     input: 1,


### PR DESCRIPTION
# PR Summary — Issue #3479

## Summary

Cache the topology-invariant structures and drop the intermediate typed arrays
in `wasmTopologicalBackprop`. Closes #3479.

`wasmTopologicalBackprop` is the single backprop entry point, invoked **once per
training record** — millions of times across a training pass. Every call
previously rebuilt structures that depend **only on topology** (which does not
change during a training pass):

- `TypedTopology.fromCreature(...).computeReverseTopologicalOrder()` — a full
  typed-array snapshot plus a WASM call to recompute the reverse topological
  `order`.
- A nested `Map<number, Map<number, number>>` synapse lookup.
- The inward-connection mapping (`inwardStarts` / `inwardCounts` /
  `inwardIndicesList`), calling `inwardConnections(i)` for every neuron.
- Per-neuron `squashTypes` / `neuronTypes` / `rangeLows` / `rangeHighs` and
  per-synapse `synFrom` / `synTo` / `isSelfLoop`.

It then filled ~10 intermediate typed arrays in one pass and re-read them
element-by-element into a `DataView` in a second pass.

### What changed

1. **New `TopologicalBackpropCache`** (`src/propagate/TopologicalBackpropCache.ts`)
   holds all topology-invariant artefacts and a **reusable serialisation buffer**
   with every topology-invariant field pre-written (header counts, per-neuron
   type/range/squash, per-synapse endpoints/self-loop, inward mapping, inward
   indices, reverse order).
2. **Generation-keyed invalidation.** A new
   `Creature.topologyInvalidationGeneration` counter is bumped by
   `invalidateScoreCache()` — the single chokepoint every structural change
   (`clearCache` / `clearConnectionCaches`) and every squash change
   (`Neuron.setSquash`) already routes through. The cache stores the generation
   it was built for and rebuilds in O(1) when it differs. The cache lives on
   `creature.state.backpropTopologyCache`, mirroring the existing
   `stateGeneration` invalidation pattern.
3. **Sparse-selection flags** (`propagateNeeded` / `updateNeeded`) depend on the
   `SparseConfig`, not pure topology, so they are re-patched only when the active
   sparse config reference changes (stable within a training pass).
4. **Direct-to-`DataView` per-sample writes.** Each sample recomputes only the
   five genuinely value-dependent regions (adjusted activation, adjusted bias,
   hint value, original weight, adjusted weight) and writes them straight into
   the reused buffer — the ~10 intermediate typed arrays and the redundant
   second read/write pass are gone. The dead `hasCustomPropagate` array was also
   removed (custom-propagate fallback is driven by the WASM `Infinity` sentinel).

Numerical behaviour is unchanged: the buffer bytes handed to
`propagate_topological` are identical to the previous implementation for a given
topology + sample.

## Evidence

This is a backend/CLI performance change — no web interface to screenshot.

### Before / after benchmark (`bench/ProductionScaleBackprop.ts`)

Production-scale creature: **1176 neurons (1164 hidden), 19500 synapses**.
Apple M2 Ultra, Deno 2.9.3. Lower time is better.

| Benchmark (production 1176N/19500S) | Before | After | Speed-up |
| ----------------------------------- | ------ | ----- | -------- |
| Propagate only | 7.2 ms | 3.7 ms | **1.95× faster** |
| Full backprop (activate + propagate) | 8.4 ms | 4.7 ms | **1.79× faster** |
| Propagate (error only) | 6.4 ms | 2.9 ms | **2.21× faster** |
| Propagate (full) | 6.8 ms | 3.7 ms | **1.84× faster** |

The topology-invariant work (reverse topo-sort WASM call, inward-mapping
construction, buffer template) now runs once per topology instead of once per
record, and the intermediate arrays plus the second serialisation pass are
eliminated — roughly halving the per-record propagate cost.

### Data flow

```mermaid
flowchart TD
    A[wasmTopologicalBackprop per record] --> B{cache.generation ==<br/>topologyInvalidationGeneration?}
    B -- "no (first call / after mutation)" --> C[TopologicalBackpropCache.build<br/>reverse order, inward map,<br/>buffer template — topology-invariant]
    C --> D[applySparse:<br/>propagateNeeded / updateNeeded]
    B -- "yes (reuse)" --> E{sparseConfig changed?}
    E -- "yes" --> D
    E -- "no" --> F
    D --> F[writeSample:<br/>adj activation/bias, hint,<br/>orig/adj weight → DataView]
    F --> G[propagate_topological WASM call]
    G --> H[deserialise results into creature state]
```

## Test Plan

Added to `test/propagate/WasmTopologicalBackprop.ts`:

- **`topology cache reused across records, not rebuilt per sample`** — asserts
  the same `backpropTopologyCache` object and unchanged
  `topologyInvalidationGeneration` across multiple records on a fixed topology
  (verifies the invariant structures are computed once per topology, not per
  record).
- **`cache invalidated after structural mutation matches uncached rebuild`** —
  trains, applies a structural mutation (adds a synapse), trains again, and
  asserts the output exactly matches a fresh control creature that received the
  same mutation without a pre-existing cache. This is the earliest detector of
  the stale-cache failure mode; it was confirmed to **fail** against a
  deliberately broken invalidation and **pass** with the fix.

Existing suites all pass unchanged (numerical output preserved):
`test/propagate/WasmTopologicalBackprop.ts`,
`test/propagate/TopologicalBackpropagation.ts`,
`test/wasm/WasmBackpropagation.ts`, `test/propagate/BackpropConvergence.ts`,
`test/propagate/BackpropBuffers.ts`,
`test/propagate/BackpropBufferIntegration.ts`,
`test/wasm/WasmPropagateTopologicalTrapGuard.ts`.



## Milestone
This PR is part of the **#3470 Please suggest performance or memory efficiency improvements** milestone and targets the `milestone/3470-please-suggest-performance-or-memory-efficien` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-ms1f7kvr-0219a0`<!-- vibe-worker-issue-3479 -->