### PR TITLE
Add init-phase timing diagnostics to WASM/worker startup (Issue #3494)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.9.40",
+  "version": "5.9.41",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-3494.md
+++ b/docs/archive/pr-summaries/pr-summary-3494.md
@@ -1,0 +1,98 @@
+# Add init-phase timing diagnostics to WASM/worker startup
+
+## Summary
+
+On GRQ-23 a discovery-replay worker once failed to initialise and logged
+`Worker init: no response after 60s. Worker may have crashed or be stuck
+loading WASM.` — a **guess**, not a measurement. From the log alone it was
+impossible to tell whether the 60s went on the bundle cache read, the
+wasm-bindgen glue `import()`, `WebAssembly.instantiate`, or the worker
+handshake itself. This change instruments the three init phases so the *next*
+occurrence is root-causable, while leaving the self-healing direct-execution
+fallback exactly as it was. Closes #3494.
+
+What changed:
+
+- **`src/wasm/WasmInitDiagnostics.ts` (new)** — single source of truth for the
+  greppable `[WasmWorkerInit]` log-line contract: the info-line and
+  timeout-breakdown formatters, plus a per-thread store for the recorded WASM
+  phase timings. The contract is documented in the module doc comment.
+- **`src/wasm/WasmBundleCache.ts`** — `loadWasmBundleBytesWithDiagnostics`
+  reports the cache `hit` / `miss` / `disabled` / `local` outcome, the resolved
+  cache directory (or an explicit *caching disabled* reason when
+  `resolveCacheDir()` returns `null`), the bundle byte length, and elapsed ms.
+  Injectable `now` and `cacheDir: null` make every branch deterministically
+  testable; `loadWasmBundleBytes` is unchanged for existing callers.
+- **`src/wasm/WasmModuleLoader.ts`** — `initWasmActivation` measures the glue
+  `import()`, the bundle load, and `module.default()` (compile + instantiate)
+  and records them for the worker init sequence to fold in.
+- **`src/workers/WorkerHandlerBase.ts`** — `createInitSequence` emits **one**
+  always-on `info` line per successful init and, on timeout, embeds the
+  parent-observed phase breakdown in the *thrown error message* so it lands
+  after the trailing `Error:` token of the fallback log line (straight into
+  GRQ's `firstError=` field). Because the worker never answered, the child's
+  internal phases are flagged **unknown** rather than reported as zeros.
+
+### Why one choke point covers all five fallback sites
+
+Every worker-init fallback listed in the issue
+(`ReplayHelpers.ts`, `DiscoveryRunner.ts`, `ImproveSquash.ts`,
+`CreatureTraining.ts`, `EpisodeWorkerPool.ts`) reaches init through
+`waitUntilReady()` → `createInitSequence`. Instrumenting that shared base
+method covers all of them without per-site changes; each handler now just
+passes its worker label (`worker-N` / `id-worker-N` / `episode-worker-N`).
+
+```mermaid
+flowchart TD
+    subgraph Sites["5 fallback sites"]
+        R[ReplayHelpers] --> W
+        D[DiscoveryRunner] --> W
+        I[ImproveSquash] --> W
+        C[CreatureTraining] --> W
+        E[EpisodeWorkerPool] --> W
+    end
+    W[waitUntilReady] --> CIS["createInitSequence (base)"]
+    CIS -->|success| L["info: [WasmWorkerInit] worker=… outcome=ok …"]
+    CIS -->|timeout| T["throw Error: [WasmWorkerInit] no response after Ns … child phases unknown"]
+    IW["initWasmActivation<br/>(glue + bundle + instantiate ms)"] -.records.-> CIS
+    BC["loadWasmBundleBytesWithDiagnostics<br/>(cache hit/miss/disabled ms)"] -.feeds.-> IW
+```
+
+### Deno regression avoided
+
+Implemented entirely with Deno-native tooling and elapsed timing via
+`performance.now()` (per the project's Temporal-vs-Date policy) — no Node-only
+dependency or config was introduced.
+
+## Evidence
+
+Backend/CLI change with no web interface, so no screenshot. Verified via the
+new unit tests and the full quality gate (`./quality.sh`):
+`ok | 7936 passed (5 steps) | 0 failed | 4 ignored`.
+
+Example info line produced (contract shape):
+
+```text
+[WasmWorkerInit] worker=worker-3 outcome=ok handshakeMs=42 cache=hit cacheDir=/home/u/.cache/neat-ai/wasm bundleBytes=1234567 bundleLoadMs=3 glueImportMs=12 instantiateMs=27 wasmTotalMs=42 workerError=none
+```
+
+Example timeout message (embedded in the thrown `Error`):
+
+```text
+[WasmWorkerInit] Worker init: no response after 60s (worker=worker-3). Parent-observed: handshakeMs=60001 workerError=none wasm[cache=hit cacheDir=… bundleBytes=1234567 bundleLoadMs=3 glueImportMs=12 instantiateMs=27 wasmTotalMs=42]. Child WASM phase timings unknown — the worker never answered the init handshake (may be stuck loading WASM, CPU-starved, or OOM).
+```
+
+## Test Plan
+
+- `test/wasm/WasmInitDiagnostics.ts` — bundle diagnostics for the **cache-hit**,
+  **cache-miss** (fetch + persist), **caching-disabled** (`cacheDir: null`), and
+  **local `file:`** branches driven through the injectable
+  `fetchFn`/`sleepFn`/`cacheDir`/`now` options; format-contract assertions for
+  the info line and the timeout breakdown (including the `wasm=null`
+  "unmeasured" cases); and `record`/`get`/`reset` round-trip.
+- `test/workers/WorkerInitDiagnostics.ts` — `createInitSequence` emits exactly
+  one `[WasmWorkerInit]` info line on success, and throws a timeout error
+  carrying the parent-observed phase breakdown and the "child phases unknown"
+  marker.
+- Existing `test/wasm/WasmBundleCache.ts`, `test/wasm/WasmModuleLoader.ts`, and
+  `test/workers/WorkerHandlerBase*.ts` suites still pass unchanged.

--- a/docs/archive/pr-summaries/pr-summary-3494.md
+++ b/docs/archive/pr-summaries/pr-summary-3494.md
@@ -8,9 +8,9 @@ loading WASM.`
 — a **guess**, not a measurement. From the log alone it was impossible to tell
 whether the 60s went on the bundle cache read, the wasm-bindgen glue `import()`,
 `WebAssembly.instantiate`, or the worker handshake itself. This change
-instruments the three init phases so the _next_ occurrence is root-causable,
-while leaving the self-healing direct-execution fallback exactly as it was.
-Closes #3494.
+instruments the three init phases so the _next_ occurrence is diagnosable, while
+leaving the self-healing direct-execution fallback exactly as it was. Closes
+#3494.
 
 What changed:
 

--- a/docs/archive/pr-summaries/pr-summary-3494.md
+++ b/docs/archive/pr-summaries/pr-summary-3494.md
@@ -4,12 +4,13 @@
 
 On GRQ-23 a discovery-replay worker once failed to initialise and logged
 `Worker init: no response after 60s. Worker may have crashed or be stuck
-loading WASM.` — a **guess**, not a measurement. From the log alone it was
-impossible to tell whether the 60s went on the bundle cache read, the
-wasm-bindgen glue `import()`, `WebAssembly.instantiate`, or the worker
-handshake itself. This change instruments the three init phases so the *next*
-occurrence is root-causable, while leaving the self-healing direct-execution
-fallback exactly as it was. Closes #3494.
+loading WASM.`
+— a **guess**, not a measurement. From the log alone it was impossible to tell
+whether the 60s went on the bundle cache read, the wasm-bindgen glue `import()`,
+`WebAssembly.instantiate`, or the worker handshake itself. This change
+instruments the three init phases so the _next_ occurrence is root-causable,
+while leaving the self-healing direct-execution fallback exactly as it was.
+Closes #3494.
 
 What changed:
 
@@ -19,7 +20,7 @@ What changed:
   phase timings. The contract is documented in the module doc comment.
 - **`src/wasm/WasmBundleCache.ts`** — `loadWasmBundleBytesWithDiagnostics`
   reports the cache `hit` / `miss` / `disabled` / `local` outcome, the resolved
-  cache directory (or an explicit *caching disabled* reason when
+  cache directory (or an explicit _caching disabled_ reason when
   `resolveCacheDir()` returns `null`), the bundle byte length, and elapsed ms.
   Injectable `now` and `cacheDir: null` make every branch deterministically
   testable; `loadWasmBundleBytes` is unchanged for existing callers.
@@ -28,19 +29,19 @@ What changed:
   and records them for the worker init sequence to fold in.
 - **`src/workers/WorkerHandlerBase.ts`** — `createInitSequence` emits **one**
   always-on `info` line per successful init and, on timeout, embeds the
-  parent-observed phase breakdown in the *thrown error message* so it lands
+  parent-observed phase breakdown in the _thrown error message_ so it lands
   after the trailing `Error:` token of the fallback log line (straight into
   GRQ's `firstError=` field). Because the worker never answered, the child's
   internal phases are flagged **unknown** rather than reported as zeros.
 
 ### Why one choke point covers all five fallback sites
 
-Every worker-init fallback listed in the issue
-(`ReplayHelpers.ts`, `DiscoveryRunner.ts`, `ImproveSquash.ts`,
-`CreatureTraining.ts`, `EpisodeWorkerPool.ts`) reaches init through
-`waitUntilReady()` → `createInitSequence`. Instrumenting that shared base
-method covers all of them without per-site changes; each handler now just
-passes its worker label (`worker-N` / `id-worker-N` / `episode-worker-N`).
+Every worker-init fallback listed in the issue (`ReplayHelpers.ts`,
+`DiscoveryRunner.ts`, `ImproveSquash.ts`, `CreatureTraining.ts`,
+`EpisodeWorkerPool.ts`) reaches init through `waitUntilReady()` →
+`createInitSequence`. Instrumenting that shared base method covers all of them
+without per-site changes; each handler now just passes its worker label
+(`worker-N` / `id-worker-N` / `episode-worker-N`).
 
 ```mermaid
 flowchart TD
@@ -66,8 +67,8 @@ dependency or config was introduced.
 
 ## Evidence
 
-Backend/CLI change with no web interface, so no screenshot. Verified via the
-new unit tests and the full quality gate (`./quality.sh`):
+Backend/CLI change with no web interface, so no screenshot. Verified via the new
+unit tests and the full quality gate (`./quality.sh`):
 `ok | 7936 passed (5 steps) | 0 failed | 4 ignored`.
 
 Example info line produced (contract shape):

--- a/docs/troubleshooting/WASM.md
+++ b/docs/troubleshooting/WASM.md
@@ -85,6 +85,44 @@ and/or `--allow-net` permissions.
 - `Worker init timed out after Ns` — Increase the timeout by setting
   `NEAT_AI_WORKER_INIT_TIMEOUT_MS` (default: 60,000 ms, minimum: 1,000 ms).
 
+### 🔎 Init-phase timing diagnostics (Issue #3494)
+
+Every worker init emits one compact, always-on `info` line so a rare init stall
+is diagnosable from the log alone (no debug flag to enable after the fact). The
+shape is a **contract** — GRQ health tooling matches on the fixed
+`[WasmWorkerInit]` prefix and field keys, so treat them as stable:
+
+```text
+[WasmWorkerInit] worker=worker-3 outcome=ok handshakeMs=42 cache=hit \
+  cacheDir=/home/u/.cache/neat-ai/wasm bundleBytes=1234567 bundleLoadMs=3 \
+  glueImportMs=12 instantiateMs=27 wasmTotalMs=42 workerError=none
+```
+
+- `cache` is `hit` / `miss` / `disabled` / `local` / `unknown`. `disabled` means
+  no cache directory could be resolved, so **every** start fetches over the
+  network — set `NEAT_AI_WASM_CACHE_DIR` (or `XDG_CACHE_HOME` / `HOME`) to
+  restore caching.
+- The WASM phase timings (`bundleLoadMs`, `glueImportMs`, `instantiateMs`) are
+  measured on the parent/main thread by `initWasmActivation`.
+
+On a handshake timeout the same breakdown is embedded in the thrown error
+message (after the trailing `Error:` token of the fallback log line). Because
+the worker never answered, the **child's** internal phases are unknowable, so
+the message reports only what the parent can see and says so explicitly rather
+than printing zeros:
+
+```text
+[WasmWorkerInit] Worker init: no response after 60s (worker=worker-3). \
+  Parent-observed: handshakeMs=60001 workerError=none wasm[cache=hit …]. \
+  Child WASM phase timings unknown — the worker never answered the init \
+  handshake (may be stuck loading WASM, CPU-starved, or OOM).
+```
+
+The self-healing direct-execution fallback is unchanged — the timeout still
+fires and the worker slot still degrades gracefully; it is now just loud about
+_what_ it was waiting on. The contract is defined in
+`src/wasm/WasmInitDiagnostics.ts`.
+
 ## 🌐 JSR-hosted NEAT-AI in your own workers (Issue #2545)
 
 **Symptoms:**

--- a/src/creature/EpisodeWorkerHandler.ts
+++ b/src/creature/EpisodeWorkerHandler.ts
@@ -57,10 +57,11 @@ export class EpisodeWorkerHandler
       new URL("../multithreading/episode/episodeWorker.ts", import.meta.url)
         .href;
 
+    const workerLabel = "episode-worker-" + (++EpisodeWorkerHandler.nextId);
     const worker = WorkerHandlerBase.createWorkerOrMock<EpisodeRequest>(
       direct,
       workerUrl,
-      "episode-worker-" + (++EpisodeWorkerHandler.nextId),
+      workerLabel,
       () =>
         new MockEpisodeWorker() as unknown as WorkerInterface<
           EpisodeRequest
@@ -95,7 +96,12 @@ export class EpisodeWorkerHandler
       );
     });
 
-    this.createInitSequence(initRequest, initErrorPromise, timeoutMs)
+    this.createInitSequence(
+      initRequest,
+      initErrorPromise,
+      timeoutMs,
+      workerLabel,
+    )
       .then((result) => {
         if (
           result &&

--- a/src/intelligentDesign/workers/WorkerHandler.ts
+++ b/src/intelligentDesign/workers/WorkerHandler.ts
@@ -85,10 +85,12 @@ export class WorkerHandler
       rejectInitError = null;
     };
 
+    const workerLabel = "id-worker-" +
+      (++WorkerHandler.nextWorkerIDForConstruction);
     const worker = WorkerHandlerBase.createWorkerOrMock<RequestData>(
       direct,
       workerUrl,
-      "id-worker-" + (++WorkerHandler.nextWorkerIDForConstruction),
+      workerLabel,
       () => new MockWorker() as unknown as WorkerInterface<RequestData>,
       onInitError,
     );
@@ -118,6 +120,7 @@ export class WorkerHandler
           initReq,
           initErrorPromise,
           INIT_RESPONSE_TIMEOUT_MS,
+          workerLabel,
         );
       },
     ).then((result) => {

--- a/src/multithreading/workers/WorkerHandler.ts
+++ b/src/multithreading/workers/WorkerHandler.ts
@@ -372,10 +372,12 @@ export class WorkerHandler
       rejectInitError = null;
     };
 
+    const workerLabel = "worker-" +
+      (++WorkerHandler.nextWorkerIDForConstruction);
     const worker = WorkerHandlerBase.createWorkerOrMock<RequestData>(
       direct,
       workerUrl,
-      "worker-" + (++WorkerHandler.nextWorkerIDForConstruction),
+      workerLabel,
       () => new MockWorker() as unknown as WorkerInterface<RequestData>,
       onInitError,
     );
@@ -440,6 +442,7 @@ export class WorkerHandler
         data,
         initErrorPromise,
         INIT_RESPONSE_TIMEOUT_MS,
+        workerLabel,
       );
       // Init complete: do not allow init error to affect anything else.
       rejectInitError = null;

--- a/src/wasm/WasmBundleCache.ts
+++ b/src/wasm/WasmBundleCache.ts
@@ -27,6 +27,7 @@
 
 import { dirname, fromFileUrl, join } from "@std/path";
 import { getLogger } from "@utils/Logger.ts";
+import type { WasmBundleLoadDiagnostics } from "@wasm/WasmInitDiagnostics.ts";
 
 /** Options for {@link loadWasmBundleBytes}; all are injectable for testing. */
 export interface LoadWasmBundleOptions {
@@ -44,8 +45,24 @@ export interface LoadWasmBundleOptions {
   /**
    * Override the cache directory. When omitted it is derived from the
    * environment (`NEAT_AI_WASM_CACHE_DIR`, then the platform cache dir).
+   * Pass `null` to force caching **disabled** (every start fetches) — used to
+   * exercise the disabled branch deterministically in tests (Issue #3494).
    */
-  cacheDir?: string;
+  cacheDir?: string | null;
+  /**
+   * Monotonic clock used for phase-timing measurement. Defaults to
+   * `performance.now`. Injectable so tests get deterministic elapsed values
+   * without real timing (Issue #3494).
+   */
+  now?: () => number;
+}
+
+/** Bytes plus the phase-timing diagnostics for a single bundle load. */
+export interface LoadWasmBundleResult {
+  /** The loaded bundle bytes. */
+  bytes: Uint8Array;
+  /** Cache outcome, resolved directory, size, and elapsed time. */
+  diagnostics: WasmBundleLoadDiagnostics;
 }
 
 /** Default bounded number of fetch attempts on a cache miss. */
@@ -68,7 +85,11 @@ function defaultSleep(ms: number): Promise<void> {
  * in which case caching is skipped and loading falls back to a plain
  * fetch-with-retry.
  */
-export function resolveCacheDir(override?: string): string | null {
+export function resolveCacheDir(override?: string | null): string | null {
+  if (override === null) {
+    // Caller forced caching off (Issue #3494).
+    return null;
+  }
   if (override !== undefined && override !== "") {
     return override;
   }
@@ -221,9 +242,38 @@ export async function loadWasmBundleBytes(
   wasmUrl: URL,
   options: LoadWasmBundleOptions = {},
 ): Promise<Uint8Array> {
+  return (await loadWasmBundleBytesWithDiagnostics(wasmUrl, options)).bytes;
+}
+
+/**
+ * Load the WASM activation bundle bytes and report the phase-timing
+ * diagnostics (Issue #3494) — cache hit/miss/disabled/local outcome, the
+ * resolved cache directory, the bundle byte length, and elapsed milliseconds.
+ *
+ * Behaviour is identical to {@link loadWasmBundleBytes}; only the return type
+ * differs so callers that want the diagnostics do not measure them twice.
+ *
+ * @throws when the bytes genuinely cannot be obtained (fail-loud).
+ */
+export async function loadWasmBundleBytesWithDiagnostics(
+  wasmUrl: URL,
+  options: LoadWasmBundleOptions = {},
+): Promise<LoadWasmBundleResult> {
+  const now = options.now ?? (() => performance.now());
+  const start = now();
+
   // Local build: the bundle is on disk beside the JS glue. No cache/network.
   if (wasmUrl.protocol === "file:") {
-    return await Deno.readFile(fromFileUrl(wasmUrl));
+    const bytes = await Deno.readFile(fromFileUrl(wasmUrl));
+    return {
+      bytes,
+      diagnostics: {
+        outcome: "local",
+        cacheDir: null,
+        byteLength: bytes.byteLength,
+        elapsedMs: now() - start,
+      },
+    };
   }
 
   const fetchFn = options.fetchFn ?? fetch;
@@ -232,6 +282,12 @@ export async function loadWasmBundleBytes(
   const baseDelayMs = options.baseDelayMs ?? DEFAULT_BASE_DELAY_MS;
 
   const cacheDir = resolveCacheDir(options.cacheDir);
+  // Explicit "caching disabled" reason so a null cache dir never reads as a
+  // silent cache hit in the diagnostics (Issue #3494).
+  const disabledReason = cacheDir === null
+    ? "no cache directory resolved (NEAT_AI_WASM_CACHE_DIR / XDG_CACHE_HOME / " +
+      "HOME unset, env access denied, or caching disabled)"
+    : undefined;
   const cachePath = cacheDir === null
     ? null
     : await wasmCacheFilePath(wasmUrl, cacheDir);
@@ -240,11 +296,20 @@ export async function loadWasmBundleBytes(
   if (cachePath !== null) {
     const cached = await readCache(cachePath);
     if (cached !== null) {
-      return cached;
+      return {
+        bytes: cached,
+        diagnostics: {
+          outcome: "hit",
+          cacheDir,
+          byteLength: cached.byteLength,
+          elapsedMs: now() - start,
+        },
+      };
     }
   }
 
-  // Cache miss: fetch with backoff, then persist for the next start.
+  // Cache miss (or disabled): fetch with backoff, then persist when caching is
+  // enabled so the next start is offline.
   const bytes = await fetchWithRetry(
     wasmUrl,
     fetchFn,
@@ -255,5 +320,14 @@ export async function loadWasmBundleBytes(
   if (cachePath !== null) {
     await writeCache(cachePath, bytes);
   }
-  return bytes;
+  return {
+    bytes,
+    diagnostics: {
+      outcome: cacheDir === null ? "disabled" : "miss",
+      cacheDir,
+      disabledReason,
+      byteLength: bytes.byteLength,
+      elapsedMs: now() - start,
+    },
+  };
 }

--- a/src/wasm/WasmInitDiagnostics.ts
+++ b/src/wasm/WasmInitDiagnostics.ts
@@ -1,0 +1,211 @@
+/**
+ * WASM / worker init-phase timing diagnostics (Issue #3494).
+ *
+ * When a discovery-replay (or any pooled) worker fails to answer its init
+ * handshake within the 60s deadline (`NEAT_AI_WORKER_INIT_TIMEOUT_MS`), the
+ * old error — "no response after 60s. Worker may have crashed or be stuck
+ * loading WASM." — was a *guess*, not a *measurement*. This module is the
+ * single source of truth for the timing/format contract that makes the stall
+ * diagnosable, without changing the self-healing fallback behaviour.
+ *
+ * ## The greppable log-line contract
+ *
+ * GRQ health tooling (`discovery_worker_fallback_health.sh`) matches on fixed
+ * substrings, so the shape below is a **contract** — keep the prefix and field
+ * keys stable. Two line shapes share the {@link WASM_WORKER_INIT_LOG_PREFIX}
+ * prefix so both are greppable:
+ *
+ * 1. **Normal path** — one compact `info`-level line per worker init (always
+ *    on, never behind a debug flag):
+ *
+ *    ```text
+ *    [WasmWorkerInit] worker=worker-3 outcome=ok handshakeMs=42 cache=hit \
+ *      cacheDir=/home/u/.cache/neat-ai/wasm bundleBytes=1234567 bundleLoadMs=3 \
+ *      glueImportMs=12 instantiateMs=27 wasmTotalMs=42 workerError=none
+ *    ```
+ *
+ * 2. **Timeout path** — the phase breakdown is embedded in the *thrown error
+ *    message*, so it lands after the trailing `Error:` token of the
+ *    `[…] Worker init failed …` log line and flows into GRQ's `firstError=`
+ *    field with no extra plumbing:
+ *
+ *    ```text
+ *    [WasmWorkerInit] Worker init: no response after 60s (worker=worker-3). \
+ *      Parent-observed: handshakeMs=60001 workerError=none wasm[cache=hit …]. \
+ *      Child WASM phase timings unknown — the worker never answered …
+ *    ```
+ *
+ * The phrases "no response after Ns" and "stuck loading WASM" are preserved so
+ * existing operator greps keep matching.
+ *
+ * The WASM phases (bundle cache resolve/read, wasm-bindgen glue import, and
+ * `WebAssembly.instantiate`) are measured on the **parent/main thread** by
+ * `initWasmActivation` and stashed here via
+ * {@link recordWasmActivationInitDiagnostics}. On a handshake timeout the
+ * *child's* internal phases are unknowable — the worker never answered — so the
+ * timeout line reports only what the parent can see and says so explicitly,
+ * rather than printing zeros that read as "instant".
+ *
+ * @module
+ */
+
+/** Fixed, greppable prefix shared by the info line and the timeout error. */
+export const WASM_WORKER_INIT_LOG_PREFIX = "[WasmWorkerInit]";
+
+/**
+ * Outcome of resolving/reading the cached WASM bundle:
+ *
+ * - `hit` — bytes served from the version-keyed on-disk cache (no network);
+ * - `miss` — cache directory resolved but empty, so bytes were fetched and
+ *   then persisted for the next start;
+ * - `disabled` — no cache directory could be resolved (env access denied, no
+ *   `HOME`, or caching switched off), so *every* start hits the network;
+ * - `local` — a `file:` build read the vendored bundle directly (no cache,
+ *   no network).
+ */
+export type WasmBundleCacheOutcome = "hit" | "miss" | "disabled" | "local";
+
+/** Timing + outcome for the bundle cache-resolve/read phase. */
+export interface WasmBundleLoadDiagnostics {
+  /** How the bundle bytes were obtained. */
+  outcome: WasmBundleCacheOutcome;
+  /** The resolved cache directory, or `null` when caching is disabled/local. */
+  cacheDir: string | null;
+  /** Human-readable reason caching was skipped (only set when disabled). */
+  disabledReason?: string;
+  /** Bundle size in bytes, or a negative sentinel when not observed. */
+  byteLength: number;
+  /** Wall-clock spent in the bundle-load phase, in milliseconds. */
+  elapsedMs: number;
+}
+
+/** Per-phase timings for a single main-thread WASM activation init. */
+export interface WasmActivationInitDiagnostics {
+  /** Bundle cache resolve/read phase. */
+  bundle: WasmBundleLoadDiagnostics;
+  /** Milliseconds spent `import()`ing the wasm-bindgen JS glue. */
+  glueImportMs: number;
+  /** Milliseconds spent in `module.default()` (compile + instantiate). */
+  instantiateMs: number;
+  /** Total milliseconds across all three phases. */
+  totalMs: number;
+}
+
+let lastInitDiagnostics: WasmActivationInitDiagnostics | null = null;
+
+/**
+ * Record the phase timings from the most recent main-thread WASM activation
+ * init. Called by `initWasmActivation`; read by the worker init sequence.
+ */
+export function recordWasmActivationInitDiagnostics(
+  diagnostics: WasmActivationInitDiagnostics,
+): void {
+  lastInitDiagnostics = diagnostics;
+}
+
+/**
+ * The phase timings from the most recent successful main-thread WASM
+ * activation init, or `null` when WASM was never initialised on this thread.
+ */
+export function getLastWasmActivationInitDiagnostics():
+  | WasmActivationInitDiagnostics
+  | null {
+  return lastInitDiagnostics;
+}
+
+/** Clears the recorded diagnostics. Intended for test isolation. */
+export function resetWasmActivationInitDiagnostics(): void {
+  lastInitDiagnostics = null;
+}
+
+/** Round a millisecond value to an integer, or `?` when not measured. */
+function ms(value: number | undefined): string {
+  return value === undefined ? "?" : String(Math.round(value));
+}
+
+/** Byte count field, or `?` for the not-observed sentinel (negative). */
+function bytesField(byteLength: number | undefined): string {
+  return byteLength === undefined || byteLength < 0 ? "?" : String(byteLength);
+}
+
+/** Single-line, greppable rendering of the captured worker `error` event. */
+function workerErrorField(workerError?: Error): string {
+  if (!workerError) return "none";
+  // JSON.stringify keeps the value on one line and quotes embedded spaces.
+  return JSON.stringify(workerError.message);
+}
+
+/** The `cache=…`/`cacheDir=…`/`bundleBytes=…` fields for a bundle phase. */
+function bundleFields(wasm: WasmActivationInitDiagnostics | null): string {
+  const cache = wasm ? wasm.bundle.outcome : "unknown";
+  const cacheDir = wasm ? (wasm.bundle.cacheDir ?? "none") : "none";
+  const bundleBytes = wasm ? bytesField(wasm.bundle.byteLength) : "?";
+  return `cache=${cache} cacheDir=${cacheDir} bundleBytes=${bundleBytes} ` +
+    `bundleLoadMs=${ms(wasm?.bundle.elapsedMs)} ` +
+    `glueImportMs=${ms(wasm?.glueImportMs)} ` +
+    `instantiateMs=${ms(wasm?.instantiateMs)} ` +
+    `wasmTotalMs=${ms(wasm?.totalMs)}`;
+}
+
+/** Inputs to {@link formatWorkerInitDiagnostics}. */
+export interface WorkerInitLineInput {
+  /** Stable label identifying the worker slot (e.g. `worker-3`). */
+  workerLabel: string;
+  /** Parent-observed handshake time (init request → response), in ms. */
+  handshakeMs: number;
+  /** Recorded main-thread WASM phase timings, or `null` when unmeasured. */
+  wasm: WasmActivationInitDiagnostics | null;
+  /** Any worker `error`/`messageerror` captured during init. */
+  workerError?: Error;
+}
+
+/**
+ * Format the always-on, `info`-level line emitted once per successful worker
+ * init. Shape is the greppable contract documented on this module.
+ */
+export function formatWorkerInitDiagnostics(
+  input: WorkerInitLineInput,
+): string {
+  const { workerLabel, handshakeMs, wasm, workerError } = input;
+  return `${WASM_WORKER_INIT_LOG_PREFIX} worker=${workerLabel} outcome=ok ` +
+    `handshakeMs=${ms(handshakeMs)} ${bundleFields(wasm)} ` +
+    `workerError=${workerErrorField(workerError)}`;
+}
+
+/** Inputs to {@link formatWorkerInitTimeout}. */
+export interface WorkerInitTimeoutInput {
+  /** Stable label identifying the worker slot (e.g. `worker-3`). */
+  workerLabel: string;
+  /** The configured init timeout, in ms. */
+  timeoutMs: number;
+  /** Parent-observed elapsed time from init start to the timeout, in ms. */
+  elapsedMs: number;
+  /** Recorded main-thread WASM phase timings, or `null` when unmeasured. */
+  wasm: WasmActivationInitDiagnostics | null;
+  /** Any worker `error`/`messageerror` captured during init. */
+  workerError?: Error;
+}
+
+/**
+ * Build the timeout error message. The breakdown is embedded here (not merely
+ * logged) so it survives into the caller's `Error:`-suffixed fallback log line
+ * and GRQ's `firstError=` field. Child-side phase timings are explicitly
+ * flagged unknown, since a worker that never answered cannot report them.
+ */
+export function formatWorkerInitTimeout(
+  input: WorkerInitTimeoutInput,
+): string {
+  const { workerLabel, timeoutMs, elapsedMs, wasm, workerError } = input;
+  const seconds = Math.round(timeoutMs / 1000);
+  const parentWasm = wasm
+    ? `wasm[${bundleFields(wasm)}]`
+    : "wasm[not-measured]";
+  return `${WASM_WORKER_INIT_LOG_PREFIX} Worker init: no response after ` +
+    `${seconds}s (worker=${workerLabel}). Parent-observed: ` +
+    `handshakeMs=${ms(elapsedMs)} workerError=${
+      workerErrorField(workerError)
+    } ` +
+    `${parentWasm}. Child WASM phase timings unknown — the worker never ` +
+    `answered the init handshake (may be stuck loading WASM, CPU-starved, ` +
+    `or OOM).`;
+}

--- a/src/wasm/WasmModuleLoader.ts
+++ b/src/wasm/WasmModuleLoader.ts
@@ -12,7 +12,11 @@
 
 import { getLogger } from "@utils/Logger.ts";
 import type { WasmCompiledNetworkConstructor } from "@wasm/WasmCompiledNetwork.ts";
-import { loadWasmBundleBytes } from "@wasm/WasmBundleCache.ts";
+import { loadWasmBundleBytesWithDiagnostics } from "@wasm/WasmBundleCache.ts";
+import {
+  recordWasmActivationInitDiagnostics,
+  type WasmBundleLoadDiagnostics,
+} from "@wasm/WasmInitDiagnostics.ts";
 
 // deno-lint-ignore no-explicit-any
 type WasmModule = any;
@@ -492,19 +496,36 @@ export async function initWasmActivation(): Promise<boolean> {
 
   initPromise = (async () => {
     try {
+      // Issue #3494: measure the init phases so a downstream worker-init
+      // timeout is diagnosable. `performance.now()` is the right tool here —
+      // these are elapsed-time deltas, not wall-clock instants.
+      const initStart = performance.now();
       const modulePath =
         new URL("../../wasm_activation/pkg/wasm_activation.js", import.meta.url)
           .href;
+      const glueStart = performance.now();
       const module = await import(modulePath);
+      const glueImportMs = performance.now() - glueStart;
       const wasmUrl = new URL(
         "../../wasm_activation/pkg/wasm_activation_bg.wasm",
         import.meta.url,
       );
+      let bundle: WasmBundleLoadDiagnostics;
+      let instantiateMs: number;
       if (wasmUrl.protocol === "file:") {
         // Local build: the vendored bundle is on disk beside the JS glue.
         // wasm-bindgen's default init reads it directly (no network) and names
-        // the WASM module after the file for readable trap stacks.
+        // the WASM module after the file for readable trap stacks — so the
+        // bundle byte length is not observed on this path (sentinel -1).
+        const instantiateStart = performance.now();
         await module.default();
+        instantiateMs = performance.now() - instantiateStart;
+        bundle = {
+          outcome: "local",
+          cacheDir: null,
+          byteLength: -1,
+          elapsedMs: 0,
+        };
       } else {
         // Issue #3419: cache-first bundle loading for remote (JSR) installs.
         // Read the immutable, version-keyed bundle from the local cache (no
@@ -512,11 +533,23 @@ export async function initWasmActivation(): Promise<boolean> {
         // Passing the bytes to the init avoids wasm-bindgen's default
         // fetch-at-startup from jsr.io, which crashed breeding on a transient
         // DNS failure (recurrence of #3230).
-        const wasmBytes = await loadWasmBundleBytes(wasmUrl);
+        const { bytes: wasmBytes, diagnostics } =
+          await loadWasmBundleBytesWithDiagnostics(wasmUrl);
+        bundle = diagnostics;
+        const instantiateStart = performance.now();
         await module.default({ module_or_path: wasmBytes });
+        instantiateMs = performance.now() - instantiateStart;
       }
       assignFunctionPointers(module);
       lastLoadError = null;
+      // Issue #3494: stash the phase timings for the worker init sequence to
+      // fold into its per-init info line and any timeout breakdown.
+      recordWasmActivationInitDiagnostics({
+        bundle,
+        glueImportMs,
+        instantiateMs,
+        totalMs: performance.now() - initStart,
+      });
       return true;
     } catch (error) {
       lastLoadError = toError(error);

--- a/src/workers/WorkerHandlerBase.ts
+++ b/src/workers/WorkerHandlerBase.ts
@@ -18,6 +18,11 @@ import type {
   WorkerInterface,
 } from "@workers/WorkerInterface.ts";
 import { getLogger, type Logger } from "@utils/Logger.ts";
+import {
+  formatWorkerInitDiagnostics,
+  formatWorkerInitTimeout,
+  getLastWasmActivationInitDiagnostics,
+} from "@wasm/WasmInitDiagnostics.ts";
 
 interface WorkerEventListener<THandler> {
   (worker: THandler): void;
@@ -304,25 +309,41 @@ export abstract class WorkerHandlerBase<
    *
    * Wraps a `makePromise` call with a timeout and races against an
    * init-error promise so that worker crashes during startup cause fast failure.
+   *
+   * Issue #3494: emits one compact, greppable `info` line per successful init
+   * (the `[WasmWorkerInit]` contract — always on, never gated) and, on a
+   * handshake timeout, embeds the parent-observed phase breakdown in the
+   * thrown error message so the stall is diagnosable from the log alone. This
+   * base method is the single choke point every pooled worker reaches via
+   * `waitUntilReady()`, so instrumenting it here covers every fallback site
+   * (discovery replay, discovery, improve-squash, creature training, episode
+   * pool) without per-site changes.
+   *
+   * @param workerLabel - Stable label for the worker slot (e.g. `worker-3`),
+   *   used in the diagnostics line. Defaults to `worker-<workerID>`.
    */
   protected createInitSequence(
     initRequest: TRequest,
     initErrorPromise: Promise<never>,
     timeoutMs: number,
+    workerLabel: string = `worker-${this.workerID}`,
   ): Promise<TResponse> {
+    // Elapsed-time measurement (parent-observed handshake), not a wall-clock
+    // instant — `performance.now()` is the correct tool per project policy.
+    const startMs = performance.now();
     const initSequence = async (): Promise<TResponse> =>
       await new Promise<TResponse>((resolve, reject) => {
         const timeoutId = setTimeout(
           () =>
             reject(
               new Error(
-                `Worker init: no response after ${
-                  timeoutMs / 1000
-                }s. Worker may have crashed or be stuck loading WASM.${
-                  this.initWorkerError
-                    ? ` First worker error: ${this.initWorkerError.message}`
-                    : ""
-                }`,
+                formatWorkerInitTimeout({
+                  workerLabel,
+                  timeoutMs,
+                  elapsedMs: performance.now() - startMs,
+                  wasm: getLastWasmActivationInitDiagnostics(),
+                  workerError: this.initWorkerError,
+                }),
               ),
             ),
           timeoutMs,
@@ -339,7 +360,18 @@ export abstract class WorkerHandlerBase<
         );
       });
 
-    return Promise.race([initSequence(), initErrorPromise]);
+    return Promise.race([initSequence(), initErrorPromise]).then((result) => {
+      // Normal path: one always-on structured line per worker init.
+      getLogger().info(
+        formatWorkerInitDiagnostics({
+          workerLabel,
+          handshakeMs: performance.now() - startMs,
+          wasm: getLastWasmActivationInitDiagnostics(),
+          workerError: this.initWorkerError,
+        }),
+      );
+      return result;
+    });
   }
 
   /**

--- a/test/wasm/WasmInitDiagnostics.ts
+++ b/test/wasm/WasmInitDiagnostics.ts
@@ -1,0 +1,250 @@
+/**
+ * Issue #3494 — Init-phase timing diagnostics for WASM/worker startup.
+ *
+ * These tests pin the timing/format **contract** that makes a worker-init
+ * timeout diagnosable:
+ *
+ *   1. {@link loadWasmBundleBytesWithDiagnostics} reports the cache
+ *      hit/miss/disabled/local outcome, the resolved cache directory, the
+ *      bundle byte length, and elapsed ms — driven through the injectable
+ *      `fetchFn` / `sleepFn` / `cacheDir` / `now` options.
+ *   2. The greppable log-line formatters ({@link formatWorkerInitDiagnostics},
+ *      {@link formatWorkerInitTimeout}) emit the fixed prefix and field keys
+ *      GRQ health tooling matches on, including the "child phases unknown"
+ *      case on the timeout path.
+ */
+
+import { assert, assertEquals, assertStringIncludes } from "@std/assert";
+import {
+  loadWasmBundleBytesWithDiagnostics,
+  wasmCacheFilePath,
+} from "@wasm/WasmBundleCache.ts";
+import {
+  formatWorkerInitDiagnostics,
+  formatWorkerInitTimeout,
+  getLastWasmActivationInitDiagnostics,
+  recordWasmActivationInitDiagnostics,
+  resetWasmActivationInitDiagnostics,
+  WASM_WORKER_INIT_LOG_PREFIX,
+  type WasmActivationInitDiagnostics,
+} from "@wasm/WasmInitDiagnostics.ts";
+
+const BUNDLE_URL = new URL(
+  "https://jsr.io/@stsoftware/neat-ai/9.9.9/wasm_activation/pkg/wasm_activation_bg.wasm",
+);
+
+/** A monotonic clock returning a fixed sequence of values (deterministic ms). */
+function fakeClock(values: number[]): () => number {
+  let i = 0;
+  return () => values[Math.min(i++, values.length - 1)];
+}
+
+/** A Response carrying the given bytes. */
+function bytesResponse(bytes: Uint8Array): Response {
+  return new Response(bytes as unknown as BodyInit, { status: 200 });
+}
+
+const noSleep = (_ms: number): Promise<void> => Promise.resolve();
+
+/** A fetch that fails the test if it is ever called. */
+function denyFetch(): typeof fetch {
+  return (() => {
+    throw new Error("network access attempted on a cache hit");
+  }) as unknown as typeof fetch;
+}
+
+Deno.test("WasmInitDiagnostics: cache hit reports outcome/dir/bytes/elapsed", async () => {
+  const cacheDir = await Deno.makeTempDir();
+  try {
+    const seeded = new Uint8Array([1, 2, 3, 4, 5]);
+    const cachePath = await wasmCacheFilePath(BUNDLE_URL, cacheDir);
+    await Deno.writeFile(cachePath, seeded);
+
+    const { bytes, diagnostics } = await loadWasmBundleBytesWithDiagnostics(
+      BUNDLE_URL,
+      {
+        cacheDir,
+        fetchFn: denyFetch(),
+        sleepFn: noSleep,
+        now: fakeClock([100, 103]),
+      },
+    );
+
+    assertEquals(bytes, seeded);
+    assertEquals(diagnostics.outcome, "hit");
+    assertEquals(diagnostics.cacheDir, cacheDir);
+    assertEquals(diagnostics.byteLength, 5);
+    assertEquals(diagnostics.elapsedMs, 3);
+    assertEquals(diagnostics.disabledReason, undefined);
+  } finally {
+    await Deno.remove(cacheDir, { recursive: true });
+  }
+});
+
+Deno.test("WasmInitDiagnostics: cache miss fetches, persists, reports miss", async () => {
+  const cacheDir = await Deno.makeTempDir();
+  try {
+    const payload = new Uint8Array([9, 8, 7, 6]);
+    const fetchFn = ((_url: URL) =>
+      Promise.resolve(bytesResponse(payload))) as unknown as typeof fetch;
+
+    const { bytes, diagnostics } = await loadWasmBundleBytesWithDiagnostics(
+      BUNDLE_URL,
+      { cacheDir, fetchFn, sleepFn: noSleep, now: fakeClock([0, 42]) },
+    );
+
+    assertEquals(bytes, payload);
+    assertEquals(diagnostics.outcome, "miss");
+    assertEquals(diagnostics.cacheDir, cacheDir);
+    assertEquals(diagnostics.byteLength, 4);
+    assertEquals(diagnostics.elapsedMs, 42);
+
+    // The miss persisted the bundle for the next (offline) start.
+    const persisted = await Deno.readFile(
+      await wasmCacheFilePath(BUNDLE_URL, cacheDir),
+    );
+    assertEquals(persisted, payload);
+  } finally {
+    await Deno.remove(cacheDir, { recursive: true });
+  }
+});
+
+Deno.test("WasmInitDiagnostics: caching disabled fetches and reports a reason", async () => {
+  const payload = new Uint8Array([1, 1, 2, 3, 5]);
+  let attempts = 0;
+  const fetchFn = ((_url: URL) => {
+    attempts++;
+    return Promise.resolve(bytesResponse(payload));
+  }) as unknown as typeof fetch;
+
+  const { bytes, diagnostics } = await loadWasmBundleBytesWithDiagnostics(
+    BUNDLE_URL,
+    // cacheDir: null forces the disabled branch deterministically.
+    { cacheDir: null, fetchFn, sleepFn: noSleep, now: fakeClock([0, 7]) },
+  );
+
+  assertEquals(bytes, payload);
+  assertEquals(attempts, 1, "disabled caching still fetches exactly once");
+  assertEquals(diagnostics.outcome, "disabled");
+  assertEquals(diagnostics.cacheDir, null);
+  assertEquals(diagnostics.byteLength, 5);
+  assertEquals(diagnostics.elapsedMs, 7);
+  assert(
+    diagnostics.disabledReason && diagnostics.disabledReason.length > 0,
+    "disabled outcome carries an explicit reason",
+  );
+});
+
+Deno.test("WasmInitDiagnostics: file URL reports the local outcome", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const local = new Uint8Array([42, 43, 44]);
+    const filePath = `${dir}/wasm_activation_bg.wasm`;
+    await Deno.writeFile(filePath, local);
+
+    const { bytes, diagnostics } = await loadWasmBundleBytesWithDiagnostics(
+      new URL(`file://${filePath}`),
+      { fetchFn: denyFetch(), sleepFn: noSleep, now: fakeClock([5, 9]) },
+    );
+
+    assertEquals(bytes, local);
+    assertEquals(diagnostics.outcome, "local");
+    assertEquals(diagnostics.cacheDir, null);
+    assertEquals(diagnostics.byteLength, 3);
+    assertEquals(diagnostics.elapsedMs, 4);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+const SAMPLE_WASM: WasmActivationInitDiagnostics = {
+  bundle: {
+    outcome: "hit",
+    cacheDir: "/home/u/.cache/neat-ai/wasm",
+    byteLength: 1234567,
+    elapsedMs: 3,
+  },
+  glueImportMs: 12,
+  instantiateMs: 27,
+  totalMs: 42,
+};
+
+Deno.test("WasmInitDiagnostics: info line carries the greppable contract", () => {
+  const line = formatWorkerInitDiagnostics({
+    workerLabel: "worker-3",
+    handshakeMs: 42.4,
+    wasm: SAMPLE_WASM,
+  });
+
+  assertStringIncludes(line, `${WASM_WORKER_INIT_LOG_PREFIX} worker=worker-3`);
+  assertStringIncludes(line, "outcome=ok");
+  assertStringIncludes(line, "handshakeMs=42");
+  assertStringIncludes(line, "cache=hit");
+  assertStringIncludes(line, "cacheDir=/home/u/.cache/neat-ai/wasm");
+  assertStringIncludes(line, "bundleBytes=1234567");
+  assertStringIncludes(line, "bundleLoadMs=3");
+  assertStringIncludes(line, "glueImportMs=12");
+  assertStringIncludes(line, "instantiateMs=27");
+  assertStringIncludes(line, "wasmTotalMs=42");
+  assertStringIncludes(line, "workerError=none");
+});
+
+Deno.test("WasmInitDiagnostics: info line marks unmeasured WASM phases with ?", () => {
+  const line = formatWorkerInitDiagnostics({
+    workerLabel: "worker-9",
+    handshakeMs: 5,
+    wasm: null,
+  });
+
+  assertStringIncludes(line, "cache=unknown");
+  assertStringIncludes(line, "bundleBytes=?");
+  assertStringIncludes(line, "bundleLoadMs=?");
+  assertStringIncludes(line, "wasmTotalMs=?");
+});
+
+Deno.test("WasmInitDiagnostics: timeout message embeds the parent-observed breakdown", () => {
+  const message = formatWorkerInitTimeout({
+    workerLabel: "worker-3",
+    timeoutMs: 60_000,
+    elapsedMs: 60_001,
+    wasm: SAMPLE_WASM,
+    workerError: new Error("boom"),
+  });
+
+  // Preserved phrases so existing operator greps keep matching.
+  assertStringIncludes(message, "no response after 60s");
+  assertStringIncludes(message, "stuck loading WASM");
+  // The greppable prefix and parent-observed breakdown.
+  assertStringIncludes(message, WASM_WORKER_INIT_LOG_PREFIX);
+  assertStringIncludes(message, "worker=worker-3");
+  assertStringIncludes(message, "handshakeMs=60001");
+  assertStringIncludes(message, "wasm[cache=hit");
+  assertStringIncludes(message, "bundleBytes=1234567");
+  assertStringIncludes(message, `workerError=${JSON.stringify("boom")}`);
+  // Child phases are explicitly unknown, not reported as zero.
+  assertStringIncludes(message, "Child WASM phase timings unknown");
+});
+
+Deno.test("WasmInitDiagnostics: timeout message flags unmeasured WASM explicitly", () => {
+  const message = formatWorkerInitTimeout({
+    workerLabel: "episode-worker-1",
+    timeoutMs: 30_000,
+    elapsedMs: 30_000,
+    wasm: null,
+  });
+
+  assertStringIncludes(message, "no response after 30s");
+  assertStringIncludes(message, "wasm[not-measured]");
+  assertStringIncludes(message, "workerError=none");
+});
+
+Deno.test("WasmInitDiagnostics: record/get/reset round-trips the last diagnostics", () => {
+  resetWasmActivationInitDiagnostics();
+  assertEquals(getLastWasmActivationInitDiagnostics(), null);
+
+  recordWasmActivationInitDiagnostics(SAMPLE_WASM);
+  assertEquals(getLastWasmActivationInitDiagnostics(), SAMPLE_WASM);
+
+  resetWasmActivationInitDiagnostics();
+  assertEquals(getLastWasmActivationInitDiagnostics(), null);
+});

--- a/test/workers/WorkerInitDiagnostics.ts
+++ b/test/workers/WorkerInitDiagnostics.ts
@@ -1,0 +1,204 @@
+/**
+ * Issue #3494 — `createInitSequence` diagnostics wiring.
+ *
+ * `WorkerHandlerBase.createInitSequence` is the single choke point every
+ * pooled worker reaches via `waitUntilReady()`. These tests verify that it:
+ *
+ *   1. emits exactly one compact, greppable `[WasmWorkerInit]` `info` line per
+ *      successful init (always on — the diagnostic must exist before the rare
+ *      stall recurs); and
+ *   2. throws a timeout error whose message carries the parent-observed phase
+ *      breakdown, so it lands after the caller's trailing `Error:` token.
+ */
+
+import { assert, assertRejects, assertStringIncludes } from "@std/assert";
+import type {
+  BaseRequestData,
+  BaseResponseData,
+  WorkerInterface,
+} from "@workers/WorkerInterface.ts";
+import { WorkerHandlerBase } from "@workers/WorkerHandlerBase.ts";
+import { getLogger, type Logger, setLogger } from "@utils/Logger.ts";
+import {
+  recordWasmActivationInitDiagnostics,
+  resetWasmActivationInitDiagnostics,
+  WASM_WORKER_INIT_LOG_PREFIX,
+} from "@wasm/WasmInitDiagnostics.ts";
+
+interface TestRequest extends BaseRequestData {
+  initialize?: { payload: string };
+}
+interface TestResponse extends BaseResponseData {
+  initialize?: { status: string };
+}
+
+/** A mock worker that either answers the init message or never does. */
+class MockWorker implements WorkerInterface<TestRequest> {
+  private callBack: EventListener | null = null;
+  constructor(private readonly respond: boolean) {}
+
+  addEventListener(
+    _type: string,
+    listener: EventListenerOrEventListenerObject,
+  ): void {
+    this.callBack = listener as EventListener;
+  }
+
+  postMessage(data: TestRequest): void {
+    if (!this.respond) return; // simulate a stuck worker
+    queueMicrotask(() => {
+      const response: TestResponse = {
+        taskID: data.taskID,
+        duration: 1,
+        initialize: { status: "OK" },
+      };
+      type MockEvent = Event & { data: TestResponse };
+      const me = new Event("message") as MockEvent;
+      me.data = response;
+      this.callBack?.(me);
+    });
+  }
+
+  terminate(): void {
+    this.callBack = null;
+  }
+}
+
+class Handler extends WorkerHandlerBase<TestRequest, TestResponse> {
+  runInit(
+    req: TestRequest,
+    errP: Promise<never>,
+    timeoutMs: number,
+    label: string,
+  ): Promise<TestResponse> {
+    return this.createInitSequence(req, errP, timeoutMs, label);
+  }
+
+  setInitError(err: Error): void {
+    this.initWorkerError = err;
+  }
+}
+
+/** Capture `info` output while running `fn`, restoring the logger after. */
+async function captureInfo(fn: () => Promise<void>): Promise<string[]> {
+  const lines: string[] = [];
+  const original = getLogger();
+  const capturing: Logger = {
+    debug() {},
+    info(...args: unknown[]) {
+      lines.push(args.map(String).join(" "));
+    },
+    warn() {},
+    error() {},
+  };
+  setLogger(capturing);
+  try {
+    await fn();
+  } finally {
+    setLogger(original);
+  }
+  return lines;
+}
+
+Deno.test("createInitSequence: emits one info line per successful init", async () => {
+  resetWasmActivationInitDiagnostics();
+  recordWasmActivationInitDiagnostics({
+    bundle: {
+      outcome: "hit",
+      cacheDir: "/tmp/neat-ai/wasm",
+      byteLength: 4242,
+      elapsedMs: 2,
+    },
+    glueImportMs: 10,
+    instantiateMs: 20,
+    totalMs: 32,
+  });
+
+  const mock = new MockWorker(true);
+  const handler = new Handler(
+    mock,
+    Promise.resolve({
+      taskID: 0,
+      duration: 0,
+      initialize: { status: "OK" },
+    }),
+  );
+
+  const lines = await captureInfo(async () => {
+    const never = new Promise<never>(() => {});
+    const result = await handler.runInit(
+      { taskID: 1, initialize: { payload: "x" } },
+      never,
+      5_000,
+      "worker-42",
+    );
+    assert(result.initialize?.status === "OK");
+  });
+
+  const initLines = lines.filter((l) =>
+    l.includes(WASM_WORKER_INIT_LOG_PREFIX)
+  );
+  assert(initLines.length === 1, "exactly one init line per successful init");
+  const line = initLines[0];
+  assertStringIncludes(line, "worker=worker-42");
+  assertStringIncludes(line, "outcome=ok");
+  assertStringIncludes(line, "cache=hit");
+  assertStringIncludes(line, "bundleBytes=4242");
+  assertStringIncludes(line, "glueImportMs=10");
+  assertStringIncludes(line, "workerError=none");
+
+  handler.terminate();
+  resetWasmActivationInitDiagnostics();
+});
+
+Deno.test("createInitSequence: timeout error carries the phase breakdown", async () => {
+  resetWasmActivationInitDiagnostics();
+  recordWasmActivationInitDiagnostics({
+    bundle: {
+      outcome: "miss",
+      cacheDir: "/tmp/neat-ai/wasm",
+      byteLength: 9001,
+      elapsedMs: 4,
+    },
+    glueImportMs: 8,
+    instantiateMs: 15,
+    totalMs: 27,
+  });
+
+  const mock = new MockWorker(false); // never answers the init handshake
+  const handler = new Handler(
+    mock,
+    Promise.resolve({
+      taskID: 0,
+      duration: 0,
+      initialize: { status: "OK" },
+    }),
+  );
+  handler.setInitError(new Error("worker error event"));
+
+  const never = new Promise<never>(() => {});
+  const error = await assertRejects(
+    () =>
+      handler.runInit(
+        { taskID: 1, initialize: { payload: "x" } },
+        never,
+        100,
+        "worker-7",
+      ),
+    Error,
+    "no response after",
+  );
+
+  assertStringIncludes(error.message, WASM_WORKER_INIT_LOG_PREFIX);
+  assertStringIncludes(error.message, "worker=worker-7");
+  assertStringIncludes(error.message, "wasm[cache=miss");
+  assertStringIncludes(error.message, "bundleBytes=9001");
+  assertStringIncludes(error.message, "Child WASM phase timings unknown");
+  assertStringIncludes(
+    error.message,
+    `workerError=${JSON.stringify("worker error event")}`,
+  );
+
+  handler.terminate();
+  resetWasmActivationInitDiagnostics();
+});


### PR DESCRIPTION
# Add init-phase timing diagnostics to WASM/worker startup

## Summary

On GRQ-23 a discovery-replay worker once failed to initialise and logged
`Worker init: no response after 60s. Worker may have crashed or be stuck
loading WASM.`
— a **guess**, not a measurement. From the log alone it was impossible to tell
whether the 60s went on the bundle cache read, the wasm-bindgen glue `import()`,
`WebAssembly.instantiate`, or the worker handshake itself. This change
instruments the three init phases so the _next_ occurrence is diagnosable, while
leaving the self-healing direct-execution fallback exactly as it was. Closes
#3494.

What changed:

- **`src/wasm/WasmInitDiagnostics.ts` (new)** — single source of truth for the
  greppable `[WasmWorkerInit]` log-line contract: the info-line and
  timeout-breakdown formatters, plus a per-thread store for the recorded WASM
  phase timings. The contract is documented in the module doc comment.
- **`src/wasm/WasmBundleCache.ts`** — `loadWasmBundleBytesWithDiagnostics`
  reports the cache `hit` / `miss` / `disabled` / `local` outcome, the resolved
  cache directory (or an explicit _caching disabled_ reason when
  `resolveCacheDir()` returns `null`), the bundle byte length, and elapsed ms.
  Injectable `now` and `cacheDir: null` make every branch deterministically
  testable; `loadWasmBundleBytes` is unchanged for existing callers.
- **`src/wasm/WasmModuleLoader.ts`** — `initWasmActivation` measures the glue
  `import()`, the bundle load, and `module.default()` (compile + instantiate)
  and records them for the worker init sequence to fold in.
- **`src/workers/WorkerHandlerBase.ts`** — `createInitSequence` emits **one**
  always-on `info` line per successful init and, on timeout, embeds the
  parent-observed phase breakdown in the _thrown error message_ so it lands
  after the trailing `Error:` token of the fallback log line (straight into
  GRQ's `firstError=` field). Because the worker never answered, the child's
  internal phases are flagged **unknown** rather than reported as zeros.

### Why one choke point covers all five fallback sites

Every worker-init fallback listed in the issue (`ReplayHelpers.ts`,
`DiscoveryRunner.ts`, `ImproveSquash.ts`, `CreatureTraining.ts`,
`EpisodeWorkerPool.ts`) reaches init through `waitUntilReady()` →
`createInitSequence`. Instrumenting that shared base method covers all of them
without per-site changes; each handler now just passes its worker label
(`worker-N` / `id-worker-N` / `episode-worker-N`).

```mermaid
flowchart TD
    subgraph Sites["5 fallback sites"]
        R[ReplayHelpers] --> W
        D[DiscoveryRunner] --> W
        I[ImproveSquash] --> W
        C[CreatureTraining] --> W
        E[EpisodeWorkerPool] --> W
    end
    W[waitUntilReady] --> CIS["createInitSequence (base)"]
    CIS -->|success| L["info: [WasmWorkerInit] worker=… outcome=ok …"]
    CIS -->|timeout| T["throw Error: [WasmWorkerInit] no response after Ns … child phases unknown"]
    IW["initWasmActivation<br/>(glue + bundle + instantiate ms)"] -.records.-> CIS
    BC["loadWasmBundleBytesWithDiagnostics<br/>(cache hit/miss/disabled ms)"] -.feeds.-> IW
```

### Deno regression avoided

Implemented entirely with Deno-native tooling and elapsed timing via
`performance.now()` (per the project's Temporal-vs-Date policy) — no Node-only
dependency or config was introduced.

## Evidence

Backend/CLI change with no web interface, so no screenshot. Verified via the new
unit tests and the full quality gate (`./quality.sh`):
`ok | 7936 passed (5 steps) | 0 failed | 4 ignored`.

Example info line produced (contract shape):

```text
[WasmWorkerInit] worker=worker-3 outcome=ok handshakeMs=42 cache=hit cacheDir=/home/u/.cache/neat-ai/wasm bundleBytes=1234567 bundleLoadMs=3 glueImportMs=12 instantiateMs=27 wasmTotalMs=42 workerError=none
```

Example timeout message (embedded in the thrown `Error`):

```text
[WasmWorkerInit] Worker init: no response after 60s (worker=worker-3). Parent-observed: handshakeMs=60001 workerError=none wasm[cache=hit cacheDir=… bundleBytes=1234567 bundleLoadMs=3 glueImportMs=12 instantiateMs=27 wasmTotalMs=42]. Child WASM phase timings unknown — the worker never answered the init handshake (may be stuck loading WASM, CPU-starved, or OOM).
```

## Test Plan

- `test/wasm/WasmInitDiagnostics.ts` — bundle diagnostics for the **cache-hit**,
  **cache-miss** (fetch + persist), **caching-disabled** (`cacheDir: null`), and
  **local `file:`** branches driven through the injectable
  `fetchFn`/`sleepFn`/`cacheDir`/`now` options; format-contract assertions for
  the info line and the timeout breakdown (including the `wasm=null`
  "unmeasured" cases); and `record`/`get`/`reset` round-trip.
- `test/workers/WorkerInitDiagnostics.ts` — `createInitSequence` emits exactly
  one `[WasmWorkerInit]` info line on success, and throws a timeout error
  carrying the parent-observed phase breakdown and the "child phases unknown"
  marker.
- Existing `test/wasm/WasmBundleCache.ts`, `test/wasm/WasmModuleLoader.ts`, and
  `test/workers/WorkerHandlerBase*.ts` suites still pass unchanged.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-ms2u6qz9-b8c8fe`<!-- vibe-worker-issue-3494 -->