### PR TITLE
🟡 Reword private GRQ worker-script and checkout paths in benches and performance docs (Issue #3457)

### DIFF
--- a/bench/SquashBudgetSelection.ts
+++ b/bench/SquashBudgetSelection.ts
@@ -7,10 +7,11 @@
  * evolutionary prior), not the activation kernel itself.
  *
  * It is a proxy for the intended production effect: a smaller, cheaper squash
- * mix flows through mutation into every generation's networks. The full GRQ
- * A/B (evolve wall-clock / `fitnessMs`) requires the production creature seed
- * and `../GRQ/.trainData-binary_115`, which are not available in this repo's
- * CI — see docs/PERFORMANCE_RESEARCH.md.
+ * mix flows through mutation into every generation's networks. The full
+ * production A/B (evolve wall-clock / `fitnessMs`) requires the production
+ * creature seed and the production training corpus (≈21 GiB, not
+ * distributable), which are not available in this repo's CI — see
+ * docs/PERFORMANCE_RESEARCH.md.
  *
  * Run with:
  *   deno bench --allow-all bench/SquashBudgetSelection.ts

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "5.9.41",
+  "version": "5.9.42",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/EVOLUTION_CONFIG_SWEEP_3400.md
+++ b/docs/EVOLUTION_CONFIG_SWEEP_3400.md
@@ -1,9 +1,9 @@
 # Evolution-mode / population / sample-rate configuration sweep
 
 > Issue #3400 (sub-issue of #3396) — tune the evolution-mode flags and
-> population / sample-rate parameters the production `worker/learn.sh` /
-> `worker/sampler.sh` (GRQ) scripts pass, to maximise **score improvement per
-> wall-clock hour** inside the production time-boxes.
+> population / sample-rate parameters the downstream production runner scripts
+> pass, to maximise **score improvement per wall-clock hour** inside the
+> production time-boxes.
 
 Source: [`bench/evolution_config_sweep.ts`](../bench/evolution_config_sweep.ts).
 Tests:
@@ -89,8 +89,8 @@ time-boxes.
 |    3 | pop50  |         50 |           5 |       -9.207e+30 |     6.760e+31 |      −34.6% |
 |    4 | pop30  |         30 |           8 |       -1.042e+31 |     5.398e+31 |      −47.8% |
 
-**`populationSize=20` — the current `worker/learn.sh` value — already maximises
-score-per-hour in the learn time-box.** No swept value beats it:
+**`populationSize=20` — the current downstream production runner value — already
+maximises score-per-hour in the learn time-box.** No swept value beats it:
 
 - `pop10` runs more generations but each is lower quality; it reaches a **worse
   final score** (flagged as a regression) _and_ a −32.6% score/hour.
@@ -128,21 +128,23 @@ wall-clock jitter — same score gained, slightly different elapsed time):
 These two knobs govern **backprop training** (`trainPerGen ≥ 1`), so they are
 no-ops for the deterministic pure-neuroevolution harness. A faithful measurement
 needs a non-deterministic `--train-per-gen ≥ 1` run on real `.trainData`, which
-belongs in the GRQ production environment — see the cross-repo GRQ issue.
+belongs in the downstream production environment — see the issue filed in the
+downstream production repo.
 
 ## Recommendation
 
-- **NEAT-AI defaults: no change.** The production settings the GRQ scripts pass
-  are already at (or validated against) the score-per-hour optimum on
-  production-scale data; no swept configuration improves score-per-hour without
-  regressing the final score. Changing an in-repo default would be an unbacked
-  regression risk.
-- **GRQ `worker/learn.sh` / `worker/sampler.sh`:** keep `populationSize=20` for
-  learn and the 20→50 sampler ramp — this sweep **validates** that design. The
+- **NEAT-AI defaults: no change.** The production settings the downstream
+  production runner scripts pass are already at (or validated against) the
+  score-per-hour optimum on production-scale data; no swept configuration
+  improves score-per-hour without regressing the final score. Changing an
+  in-repo default would be an unbacked regression risk.
+- **Downstream production runner scripts:** keep `populationSize=20` for learn
+  and the 20→50 sampler ramp — this sweep **validates** that design. The
   `trainingSampleRate` / `sparseRatio` knobs need an in-situ backprop sweep
   (`--train-per-gen ≥ 1` on real `.trainData`) that the deterministic in-repo
   harness cannot run; the reusable sweep tool here is the vehicle for it. Filed
-  as a cross-repo GRQ issue referencing #3400 with this evidence attached.
+  as an issue in the downstream production repo referencing #3400 with this
+  evidence attached.
 
 Evidence artefacts:
 [`docs/evidence/sweep-3400-time-boxed.md`](./evidence/sweep-3400-time-boxed.md),

--- a/docs/SCORE_PER_HOUR_HARNESS.md
+++ b/docs/SCORE_PER_HOUR_HARNESS.md
@@ -22,9 +22,9 @@ deno task bench:score-per-hour \
   --out=trajectory.json
 ```
 
-This drives the same production-scale synthetic topology used by
-`worker/learn.sh` / `worker/sampler.sh` — the `grq-3397` preset: **1,666 neurons
-/ ~21,513 synapses / 2,461 inputs** — from
+This drives the same production-scale synthetic topology used by the downstream
+production runner scripts — the `grq-3397` preset: **1,666 neurons / ~21,513
+synapses / 2,461 inputs** — from
 [`test/propagate/large/ProductionScaleCreature.ts`](../test/propagate/large/ProductionScaleCreature.ts),
 and writes a machine-readable JSON trajectory containing:
 

--- a/docs/archive/pr-summaries/pr-summary-3263.md
+++ b/docs/archive/pr-summaries/pr-summary-3263.md
@@ -63,11 +63,12 @@ predicted ("breeding is <5% of GRQ time"). The budget can only pay off
 population unlocks a measured GPU win — both live in the scoring path.
 
 The full GRQ evolve wall-clock / `fitnessMs` A/B requires the production
-creature seed, `../GRQ/.trainData-binary_115`, and the GPU scorer — none
-reachable from CI or an autonomous worker. That measurement, and the **≥5%**
-adoption gate that would flip the default, are deferred to a human on GRQ per
-milestone #3256 and documented in `docs/PERFORMANCE_RESEARCH.md`. The default
-stays **free mix**, so this PR adds **zero regression risk** by default.
+creature seed, the production training corpus (≈21 GiB, not distributable), and
+the GPU scorer — none reachable from CI or an autonomous worker. That
+measurement, and the **≥5%** adoption gate that would flip the default, are
+deferred to a human on GRQ per milestone #3256 and documented in
+`docs/PERFORMANCE_RESEARCH.md`. The default stays **free mix**, so this PR adds
+**zero regression risk** by default.
 
 ## Test Plan
 

--- a/docs/archive/pr-summaries/pr-summary-3457.md
+++ b/docs/archive/pr-summaries/pr-summary-3457.md
@@ -18,12 +18,12 @@ synthetic in-tree fixtures. **Closes #3457.**
 
 ### Reworded references
 
-| File | Was | Now |
-| ---- | --- | --- |
-| `bench/SquashBudgetSelection.ts` (10–13) | "The full GRQ A/B … `../GRQ/.trainData-binary_115`" | "The full production A/B … the production training corpus (≈21 GiB, not distributable)" |
-| `docs/archive/pr-summaries/pr-summary-3263.md` (66) | "`../GRQ/.trainData-binary_115`" | "the production training corpus (≈21 GiB, not distributable)" |
+| File                                                                | Was                                                                                                | Now                                                                                             |
+| ------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `bench/SquashBudgetSelection.ts` (10–13)                            | "The full GRQ A/B … `../GRQ/.trainData-binary_115`"                                                | "The full production A/B … the production training corpus (≈21 GiB, not distributable)"         |
+| `docs/archive/pr-summaries/pr-summary-3263.md` (66)                 | "`../GRQ/.trainData-binary_115`"                                                                   | "the production training corpus (≈21 GiB, not distributable)"                                   |
 | `docs/EVOLUTION_CONFIG_SWEEP_3400.md` (4–5, 92, 131, 135, 140, 145) | "`worker/learn.sh` / `worker/sampler.sh` (GRQ) scripts", "the GRQ scripts", "cross-repo GRQ issue" | "the downstream production runner scripts", "the issue filed in the downstream production repo" |
-| `docs/SCORE_PER_HOUR_HARNESS.md` (26) | "`worker/learn.sh` / `worker/sampler.sh`" | "the downstream production runner scripts" |
+| `docs/SCORE_PER_HOUR_HARNESS.md` (26)                               | "`worker/learn.sh` / `worker/sampler.sh`"                                                          | "the downstream production runner scripts"                                                      |
 
 Bare host/preset **mnemonics** (`grq-3397`, and bare `GRQ` tokens outside these
 path references) are out of this finding's scope — they name a concept, not a
@@ -45,9 +45,9 @@ flowchart LR
 
 ## Test Plan
 
-Added `test/docs/BenchAndPerfDocsNoPrivateWorkerPaths.ts` (behaviour test — reads
-real file content, asserts on it; fails against the unfixed files and passes
-after the reword):
+Added `test/docs/BenchAndPerfDocsNoPrivateWorkerPaths.ts` (behaviour test —
+reads real file content, asserts on it; fails against the unfixed files and
+passes after the reword):
 
 - `findPrivateWorkerScriptPaths` unit cases — flags the `worker/learn.sh` /
   `worker/sampler.sh` runner scripts, flags a `../GRQ/.trainData-binary_*`
@@ -55,7 +55,7 @@ after the reword):
   empty for concept-level prose and empty input.
 - Per-file scans over the four target files (`bench/SquashBudgetSelection.ts`,
   `docs/archive/pr-summaries/pr-summary-3263.md`,
-  `docs/EVOLUTION_CONFIG_SWEEP_3400.md`, `docs/SCORE_PER_HOUR_HARNESS.md`) assert
-  no private worker-script or checkout path remains.
+  `docs/EVOLUTION_CONFIG_SWEEP_3400.md`, `docs/SCORE_PER_HOUR_HARNESS.md`)
+  assert no private worker-script or checkout path remains.
 
 Full `./quality.sh` passes (`7945 passed | 0 failed`).

--- a/docs/archive/pr-summaries/pr-summary-3457.md
+++ b/docs/archive/pr-summaries/pr-summary-3457.md
@@ -1,0 +1,61 @@
+# PR Summary — Reword private GRQ worker-script and checkout paths (Issue #3457)
+
+## Summary
+
+Reworded the private-repo **file-path** references in the benches and
+performance docs to concept level, so the public repository stays fully
+self-contained. The private `stSoftwareAU/GRQ` repo was referenced by two path
+shapes the uppercase-`GRQ` audit (`LiveDocsNoPrivateGrqReference.ts`) does not
+catch, because they do not spell out the `GRQ` token:
+
+- the sibling-checkout path `../GRQ/.trainData-binary_115` (the ≈21 GiB
+  production training corpus), and
+- the downstream runner script paths `worker/learn.sh` / `worker/sampler.sh`.
+
+These pointed public readers at files they cannot see and advertised the private
+repo's internal layout. No behaviour changes — the benches already run on
+synthetic in-tree fixtures. **Closes #3457.**
+
+### Reworded references
+
+| File | Was | Now |
+| ---- | --- | --- |
+| `bench/SquashBudgetSelection.ts` (10–13) | "The full GRQ A/B … `../GRQ/.trainData-binary_115`" | "The full production A/B … the production training corpus (≈21 GiB, not distributable)" |
+| `docs/archive/pr-summaries/pr-summary-3263.md` (66) | "`../GRQ/.trainData-binary_115`" | "the production training corpus (≈21 GiB, not distributable)" |
+| `docs/EVOLUTION_CONFIG_SWEEP_3400.md` (4–5, 92, 131, 135, 140, 145) | "`worker/learn.sh` / `worker/sampler.sh` (GRQ) scripts", "the GRQ scripts", "cross-repo GRQ issue" | "the downstream production runner scripts", "the issue filed in the downstream production repo" |
+| `docs/SCORE_PER_HOUR_HARNESS.md` (26) | "`worker/learn.sh` / `worker/sampler.sh`" | "the downstream production runner scripts" |
+
+Bare host/preset **mnemonics** (`grq-3397`, and bare `GRQ` tokens outside these
+path references) are out of this finding's scope — they name a concept, not a
+private path — and are handled by the separate live/archive `GRQ`-token audits
+(#3453–#3456).
+
+## Evidence
+
+Documentation-only reword — no web interface to screenshot. Verified via the new
+audit test plus the full `./quality.sh` gate (`7945 passed | 0 failed`).
+
+```mermaid
+flowchart LR
+    A["Bench / perf doc names<br/>../GRQ/ checkout path or<br/>worker/learn.sh · worker/sampler.sh"]
+      --> B["Reword to concept level"]
+    B --> C["'the production training corpus (≈21 GiB…)'<br/>'the downstream production runner scripts'"]
+    C --> D["Test asserts no private<br/>worker-script / checkout path remains"]
+```
+
+## Test Plan
+
+Added `test/docs/BenchAndPerfDocsNoPrivateWorkerPaths.ts` (behaviour test — reads
+real file content, asserts on it; fails against the unfixed files and passes
+after the reword):
+
+- `findPrivateWorkerScriptPaths` unit cases — flags the `worker/learn.sh` /
+  `worker/sampler.sh` runner scripts, flags a `../GRQ/.trainData-binary_*`
+  sibling-checkout path, ignores the lower-case `grq-3397` fixture, and returns
+  empty for concept-level prose and empty input.
+- Per-file scans over the four target files (`bench/SquashBudgetSelection.ts`,
+  `docs/archive/pr-summaries/pr-summary-3263.md`,
+  `docs/EVOLUTION_CONFIG_SWEEP_3400.md`, `docs/SCORE_PER_HOUR_HARNESS.md`) assert
+  no private worker-script or checkout path remains.
+
+Full `./quality.sh` passes (`7945 passed | 0 failed`).

--- a/test/docs/BenchAndPerfDocsNoPrivateWorkerPaths.ts
+++ b/test/docs/BenchAndPerfDocsNoPrivateWorkerPaths.ts
@@ -1,0 +1,100 @@
+/**
+ * Issue #3457 — benches and performance docs must not reference the private
+ * `stSoftwareAU/GRQ` repository by file path.
+ *
+ * The uppercase-`GRQ` audit (`LiveDocsNoPrivateGrqReference.ts`) only catches
+ * the literal `GRQ` token, so private *path* references that do not spell out
+ * `GRQ` slip through: the downstream runner scripts `worker/learn.sh` /
+ * `worker/sampler.sh`, and the sibling-checkout path `../GRQ/.trainData-*`.
+ * These point public readers at files they cannot see and advertise the
+ * private repo's internal layout.
+ *
+ * This test walks the real benches / performance docs and fails if any
+ * reintroduces such a private path. It exercises behaviour (file content), not
+ * the source text of any function.
+ */
+
+import { assertEquals } from "@std/assert";
+import { fromFileUrl } from "@std/path";
+
+/** Benches / performance docs that must not carry a private GRQ path. */
+const TARGET_FILES = [
+  "../../bench/SquashBudgetSelection.ts",
+  "../../docs/archive/pr-summaries/pr-summary-3263.md",
+  "../../docs/EVOLUTION_CONFIG_SWEEP_3400.md",
+  "../../docs/SCORE_PER_HOUR_HARNESS.md",
+];
+
+/**
+ * Return every line that references the private `GRQ` repo by file path: the
+ * downstream runner scripts (`worker/learn.sh`, `worker/sampler.sh`) or a
+ * sibling `../GRQ/` checkout path (including the `.trainData-binary_*` corpus).
+ *
+ * The lower-case in-tree `grq-3397` scale-preset name is a synthetic fixture,
+ * not a private path, so it is deliberately not matched.
+ *
+ * @param source raw file source
+ * @returns 1-indexed line numbers carrying a private path reference
+ */
+export function findPrivateWorkerScriptPaths(source: string): number[] {
+  const pattern =
+    /worker\/(?:learn|sampler)\.sh|\.\.\/GRQ\/|\.trainData-binary_/;
+  const hits: number[] = [];
+  const lines = source.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    if (pattern.test(lines[i])) {
+      hits.push(i + 1);
+    }
+  }
+  return hits;
+}
+
+for (const rel of TARGET_FILES) {
+  Deno.test(`${rel} has no private GRQ worker-script or checkout path (#3457)`, async () => {
+    const path = fromFileUrl(new URL(rel, import.meta.url));
+    const source = await Deno.readTextFile(path);
+    const hits = findPrivateWorkerScriptPaths(source);
+    assertEquals(
+      hits,
+      [],
+      `${rel} references a private GRQ path on line(s) ${hits.join(", ")}. ` +
+        `Reword to concept level (e.g. "the downstream production runner ` +
+        `scripts", "the production training corpus (≈21 GiB, not ` +
+        `distributable)") so the file stays verifiable by public readers.`,
+    );
+  });
+}
+
+Deno.test("findPrivateWorkerScriptPaths flags the worker runner scripts", () => {
+  const src = [
+    "Intro line.",
+    "tuned by `worker/learn.sh` / `worker/sampler.sh` on the cluster.",
+    "Closing line.",
+  ].join("\n");
+  assertEquals(findPrivateWorkerScriptPaths(src), [2]);
+});
+
+Deno.test("findPrivateWorkerScriptPaths flags a sibling GRQ checkout path", () => {
+  const src = "requires the seed and `../GRQ/.trainData-binary_115`.\n";
+  assertEquals(findPrivateWorkerScriptPaths(src), [1]);
+});
+
+Deno.test("findPrivateWorkerScriptPaths ignores the lower-case grq-3397 fixture", () => {
+  const src = [
+    "The synthetic `grq-3397` scale preset reproduces the dimensions.",
+    "The downstream production runner scripts drive the same topology.",
+  ].join("\n");
+  assertEquals(findPrivateWorkerScriptPaths(src), []);
+});
+
+Deno.test("findPrivateWorkerScriptPaths returns empty for concept-level prose", () => {
+  const src = [
+    "The downstream production runner scripts select the scoring lane.",
+    "The full A/B needs the production training corpus (≈21 GiB).",
+  ].join("\n");
+  assertEquals(findPrivateWorkerScriptPaths(src), []);
+});
+
+Deno.test("findPrivateWorkerScriptPaths returns empty for empty input", () => {
+  assertEquals(findPrivateWorkerScriptPaths(""), []);
+});


### PR DESCRIPTION
# PR Summary — Reword private GRQ worker-script and checkout paths (Issue #3457)

## Summary

Reworded the private-repo **file-path** references in the benches and
performance docs to concept level, so the public repository stays fully
self-contained. The private `stSoftwareAU/GRQ` repo was referenced by two path
shapes the uppercase-`GRQ` audit (`LiveDocsNoPrivateGrqReference.ts`) does not
catch, because they do not spell out the `GRQ` token:

- the sibling-checkout path `../GRQ/.trainData-binary_115` (the ≈21 GiB
  production training corpus), and
- the downstream runner script paths `worker/learn.sh` / `worker/sampler.sh`.

These pointed public readers at files they cannot see and advertised the private
repo's internal layout. No behaviour changes — the benches already run on
synthetic in-tree fixtures. **Closes #3457.**

### Reworded references

| File | Was | Now |
| ---- | --- | --- |
| `bench/SquashBudgetSelection.ts` (10–13) | "The full GRQ A/B … `../GRQ/.trainData-binary_115`" | "The full production A/B … the production training corpus (≈21 GiB, not distributable)" |
| `docs/archive/pr-summaries/pr-summary-3263.md` (66) | "`../GRQ/.trainData-binary_115`" | "the production training corpus (≈21 GiB, not distributable)" |
| `docs/EVOLUTION_CONFIG_SWEEP_3400.md` (4–5, 92, 131, 135, 140, 145) | "`worker/learn.sh` / `worker/sampler.sh` (GRQ) scripts", "the GRQ scripts", "cross-repo GRQ issue" | "the downstream production runner scripts", "the issue filed in the downstream production repo" |
| `docs/SCORE_PER_HOUR_HARNESS.md` (26) | "`worker/learn.sh` / `worker/sampler.sh`" | "the downstream production runner scripts" |

Bare host/preset **mnemonics** (`grq-3397`, and bare `GRQ` tokens outside these
path references) are out of this finding's scope — they name a concept, not a
private path — and are handled by the separate live/archive `GRQ`-token audits
(#3453–#3456).

## Evidence

Documentation-only reword — no web interface to screenshot. Verified via the new
audit test plus the full `./quality.sh` gate (`7945 passed | 0 failed`).

```mermaid
flowchart LR
    A["Bench / perf doc names<br/>../GRQ/ checkout path or<br/>worker/learn.sh · worker/sampler.sh"]
      --> B["Reword to concept level"]
    B --> C["'the production training corpus (≈21 GiB…)'<br/>'the downstream production runner scripts'"]
    C --> D["Test asserts no private<br/>worker-script / checkout path remains"]
```

## Test Plan

Added `test/docs/BenchAndPerfDocsNoPrivateWorkerPaths.ts` (behaviour test — reads
real file content, asserts on it; fails against the unfixed files and passes
after the reword):

- `findPrivateWorkerScriptPaths` unit cases — flags the `worker/learn.sh` /
  `worker/sampler.sh` runner scripts, flags a `../GRQ/.trainData-binary_*`
  sibling-checkout path, ignores the lower-case `grq-3397` fixture, and returns
  empty for concept-level prose and empty input.
- Per-file scans over the four target files (`bench/SquashBudgetSelection.ts`,
  `docs/archive/pr-summaries/pr-summary-3263.md`,
  `docs/EVOLUTION_CONFIG_SWEEP_3400.md`, `docs/SCORE_PER_HOUR_HARNESS.md`) assert
  no private worker-script or checkout path remains.

Full `./quality.sh` passes (`7945 passed | 0 failed`).



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-ms32hzfx-bd797a`<!-- vibe-worker-issue-3457 -->