### PR TITLE
Drop redundant export on 24 file-local symbols (Issue #3511)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-3511.md
+++ b/docs/archive/pr-summaries/pr-summary-3511.md
@@ -1,0 +1,140 @@
+# Drop redundant `export` on 24 file-local symbols (Issue #3511)
+
+## Summary
+
+The dead-code audit found 24 value-level symbols (functions and consts) in
+`src/` carrying an `export` keyword despite having **zero** references outside
+their defining file. The keyword was dropped so each module boundary reflects
+its real consumers. Closes #3511.
+
+No runtime behaviour changes and no import site changes — by definition there
+was no other importer, and none of the 24 is re-exported from `mod.ts`.
+
+Every symbol was re-verified in this run before editing:
+
+```
+grep -rl '\b<SYMBOL>\b' src test bench scripts mod.ts docs
+```
+
+All 24 returned the definition file only. Two also appeared in archived PR
+summaries (`resolveCacheDir`, `moveNeuronToIndex`) — prose in
+`docs/archive/pr-summaries/`, not code, so they remain file-local.
+
+The 114 `interface` / `type` exports from the same audit are **out of scope**
+per the issue's scope note: several are cited in `docs/api/*.md` as the
+documented shape of a public API, and separating the documented ones from the
+incidental ones is a separate exercise.
+
+### Symbols changed
+
+| File                                                                         | Symbol                                                                                                       |
+| ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `src/upgrade/SemanticVersionValidation.ts`                                   | `VALID_WRITEABLE_SEMANTIC_VERSION_RE`                                                                        |
+| `src/optimize/Simplify.ts`                                                   | `removeKnownSign`                                                                                            |
+| `src/config/parsers/MutationParsers.ts`                                      | `parseDiversityAwareMCMC`                                                                                    |
+| `src/wasm/WasmBundleCache.ts`                                                | `DEFAULT_MAX_ATTEMPTS`, `DEFAULT_BASE_DELAY_MS`, `resolveCacheDir`                                           |
+| `src/discovery/BatchValidatorTypes.ts`                                       | `STRUCTURAL_CHANGE_TYPES`, `WEIGHT_ONLY_CHANGE_TYPES`                                                        |
+| `src/discovery/DiscoveryEvaluationSummary.ts`                                | `logSingleSummary`                                                                                           |
+| `src/creature/MemeticWireExport.ts`                                          | `buildNeuronIdToWireUuidMap`, `convertMemeticSnapshotToWireJson`                                             |
+| `src/architecture/NormaliseComputationalNeuronOrder.ts`                      | `moveNeuronToIndex`                                                                                          |
+| `src/architecture/ErrorGuidedStructuralEvolution/DataRecorderRecording.ts`   | `processDiscoveryFile`                                                                                       |
+| `src/architecture/ErrorGuidedStructuralEvolution/NeuronImpact.ts`            | `computeSquashDerivative`                                                                                    |
+| `src/architecture/ErrorGuidedStructuralEvolution/DiscoverDataLoading.ts`     | `openFileWithRetry`, `loadInputNeuronFromBinary`                                                             |
+| `src/architecture/ErrorGuidedStructuralEvolution/AnalysisDegradeDecision.ts` | `DEGRADED_MAX_NEURONS_FACTOR`                                                                                |
+| `src/architecture/ErrorGuidedStructuralEvolution/DiscoverAnalysis.ts`        | `candidateKey`, `neuronCandidateKey`, `filterTopSynapseCandidates`, `tryRustCoordinatedStructuralCandidates` |
+| `src/architecture/ErrorGuidedStructuralEvolution/DiscoveryAnalysisMemory.ts` | `DEFAULT_DISCOVERY_ANALYSIS_MEMORY_DEPS`                                                                     |
+| `src/breed/Father.ts`                                                        | `DEFAULT_SYNTHETIC_ALIGNMENT_THRESHOLD`                                                                      |
+| `src/workers/WorkerHandlerBase.ts`                                           | `readV8HeapLimitMb`                                                                                          |
+
+## Evidence
+
+This is a library-internal change with no web interface, so there is no
+screenshot to capture. The evidence is the test suite and the type checker.
+
+The verification flow:
+
+```mermaid
+flowchart LR
+    A["24 audited symbols"] --> B["grep -rl across<br/>src test bench scripts mod.ts docs"]
+    B --> C{"hits outside<br/>defining file?"}
+    C -- no --> D["drop 'export' keyword"]
+    C -- yes --> E["leave untouched<br/>(none hit this branch)"]
+    D --> F["deno check<br/>catches any wrong listing"]
+    F --> G["RedundantExports.ts<br/>asserts runtime namespace"]
+    G --> H["./quality.sh — fmt, lint,<br/>check green; only the<br/>pre-existing #3531 tests fail"]
+```
+
+The change is self-verifying in two independent ways:
+
+1. **`deno check`** — any test or module that actually imported one of the 24
+   would fail to resolve the symbol. It passes across all 520 source and test
+   files, proving no listing was wrong.
+2. **`test/deadcode/RedundantExports.ts`** — imports each of the 16 touched
+   modules for real and inspects the runtime module namespace object, asserting
+   each stripped symbol is genuinely absent from the module's public shape.
+
+The new test was confirmed to be a genuine regression test: with the `src/`
+changes stashed it fails, and with them applied it passes.
+
+```
+$ git stash push src/ && deno test test/deadcode/RedundantExports.ts
+Issue #3511 - file-local symbols are absent from the module namespace ... FAILED
+FAILED | 1 passed | 1 failed
+
+$ git stash pop && deno test test/deadcode/RedundantExports.ts
+Issue #3511 - file-local symbols are absent from the module namespace ... ok
+Issue #3511 - modules keep the exports their consumers rely on ... ok
+ok | 2 passed | 0 failed
+```
+
+## Test Plan
+
+Added `test/deadcode/RedundantExports.ts` with two tests:
+
+- `Issue #3511 - file-local symbols are absent from the module namespace` —
+  dynamically imports all 16 touched modules and asserts none of the 24 symbols
+  is present on the module namespace, while each module still exports at least
+  one symbol (so an over-eager sweep that stripped a module bare is caught here
+  rather than at a downstream import). Asserts the covered count is exactly 24.
+- `Issue #3511 - modules keep the exports their consumers rely on` — spot-checks
+  that `src/breed/Father.ts` still exports `createCompatibleFather` and
+  `src/optimize/Simplify.ts` still exports `simplify`, so a mis-targeted line
+  number surfaces here.
+
+Both tests assert on runtime module shape rather than source text, so they stay
+valid if a symbol is later renamed, relocated, or deleted outright.
+
+No existing tests were modified or removed.
+
+### Pre-existing failures on the base branch
+
+`./quality.sh` reports **7986 passed, 4 failed**. All four failures are
+pre-existing on `milestone/dead-code-29-jul` and already tracked by **#3531**
+("4 ErrorGuidedStructuralEvolution discovery-selection tests fail on
+milestone/dead-code-29-jul"):
+
+- `test/ErrorGuidedStructuralEvolution/DiscoveryRobustness.ts` — "Discovery
+  weighted selection completes within max iterations"
+- `test/ErrorGuidedStructuralEvolution/InvalidDataDetection.ts` — "Discovery
+  validates all neurons have finite error values"
+- `test/ErrorGuidedStructuralEvolution/InvalidDataDetection.ts` — "Discovery
+  selection falls back gracefully on invalid totalErrorSum"
+- `test/ErrorGuidedStructuralEvolution/MinimalCreature.ts` — "Discovery
+  selection respects neuron count limit"
+
+They were confirmed unrelated by stashing the `src/` changes and re-running the
+same files against the untouched base — the counts are identical either way:
+
+```
+$ git stash push src/ && deno test test/ErrorGuidedStructuralEvolution/DiscoveryRobustness.ts \
+    test/ErrorGuidedStructuralEvolution/InvalidDataDetection.ts
+FAILED | 5 passed | 3 failed          # base, without this PR
+
+$ git stash pop && deno test <same files>
+FAILED | 5 passed | 3 failed          # with this PR — unchanged
+```
+
+`MinimalCreature.ts` likewise fails identically with and without the change.
+Fixing them belongs to #3531, not to this dead-code sweep. Every other step of
+`./quality.sh` (dependency check, `deno fmt`, `deno lint`, `deno check` across
+520 source files) is green.

--- a/src/architecture/ErrorGuidedStructuralEvolution/AnalysisDegradeDecision.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/AnalysisDegradeDecision.ts
@@ -60,7 +60,7 @@ export const MIN_DEGRADED_MAX_NEURONS = 1;
  * Fraction of the current focus breadth kept when degrading. A quarter keeps a
  * meaningful (but much smaller) working set so candidates can still be found.
  */
-export const DEGRADED_MAX_NEURONS_FACTOR = 0.25;
+const DEGRADED_MAX_NEURONS_FACTOR = 0.25;
 
 /**
  * Chunk size the degraded analysis bounds each Rust FFI call to. Small enough to

--- a/src/architecture/ErrorGuidedStructuralEvolution/DataRecorderRecording.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DataRecorderRecording.ts
@@ -41,7 +41,7 @@ export interface FileProcessingContext {
  * Processes a single binary data file, reading sampled records and submitting
  * them in batches to the discovery structure for recording.
  */
-export async function processDiscoveryFile(
+async function processDiscoveryFile(
   ctx: FileProcessingContext,
   filePath: string,
   discoverStructure: DiscoverStructure,

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverAnalysis.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverAnalysis.ts
@@ -72,14 +72,14 @@ export function mapRustNeuronCandidate(
 /**
  * Generates key string for synapse candidate dedup.
  */
-export function candidateKey(candidate: CandidateSynapse): string {
+function candidateKey(candidate: CandidateSynapse): string {
   return `${candidate.fromNeuronUuid}->${candidate.toNeuronUuid}`;
 }
 
 /**
  * Generates key string for neuron candidate dedup.
  */
-export function neuronCandidateKey(candidate: CandidateNeuron): string {
+function neuronCandidateKey(candidate: CandidateNeuron): string {
   return `${candidate.fromNeuronUuid}->${candidate.toNeuronUuid}`;
 }
 
@@ -128,7 +128,7 @@ export function upsertNeuronDiscovery(
 /**
  * Groups synapse candidates by target neuron, keeps best per target.
  */
-export function filterTopSynapseCandidates(
+function filterTopSynapseCandidates(
   candidates: CandidateSynapse[],
 ): CandidateSynapse[] {
   const grouped = new Map<string, CandidateSynapse>();
@@ -368,7 +368,7 @@ function mapRustCoordinatedCandidate(
 /**
  * Reads coordinated structural candidates from Rust analysis.
  */
-export function tryRustCoordinatedStructuralCandidates(
+function tryRustCoordinatedStructuralCandidates(
   rustResult: RustAnalyzeAllResult | undefined,
 ): CoordinatedStructuralCandidate[] | undefined {
   const neuronResult = rustResult?.neuron;

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverDataLoading.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverDataLoading.ts
@@ -19,7 +19,7 @@ import type { DiscoverStructureDeps } from "@architecture/ErrorGuidedStructuralE
 /**
  * Opens a file with exponential backoff retry for "Too many open files" errors.
  */
-export async function openFileWithRetry(
+async function openFileWithRetry(
   file: string,
   maxRetries = 5,
   initialDelay = 200,
@@ -56,7 +56,7 @@ export async function openFileWithRetry(
  * Loads input neuron activation data directly from binary files using stored indices.
  * Input neurons are stored in binary format as they are not written to Parquet.
  */
-export async function loadInputNeuronFromBinary(
+async function loadInputNeuronFromBinary(
   neuronIndex: number,
   indicesFilePath: string,
   inputCount: number,

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoveryAnalysisMemory.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoveryAnalysisMemory.ts
@@ -44,11 +44,10 @@ export interface DiscoveryAnalysisMemoryDeps {
 }
 
 /** Production dependencies — the real NEAT-AI-Discovery FFI surface. */
-export const DEFAULT_DISCOVERY_ANALYSIS_MEMORY_DEPS:
-  DiscoveryAnalysisMemoryDeps = {
-    usageBytes: getDiscoveryMemoryUsageBytes,
-    cancelMemoryPressure: cancelAnalysisMemoryPressure,
-  };
+const DEFAULT_DISCOVERY_ANALYSIS_MEMORY_DEPS: DiscoveryAnalysisMemoryDeps = {
+  usageBytes: getDiscoveryMemoryUsageBytes,
+  cancelMemoryPressure: cancelAnalysisMemoryPressure,
+};
 
 /**
  * Resolves the analysis memory budget to send on `analyze_parallel`.

--- a/src/architecture/ErrorGuidedStructuralEvolution/NeuronImpact.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/NeuronImpact.ts
@@ -119,7 +119,7 @@ export function calculateNeuronImpact(
  * (e.g., TANH at large inputs) have very small derivatives and thus limited impact
  * on output error regardless of their local error magnitude.
  */
-export function computeSquashDerivative(
+function computeSquashDerivative(
   creature: Creature,
   neuronId: number,
 ): number {

--- a/src/architecture/NormaliseComputationalNeuronOrder.ts
+++ b/src/architecture/NormaliseComputationalNeuronOrder.ts
@@ -13,7 +13,7 @@ import { assertForwardOnlyTopologyAfterBulkRemap } from "@architecture/ForwardOn
  * Moves one neuron to a target index, remapping synapse endpoints and
  * `neuron.index`. Used when repair paths flip hidden→constant in place.
  */
-export function moveNeuronToIndex(
+function moveNeuronToIndex(
   creature: Creature,
   from: number,
   to: number,

--- a/src/breed/Father.ts
+++ b/src/breed/Father.ts
@@ -18,7 +18,7 @@ import {
  * Mirrors `NeatArguments.syntheticAlignmentThreshold` so callers that omit
  * the option get the same behaviour as the configured pipeline default.
  */
-export const DEFAULT_SYNTHETIC_ALIGNMENT_THRESHOLD = 0.2;
+const DEFAULT_SYNTHETIC_ALIGNMENT_THRESHOLD = 0.2;
 
 /**
  * Lightweight neuron info needed for compatibility check.

--- a/src/config/parsers/MutationParsers.ts
+++ b/src/config/parsers/MutationParsers.ts
@@ -269,7 +269,7 @@ function parseAdvantageMode(
 }
 
 /** Parse diversity-aware MCMC reheat configuration (Issue #2456). */
-export function parseDiversityAwareMCMC(
+function parseDiversityAwareMCMC(
   overrides: Record<string, unknown> | undefined,
 ): RequiredDiversityAwareMCMCConfig {
   const d = DEFAULT_DIVERSITY_AWARE_MCMC_CONFIG;

--- a/src/creature/MemeticWireExport.ts
+++ b/src/creature/MemeticWireExport.ts
@@ -7,7 +7,7 @@ import { neuronUuid } from "../neuron/NeuronSerialization.ts";
  * Runtime neuron id → canonical wire string (input-N, output-N, or neuron.uuid).
  * Used when serialising memetic state for any JSON that leaves the process.
  */
-export function buildNeuronIdToWireUuidMap(
+function buildNeuronIdToWireUuidMap(
   creature: Creature,
 ): Map<number, string> {
   const m = new Map<number, string>();
@@ -31,7 +31,7 @@ export type MemeticWeightWireRow = {
  * Rewrites one memetic snapshot for wire JSON: biases keyed by wire strings;
  * weights as an array of synapse-shaped rows (no numeric neuron keys).
  */
-export function convertMemeticSnapshotToWireJson(
+function convertMemeticSnapshotToWireJson(
   node: MemeticWireData,
   idToUuid: Map<number, string>,
 ): void {

--- a/src/discovery/BatchValidatorTypes.ts
+++ b/src/discovery/BatchValidatorTypes.ts
@@ -104,7 +104,7 @@ export interface GroupedCandidates {
 /**
  * Structural change types that modify the network topology.
  */
-export const STRUCTURAL_CHANGE_TYPES: Set<DiscoveryChangeType> = new Set([
+const STRUCTURAL_CHANGE_TYPES: Set<DiscoveryChangeType> = new Set([
   "add-synapses",
   "add-neurons",
   "coordinated-structural",
@@ -120,7 +120,7 @@ export const STRUCTURAL_CHANGE_TYPES: Set<DiscoveryChangeType> = new Set([
 /**
  * Weight-only change types that don't modify topology.
  */
-export const WEIGHT_ONLY_CHANGE_TYPES: Set<DiscoveryChangeType> = new Set([
+const WEIGHT_ONLY_CHANGE_TYPES: Set<DiscoveryChangeType> = new Set([
   "change-squash",
   "combo-add-change",
 ]);

--- a/src/discovery/DiscoveryEvaluationSummary.ts
+++ b/src/discovery/DiscoveryEvaluationSummary.ts
@@ -246,7 +246,7 @@ export function logEvaluationSummary(
 /**
  * Logs a single evaluation summary line.
  */
-export function logSingleSummary(
+function logSingleSummary(
   summary: DiscoveryEvaluationSummary,
   isBest: boolean,
 ): void {

--- a/src/optimize/Simplify.ts
+++ b/src/optimize/Simplify.ts
@@ -143,7 +143,7 @@ function simplifyComplementToIdentity(
   return exported;
 }
 
-export function removeKnownSign(exported: CreatureExport) {
+function removeKnownSign(exported: CreatureExport) {
   normaliseCreatureExport(exported);
   const neuronMap = new Map<number, NeuronExport>();
   exported.neurons.forEach((neuron) => {

--- a/src/upgrade/SemanticVersionValidation.ts
+++ b/src/upgrade/SemanticVersionValidation.ts
@@ -14,7 +14,7 @@
  * Accepts `2.0.0`, `4.0.0`, `10.1.3`, etc.
  * Rejects `""`, `"0.0.1"`, `"1.0.0"`, or any non-semver string.
  */
-export const VALID_WRITEABLE_SEMANTIC_VERSION_RE =
+const VALID_WRITEABLE_SEMANTIC_VERSION_RE =
   /^([2-9]|[1-9][0-9]+)\.[0-9]+\.[0-9]+$/;
 
 /**

--- a/src/wasm/WasmBundleCache.ts
+++ b/src/wasm/WasmBundleCache.ts
@@ -66,10 +66,10 @@ export interface LoadWasmBundleResult {
 }
 
 /** Default bounded number of fetch attempts on a cache miss. */
-export const DEFAULT_MAX_ATTEMPTS = 5;
+const DEFAULT_MAX_ATTEMPTS = 5;
 
 /** Default base backoff delay in milliseconds (doubles each attempt). */
-export const DEFAULT_BASE_DELAY_MS = 250;
+const DEFAULT_BASE_DELAY_MS = 250;
 
 /** Real sleep used when no `sleepFn` is injected. */
 function defaultSleep(ms: number): Promise<void> {
@@ -85,7 +85,7 @@ function defaultSleep(ms: number): Promise<void> {
  * in which case caching is skipped and loading falls back to a plain
  * fetch-with-retry.
  */
-export function resolveCacheDir(override?: string | null): string | null {
+function resolveCacheDir(override?: string | null): string | null {
   if (override === null) {
     // Caller forced caching off (Issue #3494).
     return null;

--- a/src/workers/WorkerHandlerBase.ts
+++ b/src/workers/WorkerHandlerBase.ts
@@ -99,7 +99,7 @@ export function requiredWorkerV8Flag(budgetMb: number): string {
 }
 
 /** The current isolate's V8 old-space heap limit, in MB. */
-export function readV8HeapLimitMb(): number {
+function readV8HeapLimitMb(): number {
   return Math.round(v8.getHeapStatistics().heap_size_limit / BYTES_PER_MB);
 }
 

--- a/test/deadcode/RedundantExports.ts
+++ b/test/deadcode/RedundantExports.ts
@@ -1,0 +1,161 @@
+/**
+ * Issue #3511 — 24 value-level symbols carried an `export` keyword but had
+ * zero references outside their defining file. The keyword was dropped so the
+ * module boundary reflects reality.
+ *
+ * This test imports each module for real and inspects its runtime namespace
+ * object, asserting the symbol is no longer part of the module's public shape.
+ * It is behaviour-based, not source-text based: it keeps passing if a symbol is
+ * later renamed, moved, or deleted outright, and fails the moment someone
+ * re-adds `export` without a genuine cross-file consumer.
+ *
+ * Each module is also asserted to still export at least one symbol, so an
+ * over-eager sweep that stripped a module bare would be caught here rather
+ * than by a downstream import failure.
+ */
+
+import { assert, assertEquals } from "@std/assert";
+
+/** A module that lost one or more redundant `export` keywords. */
+interface StrippedModule {
+  /** Import specifier, relative to this test file. */
+  readonly specifier: string;
+  /** Symbols that must no longer appear in the module namespace. */
+  readonly removed: readonly string[];
+}
+
+const STRIPPED_MODULES: readonly StrippedModule[] = [
+  {
+    specifier: "../../src/upgrade/SemanticVersionValidation.ts",
+    removed: ["VALID_WRITEABLE_SEMANTIC_VERSION_RE"],
+  },
+  {
+    specifier: "../../src/optimize/Simplify.ts",
+    removed: ["removeKnownSign"],
+  },
+  {
+    specifier: "../../src/config/parsers/MutationParsers.ts",
+    removed: ["parseDiversityAwareMCMC"],
+  },
+  {
+    specifier: "../../src/wasm/WasmBundleCache.ts",
+    removed: [
+      "DEFAULT_MAX_ATTEMPTS",
+      "DEFAULT_BASE_DELAY_MS",
+      "resolveCacheDir",
+    ],
+  },
+  {
+    specifier: "../../src/discovery/BatchValidatorTypes.ts",
+    removed: ["STRUCTURAL_CHANGE_TYPES", "WEIGHT_ONLY_CHANGE_TYPES"],
+  },
+  {
+    specifier: "../../src/discovery/DiscoveryEvaluationSummary.ts",
+    removed: ["logSingleSummary"],
+  },
+  {
+    specifier: "../../src/creature/MemeticWireExport.ts",
+    removed: [
+      "buildNeuronIdToWireUuidMap",
+      "convertMemeticSnapshotToWireJson",
+    ],
+  },
+  {
+    specifier: "../../src/architecture/NormaliseComputationalNeuronOrder.ts",
+    removed: ["moveNeuronToIndex"],
+  },
+  {
+    specifier:
+      "../../src/architecture/ErrorGuidedStructuralEvolution/DataRecorderRecording.ts",
+    removed: ["processDiscoveryFile"],
+  },
+  {
+    specifier:
+      "../../src/architecture/ErrorGuidedStructuralEvolution/NeuronImpact.ts",
+    removed: ["computeSquashDerivative"],
+  },
+  {
+    specifier:
+      "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverDataLoading.ts",
+    removed: ["openFileWithRetry", "loadInputNeuronFromBinary"],
+  },
+  {
+    specifier:
+      "../../src/architecture/ErrorGuidedStructuralEvolution/AnalysisDegradeDecision.ts",
+    removed: ["DEGRADED_MAX_NEURONS_FACTOR"],
+  },
+  {
+    specifier:
+      "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoverAnalysis.ts",
+    removed: [
+      "candidateKey",
+      "neuronCandidateKey",
+      "filterTopSynapseCandidates",
+      "tryRustCoordinatedStructuralCandidates",
+    ],
+  },
+  {
+    specifier:
+      "../../src/architecture/ErrorGuidedStructuralEvolution/DiscoveryAnalysisMemory.ts",
+    removed: ["DEFAULT_DISCOVERY_ANALYSIS_MEMORY_DEPS"],
+  },
+  {
+    specifier: "../../src/breed/Father.ts",
+    removed: ["DEFAULT_SYNTHETIC_ALIGNMENT_THRESHOLD"],
+  },
+  {
+    specifier: "../../src/workers/WorkerHandlerBase.ts",
+    removed: ["readV8HeapLimitMb"],
+  },
+];
+
+Deno.test("Issue #3511 - file-local symbols are absent from the module namespace", async () => {
+  let checked = 0;
+
+  const namespaces = await Promise.all(
+    STRIPPED_MODULES.map((module) =>
+      import(new URL(module.specifier, import.meta.url).href) as Promise<
+        Record<string, unknown>
+      >
+    ),
+  );
+
+  for (const [index, { specifier, removed }] of STRIPPED_MODULES.entries()) {
+    const namespace = namespaces[index];
+
+    const exported = Object.keys(namespace);
+    assert(
+      exported.length > 0,
+      `${specifier} exports nothing — the sweep stripped too much`,
+    );
+
+    for (const symbol of removed) {
+      assertEquals(
+        Object.hasOwn(namespace, symbol),
+        false,
+        `${specifier} still exports '${symbol}', which has no cross-file consumer`,
+      );
+      checked++;
+    }
+  }
+
+  // All 24 symbols listed in Issue #3511 are covered.
+  assertEquals(checked, 24);
+});
+
+Deno.test("Issue #3511 - modules keep the exports their consumers rely on", async () => {
+  // Spot-check the surviving public shape of the two most heavily imported
+  // modules touched by the sweep, so a mis-targeted line number would fail
+  // here rather than at the first downstream import.
+  const father = await import("../../src/breed/Father.ts") as Record<
+    string,
+    unknown
+  >;
+  assertEquals(typeof father.createCompatibleFather, "function");
+
+  const simplify = await import("../../src/optimize/Simplify.ts") as Record<
+    string,
+    unknown
+  >;
+  assertEquals(typeof simplify.simplify, "function");
+});


### PR DESCRIPTION
# Drop redundant `export` on 24 file-local symbols (Issue #3511)

## Summary

The dead-code audit found 24 value-level symbols (functions and consts) in
`src/` carrying an `export` keyword despite having **zero** references outside
their defining file. The keyword was dropped so each module boundary reflects
its real consumers. Closes #3511.

No runtime behaviour changes and no import site changes — by definition there
was no other importer, and none of the 24 is re-exported from `mod.ts`.

Every symbol was re-verified in this run before editing:

```
grep -rl '\b<SYMBOL>\b' src test bench scripts mod.ts docs
```

All 24 returned the definition file only. Two also appeared in archived PR
summaries (`resolveCacheDir`, `moveNeuronToIndex`) — prose in
`docs/archive/pr-summaries/`, not code, so they remain file-local.

The 114 `interface` / `type` exports from the same audit are **out of scope**
per the issue's scope note: several are cited in `docs/api/*.md` as the
documented shape of a public API, and separating the documented ones from the
incidental ones is a separate exercise.

### Symbols changed

| File                                                                         | Symbol                                                                                                       |
| ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
| `src/upgrade/SemanticVersionValidation.ts`                                   | `VALID_WRITEABLE_SEMANTIC_VERSION_RE`                                                                        |
| `src/optimize/Simplify.ts`                                                   | `removeKnownSign`                                                                                            |
| `src/config/parsers/MutationParsers.ts`                                      | `parseDiversityAwareMCMC`                                                                                    |
| `src/wasm/WasmBundleCache.ts`                                                | `DEFAULT_MAX_ATTEMPTS`, `DEFAULT_BASE_DELAY_MS`, `resolveCacheDir`                                           |
| `src/discovery/BatchValidatorTypes.ts`                                       | `STRUCTURAL_CHANGE_TYPES`, `WEIGHT_ONLY_CHANGE_TYPES`                                                        |
| `src/discovery/DiscoveryEvaluationSummary.ts`                                | `logSingleSummary`                                                                                           |
| `src/creature/MemeticWireExport.ts`                                          | `buildNeuronIdToWireUuidMap`, `convertMemeticSnapshotToWireJson`                                             |
| `src/architecture/NormaliseComputationalNeuronOrder.ts`                      | `moveNeuronToIndex`                                                                                          |
| `src/architecture/ErrorGuidedStructuralEvolution/DataRecorderRecording.ts`   | `processDiscoveryFile`                                                                                       |
| `src/architecture/ErrorGuidedStructuralEvolution/NeuronImpact.ts`            | `computeSquashDerivative`                                                                                    |
| `src/architecture/ErrorGuidedStructuralEvolution/DiscoverDataLoading.ts`     | `openFileWithRetry`, `loadInputNeuronFromBinary`                                                             |
| `src/architecture/ErrorGuidedStructuralEvolution/AnalysisDegradeDecision.ts` | `DEGRADED_MAX_NEURONS_FACTOR`                                                                                |
| `src/architecture/ErrorGuidedStructuralEvolution/DiscoverAnalysis.ts`        | `candidateKey`, `neuronCandidateKey`, `filterTopSynapseCandidates`, `tryRustCoordinatedStructuralCandidates` |
| `src/architecture/ErrorGuidedStructuralEvolution/DiscoveryAnalysisMemory.ts` | `DEFAULT_DISCOVERY_ANALYSIS_MEMORY_DEPS`                                                                     |
| `src/breed/Father.ts`                                                        | `DEFAULT_SYNTHETIC_ALIGNMENT_THRESHOLD`                                                                      |
| `src/workers/WorkerHandlerBase.ts`                                           | `readV8HeapLimitMb`                                                                                          |

## Evidence

This is a library-internal change with no web interface, so there is no
screenshot to capture. The evidence is the test suite and the type checker.

The verification flow:

```mermaid
flowchart LR
    A["24 audited symbols"] --> B["grep -rl across<br/>src test bench scripts mod.ts docs"]
    B --> C{"hits outside<br/>defining file?"}
    C -- no --> D["drop 'export' keyword"]
    C -- yes --> E["leave untouched<br/>(none hit this branch)"]
    D --> F["deno check<br/>catches any wrong listing"]
    F --> G["RedundantExports.ts<br/>asserts runtime namespace"]
    G --> H["./quality.sh — fmt, lint,<br/>check green; only the<br/>pre-existing #3531 tests fail"]
```

The change is self-verifying in two independent ways:

1. **`deno check`** — any test or module that actually imported one of the 24
   would fail to resolve the symbol. It passes across all 520 source and test
   files, proving no listing was wrong.
2. **`test/deadcode/RedundantExports.ts`** — imports each of the 16 touched
   modules for real and inspects the runtime module namespace object, asserting
   each stripped symbol is genuinely absent from the module's public shape.

The new test was confirmed to be a genuine regression test: with the `src/`
changes stashed it fails, and with them applied it passes.

```
$ git stash push src/ && deno test test/deadcode/RedundantExports.ts
Issue #3511 - file-local symbols are absent from the module namespace ... FAILED
FAILED | 1 passed | 1 failed

$ git stash pop && deno test test/deadcode/RedundantExports.ts
Issue #3511 - file-local symbols are absent from the module namespace ... ok
Issue #3511 - modules keep the exports their consumers rely on ... ok
ok | 2 passed | 0 failed
```

## Test Plan

Added `test/deadcode/RedundantExports.ts` with two tests:

- `Issue #3511 - file-local symbols are absent from the module namespace` —
  dynamically imports all 16 touched modules and asserts none of the 24 symbols
  is present on the module namespace, while each module still exports at least
  one symbol (so an over-eager sweep that stripped a module bare is caught here
  rather than at a downstream import). Asserts the covered count is exactly 24.
- `Issue #3511 - modules keep the exports their consumers rely on` — spot-checks
  that `src/breed/Father.ts` still exports `createCompatibleFather` and
  `src/optimize/Simplify.ts` still exports `simplify`, so a mis-targeted line
  number surfaces here.

Both tests assert on runtime module shape rather than source text, so they stay
valid if a symbol is later renamed, relocated, or deleted outright.

No existing tests were modified or removed.

### Pre-existing failures on the base branch

`./quality.sh` reports **7986 passed, 4 failed**. All four failures are
pre-existing on `milestone/dead-code-29-jul` and already tracked by **#3531**
("4 ErrorGuidedStructuralEvolution discovery-selection tests fail on
milestone/dead-code-29-jul"):

- `test/ErrorGuidedStructuralEvolution/DiscoveryRobustness.ts` — "Discovery
  weighted selection completes within max iterations"
- `test/ErrorGuidedStructuralEvolution/InvalidDataDetection.ts` — "Discovery
  validates all neurons have finite error values"
- `test/ErrorGuidedStructuralEvolution/InvalidDataDetection.ts` — "Discovery
  selection falls back gracefully on invalid totalErrorSum"
- `test/ErrorGuidedStructuralEvolution/MinimalCreature.ts` — "Discovery
  selection respects neuron count limit"

They were confirmed unrelated by stashing the `src/` changes and re-running the
same files against the untouched base — the counts are identical either way:

```
$ git stash push src/ && deno test test/ErrorGuidedStructuralEvolution/DiscoveryRobustness.ts \
    test/ErrorGuidedStructuralEvolution/InvalidDataDetection.ts
FAILED | 5 passed | 3 failed          # base, without this PR

$ git stash pop && deno test <same files>
FAILED | 5 passed | 3 failed          # with this PR — unchanged
```

`MinimalCreature.ts` likewise fails identically with and without the change.
Fixing them belongs to #3531, not to this dead-code sweep. Every other step of
`./quality.sh` (dependency check, `deno fmt`, `deno lint`, `deno check` across
520 source files) is green.



## Milestone
This PR is part of the **Dead code 29 Jul** milestone and targets the `milestone/dead-code-29-jul` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-ms6ai3do-638168`<!-- vibe-worker-issue-3511 -->