### PR TITLE
bug: classify scorer data failures instead of falling back to WASM (Issue #3541)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,19 @@ adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Issue #3541:** The WASM fallback is no longer used as a "fallback" for
+  corrupt training data. A native scorer failure whose stderr identifies a
+  malformed/truncated dataset (`Trailing N bytes (incomplete record)` and
+  friends) is now classified by `src/score/ScorerFailureClassification.ts` and
+  raised as a `DatasetError` with the new `CORRUPT_DATA` reason, preserving the
+  scorer's own message and exit code — previously that diagnostic was demoted to
+  a warning and the run died on the WASM re-read of the same bytes with a bare
+  `AssertionError: Invalid number of bytes read`. Backend failures (missing
+  binary, GPU init, process crash) still fall back to WASM unchanged, and
+  `Fitness.calculate` no longer absorbs a data fault into its per-creature
+  retry. Both dataset readers (`evaluateDir`, the training loop) now report the
+  offending file, the bytes read, the record size, and the trailing byte count
+  via `assertWholeRecordRead` (`src/architecture/DatasetIO.ts`).
 - **Issue #3508:** The population can no longer exceed the configured
   `populationSize`. Each generation is assembled from several slices (elites,
   completed training / discovery results, fine-tuned creatures, bred offspring,

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-3541.md
+++ b/docs/archive/pr-summaries/pr-summary-3541.md
@@ -1,0 +1,57 @@
+## Summary
+
+The WASM path is a fallback for _backend_ failures, never for corrupt training
+data. `tryScoreWithRustScorer` treated every non-zero exit as backend-specific,
+so a rejected dataset logged the scorer's genuinely diagnostic
+`Trailing N bytes (incomplete record)` as a warning and then died on the WASM
+re-read of the same bytes with a bare
+`AssertionError: Invalid number of bytes read` — naming neither the file nor any
+byte count. Closes #3541.
+
+- **New `src/score/ScorerFailureClassification.ts`** — `isCorruptDatasetFailure`
+  matches the scorer's data-fault stderr shapes; `assertNotCorruptDataset`
+  raises a `DatasetError` preserving the original message and exit code.
+  Classification is conservative: anything unrecognised stays retryable, so the
+  legitimate fallback is untouched.
+- **`DatasetError`** gained the `CORRUPT_DATA` reason.
+- **`RustScorerBridge`** classifies before falling back and no longer absorbs a
+  `DatasetError` into its "scorer unavailable" catch;
+  **`BatchRustScorerBridge`** classifies before raising a retryable
+  `BatchScorerError`; **`Fitness.calculate`** re-throws a `DatasetError` instead
+  of retrying the per-creature path on the same corrupt bytes.
+- **`assertWholeRecordRead`** (`src/architecture/DatasetIO.ts`) replaces the two
+  bare `assert(..., "Invalid number of bytes read")` pairs in `evaluateDir` and
+  the training reader, reporting the file, bytes read, record size, and trailing
+  byte count.
+
+```mermaid
+flowchart TD
+    A[rust_scorer exits non-zero] --> B{stderr classified}
+    B -->|data fault| C[DatasetError CORRUPT_DATA<br/>original message + exit code]
+    B -->|backend fault| D[warn + fall back to WASM]
+    C --> E[run fails once, offending file named]
+    D --> F[WASM scores the corpus]
+```
+
+## Evidence
+
+Library change with no web interface. Verified by the tests below plus the
+existing score/creature/architecture/data/multithreading suites (`591 passed`,
+`618 passed`, `0 failed`, WASM scorer mode).
+
+## Test Plan
+
+`test/score/ScorerDataFailureClassification.ts` (new):
+
+- `isCorruptDatasetFailure` recognises trailing-bytes / incomplete-record /
+  truncated-data / record-size stderr.
+- `isCorruptDatasetFailure` leaves backend stderr (missing binary, GPU init,
+  segfault, empty) retryable.
+- A failing scorer with trailing-bytes stderr rejects with a `DatasetError`
+  (`reason: CORRUPT_DATA`) preserving the message, `exit 1`, and the dataset
+  directory — no WASM attempt.
+- A failing scorer with `os error 2` stderr still falls back and returns a
+  finite error.
+- `evaluateDir` on a `.bin` with a 4-byte partial record throws a `DatasetError`
+  naming the file, `Trailing 4 bytes (incomplete record)`, and
+  `12 bytes/record`.

--- a/src/architecture/DatasetIO.ts
+++ b/src/architecture/DatasetIO.ts
@@ -77,6 +77,48 @@ export function readDatasetDirEntriesSync(dataDir: string): Deno.DirEntry[] {
   }
 }
 
+/**
+ * Assert a read returned a whole number of records.
+ *
+ * Issue #3541: both dataset readers previously used
+ * `assert(bytesRead % BYTES_PER_RECORD === 0, "Invalid number of bytes read")`,
+ * which named neither the file nor any byte count. That bare message was the
+ * one the operator saw when a corrupt corpus killed a run — one line after the
+ * native Rust scorer's genuinely diagnostic `Trailing N bytes (incomplete
+ * record)` had been demoted to a warning by the WASM "fallback".
+ *
+ * @param filePath - The `.bin` file being read
+ * @param bytesRead - Bytes returned by the read
+ * @param bytesPerRecord - Record size, `(inputs + outputs) * 4`
+ * @param shape - Creature input/output counts, reported for context
+ * @throws {DatasetError} With reason `CORRUPT_DATA` for a short/partial record
+ */
+export function assertWholeRecordRead(
+  filePath: string,
+  bytesRead: number,
+  bytesPerRecord: number,
+  shape: { inputs: number; outputs: number },
+): void {
+  if (bytesRead <= 0) {
+    throw new DatasetError(
+      `training data file ${filePath} returned ${bytesRead} bytes from a read`,
+      "CORRUPT_DATA",
+      filePath,
+    );
+  }
+  const trailingBytes = bytesRead % bytesPerRecord;
+  if (trailingBytes !== 0) {
+    throw new DatasetError(
+      `training data file ${filePath} is not a whole number of records: ` +
+        `read ${bytesRead} bytes at ${bytesPerRecord} bytes/record ` +
+        `(${shape.inputs} inputs + ${shape.outputs} outputs) — ` +
+        `Trailing ${trailingBytes} bytes (incomplete record)`,
+      "CORRUPT_DATA",
+      filePath,
+    );
+  }
+}
+
 function translateMissingFile(error: unknown, filePath: string): unknown {
   if (error instanceof Deno.errors.NotFound) {
     return new DatasetError(

--- a/src/architecture/Fitness.ts
+++ b/src/architecture/Fitness.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_PARALLEL_EVALUATION_CONFIG,
   type RequiredParallelEvaluationConfig,
 } from "@config/ParallelEvaluationConfig.ts";
+import { DatasetError } from "@errors/DatasetError.ts";
 import { ValidationError } from "@errors/ValidationError.ts";
 import type { WorkerHandler } from "@multithreading/workers/WorkerHandler.ts";
 import { CreatureUtil } from "@architecture/CreatureUtils.ts";
@@ -309,6 +310,10 @@ export class Fitness {
             creaturesForWorkerPath = recurrentCreatures;
           }
         } catch (err) {
+          // Issue #3541: a corrupt dataset is not a transient scorer issue —
+          // the per-creature and WASM paths read the same bytes. Propagate so
+          // the run fails once on the scorer's own diagnostic.
+          if (err instanceof DatasetError) throw err;
           // Surface batch reconciliation failures as explicit log errors per
           // the acceptance criteria, then fall back to the per-creature path
           // so the generation is not lost to a transient scorer issue.

--- a/src/creature/CreatureActivation.ts
+++ b/src/creature/CreatureActivation.ts
@@ -5,10 +5,12 @@
  * under 500 lines and each module focused on a single responsibility.
  */
 
-import { assert } from "@std/assert";
 import { calculateOutputRangePenalty } from "@architecture/OutputRangePenalty.ts";
 import { dataFiles } from "@architecture/Training.ts";
-import { openDatasetFileSync } from "@architecture/DatasetIO.ts";
+import {
+  assertWholeRecordRead,
+  openDatasetFileSync,
+} from "@architecture/DatasetIO.ts";
 import { DatasetError } from "@errors/DatasetError.ts";
 import type { RequiredOutputRange } from "@config/OutputRangeConfig.ts";
 import type { RequiredRustScorerConfig } from "@config/RustScorerConfig.ts";
@@ -525,13 +527,14 @@ export async function evaluateDir(
       while (true) {
         const bytesRead = file.readSync(batchBuffer);
         if (bytesRead === null) break;
-        assert(bytesRead > 0, "Invalid number of bytes read");
+        // Issue #3541: name the file and the byte counts — the bare
+        // `AssertionError: Invalid number of bytes read` named neither.
+        assertWholeRecordRead(filePath, bytesRead, BYTES_PER_RECORD, {
+          inputs: creature.input,
+          outputs: creature.output,
+        });
 
         const recordsRead = Math.floor(bytesRead / BYTES_PER_RECORD);
-        assert(
-          bytesRead % BYTES_PER_RECORD === 0,
-          "Invalid number of bytes read",
-        );
 
         if (useFusedWasm) {
           const slice = batchArray.subarray(0, recordsRead * valuesCount);

--- a/src/creature/CreatureTraining.ts
+++ b/src/creature/CreatureTraining.ts
@@ -13,7 +13,10 @@ import type { Creature } from "@creature";
 import { writeCreatures } from "@creature/CheckpointWriter.ts";
 import { TopologyError } from "@errors/TopologyError.ts";
 import { DatasetError } from "@errors/DatasetError.ts";
-import { openDatasetFileSync } from "@architecture/DatasetIO.ts";
+import {
+  assertWholeRecordRead,
+  openDatasetFileSync,
+} from "@architecture/DatasetIO.ts";
 import type { DataRecordInterface } from "@architecture/DataSet.ts";
 import { makeDataDir } from "@architecture/DataSet.ts";
 import type { DiscoverRecord } from "@architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
@@ -336,13 +339,14 @@ export function traceDir(
       while (true) {
         const bytesRead = file.readSync(batchBuffer);
         if (bytesRead === null) break;
-        assert(bytesRead > 0, "Invalid number of bytes read");
+        // Issue #3541: name the file and the byte counts — the bare
+        // `AssertionError: Invalid number of bytes read` named neither.
+        assertWholeRecordRead(filePath, bytesRead, BYTES_PER_RECORD, {
+          inputs: creature.input,
+          outputs: creature.output,
+        });
 
         const recordsRead = Math.floor(bytesRead / BYTES_PER_RECORD);
-        assert(
-          bytesRead % BYTES_PER_RECORD === 0,
-          "Invalid number of bytes read",
-        );
 
         for (let recordIndex = 0; recordIndex < recordsRead; recordIndex++) {
           const offset = recordIndex * valuesCount;

--- a/src/errors/DatasetError.ts
+++ b/src/errors/DatasetError.ts
@@ -21,7 +21,14 @@ export type DatasetErrorReason =
   /** A `.bin` file disappeared between listing and reading it. */
   | "FILE_MISSING"
   /** The directory exists but holds no `.bin` training files. */
-  | "NO_DATA_FILES";
+  | "NO_DATA_FILES"
+  /**
+   * The dataset is present but malformed — e.g. a `.bin` whose length is not a
+   * whole multiple of the record size. Issue #3541: this is a *data* fault, so
+   * it is never retryable on another scoring backend; the WASM path reads the
+   * same bytes and fails the same way with a worse message.
+   */
+  | "CORRUPT_DATA";
 
 export class DatasetError extends Error {
   override readonly name = "DatasetError";

--- a/src/score/BatchRustScorerBridge.ts
+++ b/src/score/BatchRustScorerBridge.ts
@@ -38,6 +38,7 @@ import {
   buildChildEnv,
   resolveProbeState,
 } from "./RustScorerBridgeInternal.ts";
+import { assertNotCorruptDataset } from "./ScorerFailureClassification.ts";
 
 /**
  * Outcome of a batch scorer invocation.
@@ -162,6 +163,9 @@ export async function tryBatchScoreWithRustScorer(
     );
 
     if (!result.success) {
+      // Issue #3541: classify before signalling a retryable batch failure — a
+      // corrupt dataset fails identically on the per-creature and WASM paths.
+      assertNotCorruptDataset(result.stderr, result.code, absoluteDataDir);
       throw new BatchScorerError(
         `Rust scorer batch call failed (exit ${result.code}): ${
           trimForLog(result.stderr)

--- a/src/score/RustScorerBridge.ts
+++ b/src/score/RustScorerBridge.ts
@@ -2,7 +2,9 @@ import { join, resolve } from "@std/path";
 import type { Creature } from "@creature";
 import type { RequiredRustScorerConfig } from "@config/RustScorerConfig.ts";
 import type { BuiltInCostName } from "@costs";
+import { DatasetError } from "@errors/DatasetError.ts";
 import { getLogger } from "@utils/Logger.ts";
+import { assertNotCorruptDataset } from "./ScorerFailureClassification.ts";
 import {
   __getBatchRunner,
   __resetInternal,
@@ -232,6 +234,10 @@ export async function tryScoreWithRustScorer(
     );
 
     if (!result.success) {
+      // Issue #3541: a rejected *dataset* is not retryable on another backend.
+      // Fail loud with the scorer's own diagnostic instead of demoting it to a
+      // warning and letting the WASM re-read die on a bare assertion.
+      assertNotCorruptDataset(result.stderr, result.code, dataDir);
       if (!probe.warned) {
         const stderrSnippet = trimForLog(result.stderr);
         const suffix = stderrSnippet.length > 0
@@ -286,6 +292,9 @@ export async function tryScoreWithRustScorer(
     }
     return { error };
   } catch (error) {
+    // Issue #3541: a data fault must not be absorbed into "scorer unavailable"
+    // — no backend can read a corrupt dataset, so it propagates.
+    if (error instanceof DatasetError) throw error;
     if (!probe.warned) {
       getLogger().warn(
         `[NEAT-AI] Rust scorer unavailable (${

--- a/src/score/ScorerFailureClassification.ts
+++ b/src/score/ScorerFailureClassification.ts
@@ -1,0 +1,73 @@
+/**
+ * Classify a native scorer process failure (Issue #3541).
+ *
+ * The WASM path is a fallback for *backend* failures — a missing binary, a GPU
+ * that will not initialise, a crashed process. It is not a fallback for corrupt
+ * training data: the WASM path reads the same bytes and dies with a far worse
+ * message (`AssertionError: Invalid number of bytes read`, naming neither the
+ * file nor the byte count), while the native scorer's genuinely diagnostic
+ * `Trailing N bytes (incomplete record)` is demoted to a warning.
+ *
+ * Classification is deliberately conservative: anything not recognised as a
+ * data fault stays retryable so the legitimate fallback is preserved.
+ *
+ * @module ScorerFailureClassification
+ */
+
+import { DatasetError } from "@errors/DatasetError.ts";
+
+/**
+ * Stderr shapes that identify a malformed/truncated dataset rather than a
+ * backend problem. Sourced from `NEAT-AI-scorer`'s dataset reader.
+ */
+const CORRUPT_DATASET_PATTERNS: readonly RegExp[] = [
+  /trailing\s+\d+\s+bytes/i,
+  /incomplete\s+record/i,
+  /(truncated|malformed|corrupt(ed)?)\s+\S*\s*(training|dataset|data|record|file)/i,
+  /not\s+a\s+(whole\s+)?multiple\s+of\s+the\s+record\s+size/i,
+  /record\s+size\s+mismatch/i,
+];
+
+/**
+ * True when the scorer's stderr shows it rejected the *data* rather than
+ * failing for a backend-specific reason.
+ *
+ * @param stderr - Raw stderr captured from the scorer process.
+ */
+export function isCorruptDatasetFailure(stderr: string): boolean {
+  if (!stderr) return false;
+  return CORRUPT_DATASET_PATTERNS.some((pattern) => pattern.test(stderr));
+}
+
+/** Collapse whitespace and cap length for safe inclusion in an error message. */
+function collapse(value: string, limit = 2000): string {
+  const collapsed = value.replace(/\s+/g, " ").trim();
+  return collapsed.length <= limit
+    ? collapsed
+    : collapsed.slice(0, limit) + "…";
+}
+
+/**
+ * Throw when the scorer failed because the dataset is corrupt, preserving its
+ * original diagnostic and exit code. Backend failures return normally so the
+ * caller can fall back to WASM scoring.
+ *
+ * @param stderr - Raw stderr captured from the scorer process.
+ * @param exitCode - The scorer's exit code.
+ * @param dataDir - Dataset directory handed to the scorer.
+ * @throws {DatasetError} With reason `CORRUPT_DATA` for a data fault.
+ */
+export function assertNotCorruptDataset(
+  stderr: string,
+  exitCode: number,
+  dataDir: string,
+): void {
+  if (!isCorruptDatasetFailure(stderr)) return;
+  throw new DatasetError(
+    `rust scorer rejected the training data in ${dataDir} (exit ${exitCode}): ${
+      collapse(stderr)
+    } — corrupt training data is not retryable on another backend, so WASM scoring is not attempted`,
+    "CORRUPT_DATA",
+    dataDir,
+  );
+}

--- a/test/score/ScorerDataFailureClassification.ts
+++ b/test/score/ScorerDataFailureClassification.ts
@@ -162,14 +162,17 @@ Deno.test("evaluateDir: a short final record names the file and the byte counts"
   const creature = new Creature(2, 1, { layers: [{ count: 2 }] });
   const dataDir = makeDataDir(buildDataSet(), 24);
   try {
-    const bin = [...Deno.readDirSync(dataDir)]
-      .find((e) => e.name.endsWith(".bin"))!;
-    const path = `${dataDir}/${bin.name}`;
+    const entries: string[] = [];
+    for await (const entry of Deno.readDir(dataDir)) {
+      entries.push(entry.name);
+    }
+    const bin = entries.find((name) => name.endsWith(".bin"))!;
+    const path = `${dataDir}/${bin}`;
     // Truncate the last record by appending a partial one (4 of 12 bytes).
-    const existing = Deno.readFileSync(path);
+    const existing = await Deno.readFile(path);
     const padded = new Uint8Array(existing.length + 4);
     padded.set(existing);
-    Deno.writeFileSync(path, padded);
+    await Deno.writeFile(path, padded);
 
     const error = await assertRejects(
       () => creature.evaluateDir(dataDir, Costs.find("MSE"), false),

--- a/test/score/ScorerDataFailureClassification.ts
+++ b/test/score/ScorerDataFailureClassification.ts
@@ -1,0 +1,196 @@
+/**
+ * Native-scorer failure classification (Issue #3541).
+ *
+ * The WASM path is a fallback for backend failures, never for corrupt training
+ * data: it reads the same bytes and previously died on a bare
+ * `AssertionError: Invalid number of bytes read` one line after the native
+ * scorer's genuinely diagnostic `Trailing N bytes (incomplete record)` had been
+ * demoted to a warning.
+ *
+ * Locked in here:
+ *   - a data-fault stderr fails loud as a `DatasetError`, preserving the
+ *     scorer's message and exit code, with no WASM attempt;
+ *   - a backend-fault stderr still falls back to WASM and scores;
+ *   - `evaluateDir`'s own length check names the file and the byte counts.
+ */
+
+import { assert, assertEquals, assertRejects } from "@std/assert";
+import { Creature } from "@creature";
+import { makeDataDir } from "@architecture/DataSet.ts";
+import type { DataRecordInterface } from "@architecture/DataSet.ts";
+import { Costs } from "@costs";
+import { DatasetError } from "@errors/DatasetError.ts";
+import {
+  __resetRustScorerBridgeForTests,
+  __setRustScorerRunnerForTests,
+} from "../../src/score/RustScorerBridge.ts";
+import { isCorruptDatasetFailure } from "../../src/score/ScorerFailureClassification.ts";
+import { initWasmForTests } from "../_initWasm.ts";
+
+const CORRUPT_STDERR =
+  "Error: Trailing 3696 bytes (incomplete record) after reading all training files";
+
+function buildDataSet(): DataRecordInterface[] {
+  const rows: DataRecordInterface[] = [];
+  for (let i = 0; i < 24; i++) {
+    const a = i / 24;
+    const b = (24 - i) / 24;
+    rows.push({
+      input: new Float32Array([a, b]),
+      output: new Float32Array([a > b ? 1 : -1]),
+    });
+  }
+  return rows;
+}
+
+/** Runner that probes successfully then fails scoring with `stderr`. */
+function failingRunner(stderr: string, code = 1) {
+  return (_command: string, args: string[]) => {
+    if (args.length === 1 && args[0] === "--help") {
+      return Promise.resolve({
+        success: true,
+        code: 0,
+        stdout: "usage",
+        stderr: "",
+      });
+    }
+    return Promise.resolve({ success: false, code, stdout: "", stderr });
+  };
+}
+
+const RUST_CONFIG = {
+  enabled: true,
+  binaryPath: "rust_scorer",
+  timeoutMs: 0,
+  env: {},
+  batch: false,
+} as const;
+
+Deno.test("isCorruptDatasetFailure: data faults are recognised", () => {
+  assert(isCorruptDatasetFailure(CORRUPT_STDERR));
+  assert(isCorruptDatasetFailure("incomplete record at offset 12"));
+  assert(isCorruptDatasetFailure("truncated training data file A-2007.bin"));
+  assert(
+    isCorruptDatasetFailure("file length is not a multiple of the record size"),
+  );
+});
+
+Deno.test("isCorruptDatasetFailure: backend faults stay retryable", () => {
+  assertEquals(isCorruptDatasetFailure(""), false);
+  assertEquals(
+    isCorruptDatasetFailure("No such file or directory (os error 2)"),
+    false,
+  );
+  assertEquals(
+    isCorruptDatasetFailure("failed to initialise GPU device"),
+    false,
+  );
+  assertEquals(isCorruptDatasetFailure("Segmentation fault"), false);
+});
+
+Deno.test("RustScorerBridge: corrupt training data fails loud instead of falling back", async () => {
+  await initWasmForTests();
+  __resetRustScorerBridgeForTests();
+  __setRustScorerRunnerForTests(failingRunner(CORRUPT_STDERR, 1));
+
+  const creature = new Creature(2, 1, { layers: [{ count: 2 }] });
+  const dataDir = makeDataDir(buildDataSet(), 24);
+  try {
+    const error = await assertRejects(
+      () =>
+        creature.evaluateDir(
+          dataDir,
+          Costs.find("MSE"),
+          false,
+          undefined,
+          undefined,
+          { ...RUST_CONFIG },
+        ),
+      DatasetError,
+    );
+    assertEquals(error.reason, "CORRUPT_DATA");
+    assert(
+      error.message.includes("Trailing 3696 bytes (incomplete record)"),
+      `the scorer's own diagnostic must be preserved, got: ${error.message}`,
+    );
+    assert(
+      error.message.includes("exit 1"),
+      `the scorer's exit code must be preserved, got: ${error.message}`,
+    );
+    assert(
+      error.message.includes(dataDir),
+      `the dataset directory must be named, got: ${error.message}`,
+    );
+  } finally {
+    await Deno.remove(dataDir, { recursive: true });
+    __resetRustScorerBridgeForTests();
+  }
+});
+
+Deno.test("RustScorerBridge: backend failure still falls back to WASM scoring", async () => {
+  await initWasmForTests();
+  __resetRustScorerBridgeForTests();
+  __setRustScorerRunnerForTests(
+    failingRunner("rust_scorer: No such file or directory (os error 2)", 127),
+  );
+
+  const creature = new Creature(2, 1, { layers: [{ count: 2 }] });
+  const dataDir = makeDataDir(buildDataSet(), 24);
+  try {
+    const result = await creature.evaluateDir(
+      dataDir,
+      Costs.find("MSE"),
+      false,
+      undefined,
+      undefined,
+      { ...RUST_CONFIG },
+    );
+    assert(
+      Number.isFinite(result.error),
+      `WASM fallback should have scored, got ${result.error}`,
+    );
+  } finally {
+    await Deno.remove(dataDir, { recursive: true });
+    __resetRustScorerBridgeForTests();
+  }
+});
+
+Deno.test("evaluateDir: a short final record names the file and the byte counts", async () => {
+  await initWasmForTests();
+  __resetRustScorerBridgeForTests();
+
+  const creature = new Creature(2, 1, { layers: [{ count: 2 }] });
+  const dataDir = makeDataDir(buildDataSet(), 24);
+  try {
+    const bin = [...Deno.readDirSync(dataDir)]
+      .find((e) => e.name.endsWith(".bin"))!;
+    const path = `${dataDir}/${bin.name}`;
+    // Truncate the last record by appending a partial one (4 of 12 bytes).
+    const existing = Deno.readFileSync(path);
+    const padded = new Uint8Array(existing.length + 4);
+    padded.set(existing);
+    Deno.writeFileSync(path, padded);
+
+    const error = await assertRejects(
+      () => creature.evaluateDir(dataDir, Costs.find("MSE"), false),
+      DatasetError,
+    );
+    assertEquals(error.reason, "CORRUPT_DATA");
+    assertEquals(error.path, path);
+    assert(
+      error.message.includes(path),
+      `the offending file must be named, got: ${error.message}`,
+    );
+    assert(
+      error.message.includes("Trailing 4 bytes (incomplete record)"),
+      `the trailing byte count must be reported, got: ${error.message}`,
+    );
+    assert(
+      error.message.includes("12 bytes/record"),
+      `the record size must be reported, got: ${error.message}`,
+    );
+  } finally {
+    await Deno.remove(dataDir, { recursive: true });
+    __resetRustScorerBridgeForTests();
+  }
+});


### PR DESCRIPTION
## Summary

The WASM path is a fallback for _backend_ failures, never for corrupt training
data. `tryScoreWithRustScorer` treated every non-zero exit as backend-specific,
so a rejected dataset logged the scorer's genuinely diagnostic
`Trailing N bytes (incomplete record)` as a warning and then died on the WASM
re-read of the same bytes with a bare
`AssertionError: Invalid number of bytes read` — naming neither the file nor any
byte count. Closes #3541.

- **New `src/score/ScorerFailureClassification.ts`** — `isCorruptDatasetFailure`
  matches the scorer's data-fault stderr shapes; `assertNotCorruptDataset`
  raises a `DatasetError` preserving the original message and exit code.
  Classification is conservative: anything unrecognised stays retryable, so the
  legitimate fallback is untouched.
- **`DatasetError`** gained the `CORRUPT_DATA` reason.
- **`RustScorerBridge`** classifies before falling back and no longer absorbs a
  `DatasetError` into its "scorer unavailable" catch;
  **`BatchRustScorerBridge`** classifies before raising a retryable
  `BatchScorerError`; **`Fitness.calculate`** re-throws a `DatasetError` instead
  of retrying the per-creature path on the same corrupt bytes.
- **`assertWholeRecordRead`** (`src/architecture/DatasetIO.ts`) replaces the two
  bare `assert(..., "Invalid number of bytes read")` pairs in `evaluateDir` and
  the training reader, reporting the file, bytes read, record size, and trailing
  byte count.

```mermaid
flowchart TD
    A[rust_scorer exits non-zero] --> B{stderr classified}
    B -->|data fault| C[DatasetError CORRUPT_DATA<br/>original message + exit code]
    B -->|backend fault| D[warn + fall back to WASM]
    C --> E[run fails once, offending file named]
    D --> F[WASM scores the corpus]
```

## Evidence

Library change with no web interface. Verified by the tests below plus the
existing score/creature/architecture/data/multithreading suites (`591 passed`,
`618 passed`, `0 failed`, WASM scorer mode).

## Test Plan

`test/score/ScorerDataFailureClassification.ts` (new):

- `isCorruptDatasetFailure` recognises trailing-bytes / incomplete-record /
  truncated-data / record-size stderr.
- `isCorruptDatasetFailure` leaves backend stderr (missing binary, GPU init,
  segfault, empty) retryable.
- A failing scorer with trailing-bytes stderr rejects with a `DatasetError`
  (`reason: CORRUPT_DATA`) preserving the message, `exit 1`, and the dataset
  directory — no WASM attempt.
- A failing scorer with `os error 2` stderr still falls back and returns a
  finite error.
- `evaluateDir` on a `.bin` with a 4-byte partial record throws a `DatasetError`
  naming the file, `Trailing 4 bytes (incomplete record)`, and
  `12 bytes/record`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)