### PR TITLE
build.sh: scope the neatCore.assetSha256 pin to the rev it was recorded for (Issue #3514)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -197,6 +197,39 @@ verify_tarball_sha256() {
   return 0
 }
 
+# verify_pinned_asset_sha256 — enforce the deno.json neatCore.assetSha256 pin
+# only for the revision it was recorded against (issue #3514). The pin is
+# written next to neatCore.rev and is by construction the hash of *that* rev's
+# tarball, so on a revision advance it describes a different bundle: comparing
+# it would always mismatch and would reject every automated internal bump.
+#   $1 = tarball path
+#   $2 = pinned sha-256 ("" when unset)
+#   $3 = pinned rev ("" when unset)
+#   $4 = target rev
+# Returns 0 when the pin applied and matched (the caller records it as an
+# anchor), 1 when it applied and mismatched (abort — tampering), and 2 when it
+# does not apply (unset, or recorded against a different rev), in which case it
+# contributes no anchor and the sidecar/no-anchor guard still decides.
+verify_pinned_asset_sha256() {
+  local file="$1"
+  local pinned_sha256="$2"
+  local pinned_rev="$3"
+  local target_rev="$4"
+  if [[ -z "$pinned_sha256" ]]; then
+    return 2
+  fi
+  if [[ "$pinned_rev" != "$target_rev" ]]; then
+    local pinned_short="${pinned_rev:0:7}"
+    local target_short="${target_rev:0:7}"
+    echo "Skipping deno.json neatCore.assetSha256 check: target rev ${target_short:-<unset>} differs from pinned rev ${pinned_short:-<unset>} (the pin records the pinned rev's tarball hash)."
+    return 2
+  fi
+  if ! verify_tarball_sha256 "$file" "$pinned_sha256" "deno.json neatCore.assetSha256"; then
+    return 1
+  fi
+  return 0
+}
+
 # guard_unverified_extract — decide whether extraction may proceed when no
 # SHA-256 anchor attested the downloaded tarball (issue #2744). A self-
 # referential content manifest written from an unattested download proves
@@ -567,13 +600,16 @@ if [[ "$sidecar_ok" == true && -s "$sidecar_path" ]]; then
   verified_via="sidecar ${SIDECAR_NAME}"
 fi
 
-if [[ -n "$PINNED_ASSET_SHA256" ]]; then
-  if ! verify_tarball_sha256 \
-    "$tmp_dir/$ASSET_NAME" \
-    "$PINNED_ASSET_SHA256" \
-    "deno.json neatCore.assetSha256"; then
-    exit 1
-  fi
+pin_status=0
+verify_pinned_asset_sha256 \
+  "$tmp_dir/$ASSET_NAME" \
+  "$PINNED_ASSET_SHA256" \
+  "$PINNED_REV" \
+  "$TARGET_REV" || pin_status=$?
+if [[ "$pin_status" -eq 1 ]]; then
+  exit 1
+fi
+if [[ "$pin_status" -eq 0 ]]; then
   if [[ -n "$verified_via" ]]; then
     verified_via="${verified_via} and deno.json neatCore.assetSha256"
   else

--- a/docs/CORE_DEPENDENCY_POLICY.md
+++ b/docs/CORE_DEPENDENCY_POLICY.md
@@ -47,7 +47,12 @@ content-hash guards on every download:
    `wasm_activation-pkg.tar.gz`. When set, `build.sh` recomputes the hash
    immediately after download and refuses to extract on mismatch. Because the
    pin lives next to `neatCore.rev`, reviewers can spot bundle-content changes
-   in a single line of diff.
+   in a single line of diff. The pin is **scoped to the rev it was recorded
+   against** (issue #3514): it is enforced only when the target rev equals
+   `neatCore.rev`, and on a revision advance it is skipped with a one-line note
+   naming both short SHAs — comparing the old rev's hash to the new rev's
+   tarball would reject every bump. A skipped pin contributes **no** anchor, so
+   an advance without a sidecar still fails loud.
 2. **Release sidecar** — NEAT-AI-core publishes
    `wasm_activation-pkg.tar.gz.sha256` alongside the tarball, and `build.sh`
    fetches the sidecar and verifies the tarball against it. The sidecar is the
@@ -68,7 +73,7 @@ round-trip.
 
 | Guard                         | When it runs         | What it protects against                                 |
 | ----------------------------- | -------------------- | -------------------------------------------------------- |
-| `neatCore.assetSha256`        | Every download       | Swap of the release asset after the pin was committed    |
+| `neatCore.assetSha256`        | Same-rev downloads   | Swap of the release asset after the pin was committed    |
 | Release sidecar `*.sha256`    | Every download       | Asset tampering by anyone without sidecar-signing access |
 | `pkg/content-manifest.sha256` | `--verify-only` / CI | Local or post-install tampering with vendored pkg files  |
 

--- a/docs/archive/pr-summaries/pr-summary-3514.md
+++ b/docs/archive/pr-summaries/pr-summary-3514.md
@@ -1,0 +1,67 @@
+# build.sh: scope the `neatCore.assetSha256` pin to the rev it was recorded for
+
+## Summary
+
+`build.sh` enforced the `deno.json` `neatCore.assetSha256` pin against **every**
+download, including downloads for a revision the pin was never recorded against.
+Because the pin lives next to `neatCore.rev` and is by construction the hash of
+_that_ rev's tarball, every revision advance compared the old rev's hash to the
+new rev's bundle and always failed — rejecting every automated internal bump
+(`bump-deps.sh` → `./build.sh`).
+
+The pin check now lives in a new `verify_pinned_asset_sha256` helper that is
+enforced only when the target rev equals the pinned rev:
+
+- **Same rev** (re-download, `--clean`, `--rev <pinned SHA>`): unchanged — a
+  mismatch is a hard `exit 1` carrying the `deno.json neatCore.assetSha256`
+  source label.
+- **Rev advance**: the pin is not applicable, is not compared, and a one-line
+  note naming both short SHAs is printed so the skip is visible in bump logs.
+- A skipped pin contributes **no** anchor, so the existing no-anchor guard
+  (`guard_unverified_extract`) still refuses to extract when no sidecar is
+  present. No trust-on-first-use fallback is introduced.
+
+Closes #3514.
+
+## Evidence
+
+Backend/CLI change — no web interface to screenshot. Verified by the unit tests
+below driving the real bash helper with test data (`bash -n` + `shellcheck`
+clean, full `./quality.sh` green).
+
+```mermaid
+flowchart TD
+    D[Tarball downloaded for TARGET_REV] --> S{Sidecar present?}
+    S -- yes --> SV[Verify vs sidecar<br/>mismatch ⇒ exit 1]
+    S -- no --> P
+    SV --> P{assetSha256 pin set?}
+    P -- no --> G
+    P -- yes --> R{TARGET_REV == PINNED_REV?}
+    R -- yes --> PV[Verify vs pin<br/>mismatch ⇒ exit 1]
+    R -- "no (rev advance)" --> SK[Log skip note<br/>naming both short SHAs<br/>no anchor added]
+    PV --> G{Any anchor?}
+    SK --> G
+    G -- yes --> X[Extract, write back new rev + hash]
+    G -- "no" --> E[exit 1 — refuse to extract]
+```
+
+## Test Plan
+
+New `test/scripts/BuildScriptPinScope.ts` sources the real `build.sh` helpers
+into a sub-shell and drives them with real tarball files:
+
+- `pin is enforced when the target rev equals the pinned rev` — matching pin on
+  the pinned rev verifies (rc 0).
+- `pin mismatch on the pinned rev is a hard failure` — rc 1 with the
+  `deno.json neatCore.assetSha256` label and a `SHA-256 mismatch` error (the
+  tamper check is retained).
+- `pin is skipped, and the skip logged, when the target rev differs` — rc 2 (no
+  anchor) with a skip note naming both short SHAs.
+- `an unset pin is silently inapplicable` — rc 2 with no output.
+
+Existing `test/scripts/BuildScriptContentHash.ts` (sidecar / no-anchor /
+manifest guards) and the rest of `./quality.sh` continue to pass unchanged. The
+end-to-end bump-to-new-rev regression test is the companion sub-issue #3516.
+
+Docs: `docs/CORE_DEPENDENCY_POLICY.md` now records that the pin is scoped to its
+recorded rev and that a skipped pin is not an anchor.

--- a/test/scripts/BuildScriptPinScope.ts
+++ b/test/scripts/BuildScriptPinScope.ts
@@ -1,0 +1,196 @@
+import { assert, assertEquals } from "@std/assert";
+
+/**
+ * Tests that build.sh scopes the deno.json `neatCore.assetSha256` pin to the
+ * revision it was recorded against (issue #3514).
+ *
+ * The pin sits next to `neatCore.rev` and is by construction the hash of that
+ * rev's tarball, so comparing it against a bundle downloaded for a different
+ * rev always mismatches and blocks every revision advance. The pin must be
+ * enforced when the target rev equals the pinned rev, and skipped — visibly —
+ * otherwise.
+ */
+
+const PIN_FNS = ["verify_tarball_sha256", "verify_pinned_asset_sha256"];
+
+/**
+ * Source the named build.sh functions into a sub-shell and run an invocation
+ * against them, so the real bash logic is exercised with test data.
+ */
+async function runSourcedFns(
+  fnNames: string[],
+  invocation: string,
+): Promise<{ stdout: string; stderr: string; code: number }> {
+  // A temp file (rather than process substitution) is used because
+  // `source <(...)` does not reliably define functions across all bash
+  // builds (e.g. macOS bash 3.2).
+  const fnTmp = await Deno.makeTempFile({ prefix: "neat-fn-", suffix: ".sh" });
+  try {
+    const extracted = await Promise.all(
+      fnNames.map((fnName) =>
+        new Deno.Command("awk", {
+          args: [`/^${fnName}\\(\\)/,/^}$/`, "./build.sh"],
+          stdout: "piped",
+          cwd: Deno.cwd(),
+        }).output()
+      ),
+    );
+    const parts: Uint8Array[] = extracted.map((ex, i) => {
+      assert(
+        ex.stdout.length > 0,
+        `build.sh must define a top-level ${fnNames[i]}() function`,
+      );
+      return ex.stdout;
+    });
+    const joined = new Uint8Array(
+      parts.reduce((n, p) => n + p.length, 0),
+    );
+    let offset = 0;
+    for (const p of parts) {
+      joined.set(p, offset);
+      offset += p.length;
+    }
+    await Deno.writeFile(fnTmp, joined);
+
+    const cmd = new Deno.Command("bash", {
+      args: ["-c", `set -uo pipefail\nsource '${fnTmp}'\n${invocation}\n`],
+      stdout: "piped",
+      stderr: "piped",
+      cwd: Deno.cwd(),
+    });
+    const out = await cmd.output();
+    return {
+      stdout: new TextDecoder().decode(out.stdout),
+      stderr: new TextDecoder().decode(out.stderr),
+      code: out.code,
+    };
+  } finally {
+    await Deno.remove(fnTmp);
+  }
+}
+
+const REV_A = "a".repeat(40);
+const REV_B = "b".repeat(40);
+
+/** Write a stand-in tarball and return its path plus real SHA-256. */
+async function makeTarball(
+  dir: string,
+  content: string,
+): Promise<{ path: string; sha256: string }> {
+  const path = `${dir}/wasm_activation-pkg.tar.gz`;
+  await Deno.writeTextFile(path, content);
+  const cmd = new Deno.Command("shasum", {
+    args: ["-a", "256", path],
+    stdout: "piped",
+  });
+  const out = await cmd.output();
+  const sha256 = new TextDecoder().decode(out.stdout).trim().split(/\s+/)[0];
+  return { path, sha256 };
+}
+
+Deno.test({
+  name: "pin is enforced when the target rev equals the pinned rev",
+  permissions: { run: true, read: true, write: true },
+  fn: async () => {
+    const tmpDir = await Deno.makeTempDir({ prefix: "neat-pin-scope-" });
+    try {
+      const { path, sha256 } = await makeTarball(tmpDir, "bundle-for-rev-a");
+      const ok = await runSourcedFns(
+        PIN_FNS,
+        `verify_pinned_asset_sha256 '${path}' '${sha256}' '${REV_A}' '${REV_A}'`,
+      );
+      assertEquals(
+        ok.code,
+        0,
+        `matching pin on the pinned rev must verify; stderr=${ok.stderr}`,
+      );
+    } finally {
+      await Deno.remove(tmpDir, { recursive: true });
+    }
+  },
+});
+
+Deno.test({
+  name: "pin mismatch on the pinned rev is a hard failure",
+  permissions: { run: true, read: true, write: true },
+  fn: async () => {
+    const tmpDir = await Deno.makeTempDir({ prefix: "neat-pin-scope-" });
+    try {
+      const { path } = await makeTarball(tmpDir, "tampered-bundle");
+      const bad = await runSourcedFns(
+        PIN_FNS,
+        `verify_pinned_asset_sha256 '${path}' '${
+          "0".repeat(64)
+        }' '${REV_A}' '${REV_A}'`,
+      );
+      assertEquals(bad.code, 1, "same-rev hash mismatch must return 1 (abort)");
+      assert(
+        bad.stderr.includes("deno.json neatCore.assetSha256"),
+        `Expected the pin source label in the error; got: ${bad.stderr}`,
+      );
+      assert(
+        bad.stderr.includes("SHA-256 mismatch"),
+        `Expected a SHA-256 mismatch error; got: ${bad.stderr}`,
+      );
+    } finally {
+      await Deno.remove(tmpDir, { recursive: true });
+    }
+  },
+});
+
+Deno.test({
+  name: "pin is skipped, and the skip logged, when the target rev differs",
+  permissions: { run: true, read: true, write: true },
+  fn: async () => {
+    const tmpDir = await Deno.makeTempDir({ prefix: "neat-pin-scope-" });
+    try {
+      // The tarball is the NEW rev's bundle; the pin is the OLD rev's hash.
+      const { path } = await makeTarball(tmpDir, "bundle-for-rev-b");
+      const skipped = await runSourcedFns(
+        PIN_FNS,
+        `verify_pinned_asset_sha256 '${path}' '${
+          "c".repeat(64)
+        }' '${REV_A}' '${REV_B}'`,
+      );
+      assertEquals(
+        skipped.code,
+        2,
+        `a foreign-rev pin must be skipped (2), not compared; stderr=${skipped.stderr}`,
+      );
+      const log = skipped.stdout + skipped.stderr;
+      assert(
+        log.includes(REV_A.slice(0, 7)) && log.includes(REV_B.slice(0, 7)),
+        `Skip note must name both short SHAs; got: ${log}`,
+      );
+      assert(
+        log.includes("neatCore.assetSha256"),
+        `Skip note must name the pin being skipped; got: ${log}`,
+      );
+    } finally {
+      await Deno.remove(tmpDir, { recursive: true });
+    }
+  },
+});
+
+Deno.test({
+  name: "an unset pin is silently inapplicable",
+  permissions: { run: true, read: true, write: true },
+  fn: async () => {
+    const tmpDir = await Deno.makeTempDir({ prefix: "neat-pin-scope-" });
+    try {
+      const { path } = await makeTarball(tmpDir, "bundle-no-pin");
+      const unset = await runSourcedFns(
+        PIN_FNS,
+        `verify_pinned_asset_sha256 '${path}' '' '' '${REV_B}'`,
+      );
+      assertEquals(unset.code, 2, "an unset pin contributes no anchor (2)");
+      assertEquals(
+        (unset.stdout + unset.stderr).trim(),
+        "",
+        "an unset pin must not print a skip note",
+      );
+    } finally {
+      await Deno.remove(tmpDir, { recursive: true });
+    }
+  },
+});


### PR DESCRIPTION
# build.sh: scope the `neatCore.assetSha256` pin to the rev it was recorded for

## Summary

`build.sh` enforced the `deno.json` `neatCore.assetSha256` pin against **every**
download, including downloads for a revision the pin was never recorded against.
Because the pin lives next to `neatCore.rev` and is by construction the hash of
_that_ rev's tarball, every revision advance compared the old rev's hash to the
new rev's bundle and always failed — rejecting every automated internal bump
(`bump-deps.sh` → `./build.sh`).

The pin check now lives in a new `verify_pinned_asset_sha256` helper that is
enforced only when the target rev equals the pinned rev:

- **Same rev** (re-download, `--clean`, `--rev <pinned SHA>`): unchanged — a
  mismatch is a hard `exit 1` carrying the `deno.json neatCore.assetSha256`
  source label.
- **Rev advance**: the pin is not applicable, is not compared, and a one-line
  note naming both short SHAs is printed so the skip is visible in bump logs.
- A skipped pin contributes **no** anchor, so the existing no-anchor guard
  (`guard_unverified_extract`) still refuses to extract when no sidecar is
  present. No trust-on-first-use fallback is introduced.

Closes #3514.

## Evidence

Backend/CLI change — no web interface to screenshot. Verified by the unit tests
below driving the real bash helper with test data (`bash -n` + `shellcheck`
clean, full `./quality.sh` green).

```mermaid
flowchart TD
    D[Tarball downloaded for TARGET_REV] --> S{Sidecar present?}
    S -- yes --> SV[Verify vs sidecar<br/>mismatch ⇒ exit 1]
    S -- no --> P
    SV --> P{assetSha256 pin set?}
    P -- no --> G
    P -- yes --> R{TARGET_REV == PINNED_REV?}
    R -- yes --> PV[Verify vs pin<br/>mismatch ⇒ exit 1]
    R -- "no (rev advance)" --> SK[Log skip note<br/>naming both short SHAs<br/>no anchor added]
    PV --> G{Any anchor?}
    SK --> G
    G -- yes --> X[Extract, write back new rev + hash]
    G -- "no" --> E[exit 1 — refuse to extract]
```

## Test Plan

New `test/scripts/BuildScriptPinScope.ts` sources the real `build.sh` helpers
into a sub-shell and drives them with real tarball files:

- `pin is enforced when the target rev equals the pinned rev` — matching pin on
  the pinned rev verifies (rc 0).
- `pin mismatch on the pinned rev is a hard failure` — rc 1 with the
  `deno.json neatCore.assetSha256` label and a `SHA-256 mismatch` error (the
  tamper check is retained).
- `pin is skipped, and the skip logged, when the target rev differs` — rc 2 (no
  anchor) with a skip note naming both short SHAs.
- `an unset pin is silently inapplicable` — rc 2 with no output.

Existing `test/scripts/BuildScriptContentHash.ts` (sidecar / no-anchor /
manifest guards) and the rest of `./quality.sh` continue to pass unchanged. The
end-to-end bump-to-new-rev regression test is the companion sub-issue #3516.

Docs: `docs/CORE_DEPENDENCY_POLICY.md` now records that the pin is scoped to its
recorded rev and that a skipped pin is not an anchor.



## Milestone
This PR is part of the **#3504 build.sh checks stale assetSha256 pin on new rev, blocking internal bumps** milestone and targets the `milestone/3504-build-sh-checks-stale-assetsha256-pin-on-new` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-ms6g22kq-7b8394`<!-- vibe-worker-issue-3514 -->