### PR TITLE
Give MALFORMED_BUFFER codes a caller and a loud label (Issue #3512)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-3512.md
+++ b/docs/archive/pr-summaries/pr-summary-3512.md
@@ -1,0 +1,92 @@
+# PR Summary — Issue #3512
+
+## Summary
+
+`TOPOLOGY_MALFORMED_BUFFER` and `STRUCTURAL_MALFORMED_BUFFER` in
+`src/wasm/WasmTopologyOps.ts` had no reference anywhere in the repository. The
+dead-code audit offered two options — keep them with an explanatory comment, or
+delete them. Investigating showed a third, better answer: the codes were dead
+**because a real gap existed downstream**. `creatureValidate` maps error codes
+to human-readable labels, and neither malformed-buffer code was in those maps —
+so a Rust-side `MALFORMED_BUFFER` return surfaced to users as
+`WASM topology validation failed: unknown at synapse N`. That is a quiet
+failure: the fault happened, but the diagnostic hid its cause.
+
+This PR **keeps** both constants and gives them a real caller:
+
+- New `src/wasm/TopologyErrorMessages.ts` holds the single source of truth for
+  code → label, including `Malformed input buffers` and
+  `Malformed structural input buffers`.
+- `src/architecture/CreatureValidate.ts` now calls `topologyErrorMessage()` /
+  `structuralErrorMessage()` instead of rebuilding two inline
+  `Record<number, string>` maps at every validation failure (DRY).
+- Unrecognised codes fall back to `unrecognised topology error code N` rather
+  than a bare `unknown`, so a future core code that outruns the TypeScript side
+  is still loud and self-identifying.
+- A short comment on the constants block records that it deliberately mirrors
+  the complete Rust code set, so the next audit does not re-flag it.
+
+No public API changed; the constants keep their existing exports and values.
+
+Closes #3512.
+
+## Evidence
+
+Backend/library change — no web interface to screenshot. Evidence is the test
+run plus the reference check.
+
+Before: the constants had no caller outside their own file.
+
+```
+$ grep -rn 'TOPOLOGY_MALFORMED_BUFFER\|STRUCTURAL_MALFORMED_BUFFER' src test bench scripts mod.ts
+src/wasm/WasmTopologyOps.ts:48:export const TOPOLOGY_MALFORMED_BUFFER = 6;
+src/wasm/WasmTopologyOps.ts:81:export const STRUCTURAL_MALFORMED_BUFFER = 10;
+```
+
+After: both are referenced by the label lookup and its tests.
+
+```
+src/wasm/TopologyErrorMessages.ts:37:  [TOPOLOGY_MALFORMED_BUFFER]: "Malformed input buffers",
+src/wasm/TopologyErrorMessages.ts:50:  [STRUCTURAL_MALFORMED_BUFFER]: "Malformed structural input buffers",
+test/wasm/TopologyErrorMessages.ts: (8 assertions across both families)
+```
+
+New tests:
+
+```
+$ deno test --allow-all test/wasm/TopologyErrorMessages.ts < /dev/null
+ok | 8 passed | 0 failed (4ms)
+```
+
+Error-code flow after the change:
+
+```mermaid
+flowchart LR
+    Rust["neat-core topology_ops.rs<br/>returns errorCode"] --> Ops["WasmTopologyOps.ts<br/>TOPOLOGY_* / STRUCTURAL_* constants"]
+    Ops --> Msg["TopologyErrorMessages.ts<br/>topologyErrorMessage / structuralErrorMessage"]
+    Msg --> Val["CreatureValidate.ts<br/>TopologyError / ValidationError"]
+    Msg -. "unmapped code" .-> Loud["unrecognised … code N<br/>(names itself, never silent)"]
+```
+
+### Quality gate
+
+`./quality.sh < /dev/null` — lint, format, bash syntax, `deno check`, WASM sync
+and parity gate all pass. The suite finished `7994 passed | 4 failed`; the four
+failures are pre-existing Discovery-selection tests
+(`test/ErrorGuidedStructuralEvolution/*`) that fail identically on the branch
+point with these changes stashed, and are unrelated to this PR.
+
+## Test Plan
+
+Added `test/wasm/TopologyErrorMessages.ts` (8 tests, all calling the real
+functions and asserting on returned values):
+
+- `topologyErrorMessage`/`structuralErrorMessage` return a specific label for
+  the malformed-buffer codes — the regression test for the "unknown" gap.
+- Every code in each family maps to a non-empty, distinct, non-fallback label.
+- Code `6` resolves differently per family (topology `MALFORMED_BUFFER` vs
+  structural `IF_TOO_FEW_INWARD`), so the two lookups are not interchangeable.
+- Unrecognised codes (`99`, `-1`) name the code in the fallback message.
+- Non-finite codes (`NaN`, `Infinity`) fall back without throwing.
+
+No existing tests were removed or modified.

--- a/src/architecture/CreatureValidate.ts
+++ b/src/architecture/CreatureValidate.ts
@@ -15,21 +15,9 @@ import { neuronWireLabelForDiagnostics } from "@neuron/NeuronSerialization.ts";
 import { DIAGNOSTICS_DIR } from "@utils/Diagnostics.ts";
 import { TypedTopology } from "@architecture/TypedTopology.ts";
 import {
-  STRUCTURAL_BIAS_NOT_FINITE,
-  STRUCTURAL_CONSTANT_HAS_INWARD,
-  STRUCTURAL_HIDDEN_NO_INWARD,
-  STRUCTURAL_HIDDEN_NO_OUTWARD,
-  STRUCTURAL_IF_MISSING_CONDITION,
-  STRUCTURAL_IF_MISSING_NEGATIVE,
-  STRUCTURAL_IF_MISSING_POSITIVE,
-  STRUCTURAL_IF_TOO_FEW_INWARD,
-  STRUCTURAL_SYNAPSE_TARGETS_INPUT,
-  TOPOLOGY_BACKWARD_CONNECTION,
-  TOPOLOGY_DUPLICATE_CONNECTION,
-  TOPOLOGY_SELF_CONNECTION,
-  TOPOLOGY_SORT_ERROR_FROM,
-  TOPOLOGY_SORT_ERROR_TO,
-} from "@wasm/WasmTopologyOps.ts";
+  structuralErrorMessage,
+  topologyErrorMessage,
+} from "@wasm/TopologyErrorMessages.ts";
 
 const MAX_NEURON_ID = 2_147_483_647; // int32 max
 
@@ -434,16 +422,9 @@ export function creatureValidate(
     const topoResult = topo.validateForwardOnly();
     if (!topoResult.valid) {
       debugWrite(creature);
-      const messages: Record<number, string> = {
-        [TOPOLOGY_SELF_CONNECTION]: "Self-connection",
-        [TOPOLOGY_BACKWARD_CONNECTION]: "Backward connection",
-        [TOPOLOGY_SORT_ERROR_FROM]: "From indices not sorted",
-        [TOPOLOGY_SORT_ERROR_TO]: "To indices not sorted",
-        [TOPOLOGY_DUPLICATE_CONNECTION]: "Duplicate connection",
-      };
       throw new TopologyError(
         `WASM topology validation failed: ${
-          messages[topoResult.errorCode] ?? "unknown"
+          topologyErrorMessage(topoResult.errorCode)
         } at synapse ${topoResult.synapseIndex}`,
         "INVALID_CONNECTION",
       );
@@ -453,25 +434,9 @@ export function creatureValidate(
     const structResult = topo.validateStructuralIntegrity();
     if (!structResult.valid) {
       debugWrite(creature);
-      const messages: Record<number, string> = {
-        [STRUCTURAL_SYNAPSE_TARGETS_INPUT]: "Synapse targets input neuron",
-        [STRUCTURAL_CONSTANT_HAS_INWARD]:
-          "Constant neuron has inward connections",
-        [STRUCTURAL_HIDDEN_NO_INWARD]:
-          "Hidden neuron has no inward connections",
-        [STRUCTURAL_HIDDEN_NO_OUTWARD]:
-          "Hidden neuron has no outward connections",
-        [STRUCTURAL_BIAS_NOT_FINITE]: "Non-finite bias",
-        [STRUCTURAL_IF_TOO_FEW_INWARD]:
-          "IF neuron has too few inward connections",
-        [STRUCTURAL_IF_MISSING_CONDITION]:
-          "IF neuron missing condition synapse",
-        [STRUCTURAL_IF_MISSING_POSITIVE]: "IF neuron missing positive synapse",
-        [STRUCTURAL_IF_MISSING_NEGATIVE]: "IF neuron missing negative synapse",
-      };
       throw new ValidationError(
         `WASM structural validation failed: ${
-          messages[structResult.errorCode] ?? "unknown"
+          structuralErrorMessage(structResult.errorCode)
         } at neuron ${structResult.neuronIndex}`,
         "OTHER",
       );

--- a/src/wasm/TopologyErrorMessages.ts
+++ b/src/wasm/TopologyErrorMessages.ts
@@ -1,0 +1,63 @@
+/**
+ * TopologyErrorMessages.ts — human-readable labels for the topology and
+ * structural error codes returned by NEAT-AI-core (`topology_ops.rs`).
+ *
+ * Issue #3512: the malformed-buffer codes added for #2659 had no caller, so
+ * a Rust-side `MALFORMED_BUFFER` return reached users as a bare "unknown".
+ * Keeping the lookup here — beside the constants it mirrors — gives every
+ * code in the wire contract a loud, specific label and a single source of
+ * truth for callers such as `creatureValidate`.
+ */
+
+import {
+  STRUCTURAL_BIAS_NOT_FINITE,
+  STRUCTURAL_CONSTANT_HAS_INWARD,
+  STRUCTURAL_HIDDEN_NO_INWARD,
+  STRUCTURAL_HIDDEN_NO_OUTWARD,
+  STRUCTURAL_IF_MISSING_CONDITION,
+  STRUCTURAL_IF_MISSING_NEGATIVE,
+  STRUCTURAL_IF_MISSING_POSITIVE,
+  STRUCTURAL_IF_TOO_FEW_INWARD,
+  STRUCTURAL_MALFORMED_BUFFER,
+  STRUCTURAL_SYNAPSE_TARGETS_INPUT,
+  TOPOLOGY_BACKWARD_CONNECTION,
+  TOPOLOGY_DUPLICATE_CONNECTION,
+  TOPOLOGY_MALFORMED_BUFFER,
+  TOPOLOGY_SELF_CONNECTION,
+  TOPOLOGY_SORT_ERROR_FROM,
+  TOPOLOGY_SORT_ERROR_TO,
+} from "@wasm/WasmTopologyOps.ts";
+
+const TOPOLOGY_MESSAGES: Record<number, string> = {
+  [TOPOLOGY_SELF_CONNECTION]: "Self-connection",
+  [TOPOLOGY_BACKWARD_CONNECTION]: "Backward connection",
+  [TOPOLOGY_SORT_ERROR_FROM]: "From indices not sorted",
+  [TOPOLOGY_SORT_ERROR_TO]: "To indices not sorted",
+  [TOPOLOGY_DUPLICATE_CONNECTION]: "Duplicate connection",
+  [TOPOLOGY_MALFORMED_BUFFER]: "Malformed input buffers",
+};
+
+const STRUCTURAL_MESSAGES: Record<number, string> = {
+  [STRUCTURAL_SYNAPSE_TARGETS_INPUT]: "Synapse targets input neuron",
+  [STRUCTURAL_CONSTANT_HAS_INWARD]: "Constant neuron has inward connections",
+  [STRUCTURAL_HIDDEN_NO_INWARD]: "Hidden neuron has no inward connections",
+  [STRUCTURAL_HIDDEN_NO_OUTWARD]: "Hidden neuron has no outward connections",
+  [STRUCTURAL_BIAS_NOT_FINITE]: "Non-finite bias",
+  [STRUCTURAL_IF_TOO_FEW_INWARD]: "IF neuron has too few inward connections",
+  [STRUCTURAL_IF_MISSING_CONDITION]: "IF neuron missing condition synapse",
+  [STRUCTURAL_IF_MISSING_POSITIVE]: "IF neuron missing positive synapse",
+  [STRUCTURAL_IF_MISSING_NEGATIVE]: "IF neuron missing negative synapse",
+  [STRUCTURAL_MALFORMED_BUFFER]: "Malformed structural input buffers",
+};
+
+/** Label for a `TOPOLOGY_*` error code; unrecognised codes name themselves. */
+export function topologyErrorMessage(errorCode: number): string {
+  return TOPOLOGY_MESSAGES[errorCode] ??
+    `unrecognised topology error code ${errorCode}`;
+}
+
+/** Label for a `STRUCTURAL_*` error code; unrecognised codes name themselves. */
+export function structuralErrorMessage(errorCode: number): string {
+  return STRUCTURAL_MESSAGES[errorCode] ??
+    `unrecognised structural error code ${errorCode}`;
+}

--- a/src/wasm/WasmTopologyOps.ts
+++ b/src/wasm/WasmTopologyOps.ts
@@ -24,6 +24,11 @@ import {
 
 // ---------------------------------------------------------------------------
 // Constants — topology validation error codes (must match Rust topology_ops.rs)
+//
+// This block deliberately mirrors the *complete* Rust code set, so a code
+// returned by core always has a named constant here. Every code is labelled
+// for diagnostics in `TopologyErrorMessages.ts` (Issue #3512) — add both the
+// constant and its label when core gains a new code.
 // ---------------------------------------------------------------------------
 
 /** Topology is valid. */

--- a/test/wasm/TopologyErrorMessages.ts
+++ b/test/wasm/TopologyErrorMessages.ts
@@ -1,0 +1,114 @@
+/**
+ * Tests for the WASM topology/structural error-code labels (Issue #3512).
+ *
+ * The malformed-buffer codes added by NEAT-AI #2659 previously had no
+ * caller, so a Rust-side `MALFORMED_BUFFER` return surfaced to users as
+ * "unknown" — a quiet failure. These tests assert every code in the wire
+ * contract maps to a distinct, meaningful label, and that an unrecognised
+ * code names itself rather than hiding behind a bare "unknown".
+ */
+
+import { assert, assertEquals, assertNotEquals } from "@std/assert";
+import {
+  structuralErrorMessage,
+  topologyErrorMessage,
+} from "@wasm/TopologyErrorMessages.ts";
+import {
+  STRUCTURAL_BIAS_NOT_FINITE,
+  STRUCTURAL_CONSTANT_HAS_INWARD,
+  STRUCTURAL_HIDDEN_NO_INWARD,
+  STRUCTURAL_HIDDEN_NO_OUTWARD,
+  STRUCTURAL_IF_MISSING_CONDITION,
+  STRUCTURAL_IF_MISSING_NEGATIVE,
+  STRUCTURAL_IF_MISSING_POSITIVE,
+  STRUCTURAL_IF_TOO_FEW_INWARD,
+  STRUCTURAL_MALFORMED_BUFFER,
+  STRUCTURAL_SYNAPSE_TARGETS_INPUT,
+  TOPOLOGY_BACKWARD_CONNECTION,
+  TOPOLOGY_DUPLICATE_CONNECTION,
+  TOPOLOGY_MALFORMED_BUFFER,
+  TOPOLOGY_SELF_CONNECTION,
+  TOPOLOGY_SORT_ERROR_FROM,
+  TOPOLOGY_SORT_ERROR_TO,
+} from "@wasm/WasmTopologyOps.ts";
+
+Deno.test("topologyErrorMessage: malformed buffer code is described, not 'unknown'", () => {
+  const message = topologyErrorMessage(TOPOLOGY_MALFORMED_BUFFER);
+  assertEquals(message, "Malformed input buffers");
+});
+
+Deno.test("structuralErrorMessage: malformed buffer code is described, not 'unknown'", () => {
+  const message = structuralErrorMessage(STRUCTURAL_MALFORMED_BUFFER);
+  assertEquals(message, "Malformed structural input buffers");
+});
+
+Deno.test("topologyErrorMessage: every topology error code has a distinct label", () => {
+  const codes = [
+    TOPOLOGY_SELF_CONNECTION,
+    TOPOLOGY_BACKWARD_CONNECTION,
+    TOPOLOGY_SORT_ERROR_FROM,
+    TOPOLOGY_SORT_ERROR_TO,
+    TOPOLOGY_DUPLICATE_CONNECTION,
+    TOPOLOGY_MALFORMED_BUFFER,
+  ];
+  const labels = codes.map(topologyErrorMessage);
+  for (const label of labels) {
+    assert(label.length > 0, "label must not be empty");
+    assert(
+      !label.includes("unrecognised"),
+      `known code produced a fallback label: ${label}`,
+    );
+  }
+  assertEquals(new Set(labels).size, codes.length, "labels must be distinct");
+});
+
+Deno.test("structuralErrorMessage: every structural error code has a distinct label", () => {
+  const codes = [
+    STRUCTURAL_SYNAPSE_TARGETS_INPUT,
+    STRUCTURAL_CONSTANT_HAS_INWARD,
+    STRUCTURAL_HIDDEN_NO_INWARD,
+    STRUCTURAL_HIDDEN_NO_OUTWARD,
+    STRUCTURAL_BIAS_NOT_FINITE,
+    STRUCTURAL_IF_TOO_FEW_INWARD,
+    STRUCTURAL_IF_MISSING_CONDITION,
+    STRUCTURAL_IF_MISSING_POSITIVE,
+    STRUCTURAL_IF_MISSING_NEGATIVE,
+    STRUCTURAL_MALFORMED_BUFFER,
+  ];
+  const labels = codes.map(structuralErrorMessage);
+  for (const label of labels) {
+    assert(label.length > 0, "label must not be empty");
+    assert(
+      !label.includes("unrecognised"),
+      `known code produced a fallback label: ${label}`,
+    );
+  }
+  assertEquals(new Set(labels).size, codes.length, "labels must be distinct");
+});
+
+Deno.test("topologyErrorMessage: the two families do not share labels", () => {
+  // Code 6 means MALFORMED_BUFFER for topology but IF_TOO_FEW_INWARD for
+  // structural — the lookups must not be interchangeable.
+  assertNotEquals(topologyErrorMessage(6), structuralErrorMessage(6));
+});
+
+Deno.test("topologyErrorMessage: unrecognised code names itself", () => {
+  const message = topologyErrorMessage(99);
+  assert(
+    message.includes("99"),
+    `fallback must name the code, got: ${message}`,
+  );
+});
+
+Deno.test("structuralErrorMessage: unrecognised code names itself", () => {
+  const message = structuralErrorMessage(-1);
+  assert(
+    message.includes("-1"),
+    `fallback must name the code, got: ${message}`,
+  );
+});
+
+Deno.test("topologyErrorMessage: non-finite code falls back without throwing", () => {
+  assert(topologyErrorMessage(NaN).includes("NaN"));
+  assert(structuralErrorMessage(Number.POSITIVE_INFINITY).includes("Infinity"));
+});


### PR DESCRIPTION
# PR Summary — Issue #3512

## Summary

`TOPOLOGY_MALFORMED_BUFFER` and `STRUCTURAL_MALFORMED_BUFFER` in
`src/wasm/WasmTopologyOps.ts` had no reference anywhere in the repository. The
dead-code audit offered two options — keep them with an explanatory comment, or
delete them. Investigating showed a third, better answer: the codes were dead
**because a real gap existed downstream**. `creatureValidate` maps error codes
to human-readable labels, and neither malformed-buffer code was in those maps —
so a Rust-side `MALFORMED_BUFFER` return surfaced to users as
`WASM topology validation failed: unknown at synapse N`. That is a quiet
failure: the fault happened, but the diagnostic hid its cause.

This PR **keeps** both constants and gives them a real caller:

- New `src/wasm/TopologyErrorMessages.ts` holds the single source of truth for
  code → label, including `Malformed input buffers` and
  `Malformed structural input buffers`.
- `src/architecture/CreatureValidate.ts` now calls `topologyErrorMessage()` /
  `structuralErrorMessage()` instead of rebuilding two inline
  `Record<number, string>` maps at every validation failure (DRY).
- Unrecognised codes fall back to `unrecognised topology error code N` rather
  than a bare `unknown`, so a future core code that outruns the TypeScript side
  is still loud and self-identifying.
- A short comment on the constants block records that it deliberately mirrors
  the complete Rust code set, so the next audit does not re-flag it.

No public API changed; the constants keep their existing exports and values.

Closes #3512.

## Evidence

Backend/library change — no web interface to screenshot. Evidence is the test
run plus the reference check.

Before: the constants had no caller outside their own file.

```
$ grep -rn 'TOPOLOGY_MALFORMED_BUFFER\|STRUCTURAL_MALFORMED_BUFFER' src test bench scripts mod.ts
src/wasm/WasmTopologyOps.ts:48:export const TOPOLOGY_MALFORMED_BUFFER = 6;
src/wasm/WasmTopologyOps.ts:81:export const STRUCTURAL_MALFORMED_BUFFER = 10;
```

After: both are referenced by the label lookup and its tests.

```
src/wasm/TopologyErrorMessages.ts:37:  [TOPOLOGY_MALFORMED_BUFFER]: "Malformed input buffers",
src/wasm/TopologyErrorMessages.ts:50:  [STRUCTURAL_MALFORMED_BUFFER]: "Malformed structural input buffers",
test/wasm/TopologyErrorMessages.ts: (8 assertions across both families)
```

New tests:

```
$ deno test --allow-all test/wasm/TopologyErrorMessages.ts < /dev/null
ok | 8 passed | 0 failed (4ms)
```

Error-code flow after the change:

```mermaid
flowchart LR
    Rust["neat-core topology_ops.rs<br/>returns errorCode"] --> Ops["WasmTopologyOps.ts<br/>TOPOLOGY_* / STRUCTURAL_* constants"]
    Ops --> Msg["TopologyErrorMessages.ts<br/>topologyErrorMessage / structuralErrorMessage"]
    Msg --> Val["CreatureValidate.ts<br/>TopologyError / ValidationError"]
    Msg -. "unmapped code" .-> Loud["unrecognised … code N<br/>(names itself, never silent)"]
```

### Quality gate

`./quality.sh < /dev/null` — lint, format, bash syntax, `deno check`, WASM sync
and parity gate all pass. The suite finished `7994 passed | 4 failed`; the four
failures are pre-existing Discovery-selection tests
(`test/ErrorGuidedStructuralEvolution/*`) that fail identically on the branch
point with these changes stashed, and are unrelated to this PR.

## Test Plan

Added `test/wasm/TopologyErrorMessages.ts` (8 tests, all calling the real
functions and asserting on returned values):

- `topologyErrorMessage`/`structuralErrorMessage` return a specific label for
  the malformed-buffer codes — the regression test for the "unknown" gap.
- Every code in each family maps to a non-empty, distinct, non-fallback label.
- Code `6` resolves differently per family (topology `MALFORMED_BUFFER` vs
  structural `IF_TOO_FEW_INWARD`), so the two lookups are not interchangeable.
- Unrecognised codes (`99`, `-1`) name the code in the fallback message.
- Non-finite codes (`NaN`, `Infinity`) fall back without throwing.

No existing tests were removed or modified.



## Milestone
This PR is part of the **Dead code 29 Jul** milestone and targets the `milestone/dead-code-29-jul` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-ms6dgvmj-0688e7`<!-- vibe-worker-issue-3512 -->