### PR TITLE
Docs: update CORE_DEPENDENCY_POLICY.md + CONTRIBUTING.md for rev-scoped assetSha256 pin and sidecar anchor (Issue #3517)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,11 +136,12 @@ optional — tests and the core library work without it.
 Shared native Rust computation lives in the external
 [NEAT-AI-core](https://github.com/stSoftwareAU/NEAT-AI-core) repository and is
 consumed as a vendored WASM bundle **pinned by an immutable 40-char SHA** in
-`deno.json` (`neatCore.rev`), attested by `neatCore.assetSha256`, and synced
-into `wasm_activation/pkg` via `./build.sh`. The `neatCore.ref` field is only a
-human-readable label recording which branch the pinned SHA came from — it is
-**not** branch-tracking. `deno.json` is the single source of truth; `neatCore`
-is pinned by SHA, never by branch.
+`deno.json` (`neatCore.rev`), attested by the per-revision
+`neatCore.assetSha256` pin, and synced into `wasm_activation/pkg` via
+`./build.sh`. The `neatCore.ref` field is only a human-readable label recording
+which branch the pinned SHA came from — it is **not** branch-tracking.
+`deno.json` is the single source of truth; `neatCore` is pinned by SHA, never by
+branch.
 
 For the full pinning policy (semver rules, approval tiers, CI auth) see
 [docs/CORE_DEPENDENCY_POLICY.md](./docs/CORE_DEPENDENCY_POLICY.md); for the
@@ -163,6 +164,16 @@ day-to-day bump workflow see
 
 An example that omits `rev`/`assetSha256` would fail `./quality.sh`, which runs
 `./build.sh --verify-only` and errors when `neatCore.rev` is unset.
+
+`assetSha256` is **per-revision**: it is the SHA-256 of the
+`wasm_activation-pkg.tar.gz` belonging to the pinned `rev`, so the two fields
+always move together. You never hand-maintain it across bumps — `./build.sh`
+rewrites both fields on a revision advance, after verifying the new tarball
+against the release sidecar `wasm_activation-pkg.tar.gz.sha256`. An advance
+whose target release serves no sidecar fails loud rather than adopting an
+unattested bundle; see
+[docs/CORE_DEPENDENCY_POLICY.md](./docs/CORE_DEPENDENCY_POLICY.md) for the
+same-rev vs revision-advance rules.
 
 To bump the pin (see
 [docs/EXTERNAL_NEAT_AI_CORE.md](./docs/EXTERNAL_NEAT_AI_CORE.md) for the

--- a/docs/CORE_DEPENDENCY_POLICY.md
+++ b/docs/CORE_DEPENDENCY_POLICY.md
@@ -13,7 +13,8 @@ NEAT-AI tracks NEAT-AI-core in `deno.json`:
 "neatCore": {
   "repo": "stSoftwareAU/NEAT-AI-core",
   "ref": "Develop",
-  "rev": "<40-char SHA>"
+  "rev": "<40-char SHA>",
+  "assetSha256": "<64-char SHA-256 of that rev's tarball>"
 }
 ```
 
@@ -22,15 +23,17 @@ NEAT-AI tracks NEAT-AI-core in `deno.json`:
 `wasm_activation-pkg.tar.gz` asset from the per-commit Release tagged
 `wasm-bundle-<SHA>`, content-verifies the tarball via SHA-256, unpacks it into
 `wasm_activation/`, writes a per-file content manifest, and updates `deno.json`
-`neatCore.rev` to the new SHA. The maintainer (or worker) running `./build.sh`
-commits the updated `deno.json` and `wasm_activation/pkg/**` together.
+`neatCore.rev` to the new SHA along with `neatCore.assetSha256` to that
+tarball's hash. The maintainer (or worker) running `./build.sh` commits the
+updated `deno.json` and `wasm_activation/pkg/**` together.
 
 ```mermaid
 flowchart LR
   CORE["NEAT-AI-core Develop"] -- "wasm-pack CI" --> REL["GitHub Release<br/>wasm-bundle-&lt;SHA&gt;"]
   REL -- "wasm_activation-pkg.tar.gz" --> BUILD["./build.sh"]
+  REL -- "wasm_activation-pkg.tar.gz.sha256<br/>(sidecar anchor)" --> BUILD
   BUILD -- "extract" --> PKG["wasm_activation/pkg/**"]
-  BUILD -- "bump rev" --> DENO["deno.json neatCore.rev"]
+  BUILD -- "bump rev + pin" --> DENO["deno.json neatCore.rev<br/>+ assetSha256"]
   PKG -- "import (unchanged)" --> GRQ["GRQ / downstream clients"]
 ```
 
@@ -40,30 +43,62 @@ Pinning by upstream commit SHA stops a release _tag_ from being renamed or
 replaced, but it does not prevent the _asset_ attached to a release from being
 swapped (compromised Continuous Integration (CI) runner, leaked release-write
 token, Man-in-the-Middle (MITM) attack on the unauthenticated
-`releases/download/...` URL). `build.sh` therefore enforces two independent
-content-hash guards on every download:
+`releases/download/...` URL). `build.sh` therefore anchors every download to a
+SHA-256 it did not compute itself. Two sources can supply that anchor, and which
+one applies depends on whether the run advances `neatCore.rev`:
 
-1. **`deno.json` pin** — set `neatCore.assetSha256` to the expected SHA-256 of
-   `wasm_activation-pkg.tar.gz`. When set, `build.sh` recomputes the hash
-   immediately after download and refuses to extract on mismatch. Because the
-   pin lives next to `neatCore.rev`, reviewers can spot bundle-content changes
-   in a single line of diff. The pin is **scoped to the rev it was recorded
-   against** (issue #3514): it is enforced only when the target rev equals
-   `neatCore.rev`, and on a revision advance it is skipped with a one-line note
-   naming both short SHAs — comparing the old rev's hash to the new rev's
-   tarball would reject every bump. A skipped pin contributes **no** anchor, so
-   an advance without a sidecar still fails loud.
-2. **Release sidecar** — NEAT-AI-core publishes
-   `wasm_activation-pkg.tar.gz.sha256` alongside the tarball, and `build.sh`
-   fetches the sidecar and verifies the tarball against it. The sidecar is the
-   **per-revision** anchor: it is produced by the same workflow run that built
-   the tarball, so advancing `neatCore.rev` has a trustworthy hash for the _new_
-   bundle, whereas the `assetSha256` pin only ever describes the _pinned_
-   revision (issue #3513). Publication is guaranteed from NEAT-AI-core
-   [PR #439](https://github.com/stSoftwareAU/NEAT-AI-core/pull/439) onwards;
-   `wasm-bundle-<SHA>` releases created before it carry only the tarball and the
-   CycloneDX Software Bill of Materials (SBOM), so advancing to one of those
-   revisions still fails loud unless `--allow-unverified` is passed.
+1. **`deno.json` pin** — `neatCore.assetSha256` records the SHA-256 of the
+   `wasm_activation-pkg.tar.gz` that `neatCore.rev` was pinned against. The pin
+   is **scoped to that rev** (issue #3514): `build.sh` enforces it only when the
+   target rev equals `neatCore.rev`, recomputing the hash immediately after
+   download and refusing to extract on mismatch. On a revision advance the pin
+   is skipped with a one-line note naming both short SHAs — comparing the old
+   rev's hash to the new rev's tarball would reject every bump — and a skipped
+   pin contributes **no** anchor. Because the pin lives next to `neatCore.rev`,
+   reviewers can spot bundle-content changes in a single line of diff.
+2. **Release sidecar** — NEAT-AI-core CI publishes
+   `wasm_activation-pkg.tar.gz.sha256` alongside the tarball on **every**
+   `wasm-bundle-<SHA>` release, from the same workflow run that built that
+   tarball (issue #3513). `build.sh` fetches the sidecar and verifies the
+   tarball against it on every download. It is therefore the only anchor that
+   can vouch for a revision this repo has never seen, whereas the `assetSha256`
+   pin only ever describes the _pinned_ revision.
+
+### Same rev vs revision advance
+
+| Case                                                                       | Anchor                                                     | Fails loud when                                                 |
+| -------------------------------------------------------------------------- | ---------------------------------------------------------- | --------------------------------------------------------------- |
+| **Same rev** — re-download of `neatCore.rev`, or the `--verify-only` no-op | committed `assetSha256` pin (plus the sidecar when served) | the pin mismatches: the release asset changed under a live pin  |
+| **Revision advance** — `./build.sh`, `--rev <new SHA>`, `./bump-deps.sh`   | release sidecar — **required**                             | the sidecar is missing or disagrees with the downloaded tarball |
+
+```mermaid
+flowchart TD
+  DL["Download wasm_activation-pkg.tar.gz"] --> Q{"target rev ==<br/>deno.json neatCore.rev?"}
+  Q -- "yes (same rev)" --> PIN{"assetSha256 pin matches?"}
+  PIN -- "yes" --> OK["Extract + write content manifest"]
+  PIN -- "no" --> FAIL["Fail loud — nothing extracted"]
+  Q -- "no (revision advance)" --> SC{"sidecar present<br/>and matches?"}
+  SC -- "yes" --> REC["Record sidecar-verified hash into<br/>deno.json neatCore.assetSha256"] --> OK
+  SC -- "no" --> FAIL
+```
+
+On a revision advance the sidecar is mandatory and there is **no
+trust-on-first-use** (issue #3515): an advance is exactly the moment a
+substituted asset would be adopted, so `--allow-unverified` does not override
+it. When the sidecar verifies, `build.sh` extracts and rewrites `deno.json`
+`neatCore.assetSha256` to the downloaded hash — the advanced rev arrives with
+its own pin, and every later same-rev run is attested against it. When the
+sidecar is absent or disagrees, `build.sh` fails loud and extracts nothing.
+
+Sidecar publication is guaranteed from NEAT-AI-core
+[PR #439](https://github.com/stSoftwareAU/NEAT-AI-core/pull/439) onwards;
+`wasm-bundle-<SHA>` releases created before it carry only the tarball and the
+CycloneDX Software Bill of Materials (SBOM), so an advance targeting one of
+those historical revisions legitimately fails loud. Either trigger the upstream
+[`wasm-bundle.yml`](https://github.com/stSoftwareAU/NEAT-AI-core/actions/workflows/wasm-bundle.yml)
+workflow to publish the missing sidecar, or commit the known-good hash to
+`neatCore.assetSha256` first and re-run `./build.sh --rev <SHA>` so the download
+is a same-rev, pin-anchored one.
 
 After extraction `build.sh` writes `wasm_activation/pkg/content-manifest.sha256`
 (standard `shasum -a 256` format). This per-file manifest is committed with the
@@ -71,23 +106,25 @@ rest of `pkg/**` and is re-checked on every `./build.sh --verify-only` run — s
 any later tampering with the vendored bundle is detected without a network
 round-trip.
 
-| Guard                         | When it runs         | What it protects against                                 |
-| ----------------------------- | -------------------- | -------------------------------------------------------- |
-| `neatCore.assetSha256`        | Same-rev downloads   | Swap of the release asset after the pin was committed    |
-| Release sidecar `*.sha256`    | Every download       | Asset tampering by anyone without sidecar-signing access |
-| `pkg/content-manifest.sha256` | `--verify-only` / CI | Local or post-install tampering with vendored pkg files  |
+| Guard                         | When it runs                                         | What it protects against                                 |
+| ----------------------------- | ---------------------------------------------------- | -------------------------------------------------------- |
+| `neatCore.assetSha256`        | Same-rev downloads only                              | Swap of the release asset after the pin was committed    |
+| Release sidecar `*.sha256`    | Every download; the required anchor on a rev advance | Asset tampering by anyone without sidecar-signing access |
+| `pkg/content-manifest.sha256` | `--verify-only` / CI                                 | Local or post-install tampering with vendored pkg files  |
 
-If neither sidecar nor `assetSha256` is available, `build.sh` **refuses to
-extract** and exits non-zero (issue #2744). A content manifest written from an
-unattested download is self-referential — `--verify-only` would compare the
-freshly written files against the freshly written manifest and always pass — so
-silently extracting an unverified bundle proves nothing about provenance. To
-bootstrap a fresh setup (or pin a rev whose upstream release has no sidecar),
-re-run with `--allow-unverified`: `build.sh` then extracts and records the
-downloaded hash into `deno.json` `neatCore.assetSha256`, so every subsequent run
-is attested against that committed pin. Because the standing pin is committed,
-the default `./build.sh` (and the `--verify-only` no-op path used by
-`quality.sh`) always has an anchor and never needs the override.
+If no anchor attested the tarball, `build.sh` **refuses to extract** and exits
+non-zero (issue #2744). A content manifest written from an unattested download
+is self-referential — `--verify-only` would compare the freshly written files
+against the freshly written manifest and always pass — so silently extracting an
+unverified bundle proves nothing about provenance. `--allow-unverified` covers
+exactly one narrow case: a **same-rev bootstrap** where `neatCore.assetSha256`
+is unset and the upstream release serves no sidecar. It then extracts and
+records the downloaded hash into `deno.json` `neatCore.assetSha256`, so every
+subsequent run is attested against that committed pin. It does **not** cover a
+revision advance — that always requires the sidecar, with no override (issue
+#3515). Because the standing pin is committed, the default `./build.sh` (and the
+`--verify-only` no-op path used by `quality.sh`) always has an anchor and never
+needs the override.
 
 Before extraction, `build.sh` also lists the tarball with `tar -tzf` and rejects
 any entry whose normalised path is absolute or escapes the destination via `..`
@@ -108,14 +145,14 @@ bits are never honoured.
 
 ## `build.sh` Modes
 
-| Invocation                      | Behaviour                                                                                                                                             |
-| ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `./build.sh`                    | Resolve Develop HEAD, download artefact, refresh pkg, update `deno.json` `neatCore.rev`. No-op if up to date.                                         |
-| `./build.sh --rev <SHA>`        | Same as above but pin to a specific 40-char SHA instead of resolving HEAD. Used for reproducible builds.                                              |
-| `./build.sh --verify-only`      | Verify the vendored pkg matches `deno.json` `neatCore.rev`. No network. No mutation. Used by `quality.sh`.                                            |
-| `./build.sh --clean`            | Delete `wasm_activation/pkg` before download.                                                                                                         |
-| `./build.sh --allow-unverified` | Proceed even when no SHA-256 anchor attested the tarball; records the downloaded hash into `neatCore.assetSha256` to bootstrap the pin (issue #2744). |
-| `./build.sh --help`             | Show usage.                                                                                                                                           |
+| Invocation                      | Behaviour                                                                                                                                                                                                                                      |
+| ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `./build.sh`                    | Resolve Develop HEAD, download artefact, refresh pkg, update `deno.json` `neatCore.rev` + `assetSha256`. No-op if up to date.                                                                                                                  |
+| `./build.sh --rev <SHA>`        | Same as above but pin to a specific 40-char SHA instead of resolving HEAD. Used for reproducible builds.                                                                                                                                       |
+| `./build.sh --verify-only`      | Verify the vendored pkg matches `deno.json` `neatCore.rev`. No network. No mutation. Used by `quality.sh`.                                                                                                                                     |
+| `./build.sh --clean`            | Delete `wasm_activation/pkg` before download.                                                                                                                                                                                                  |
+| `./build.sh --allow-unverified` | Bootstrap a **same-rev** download that no anchor attested (no pin, no sidecar); records the downloaded hash into `neatCore.assetSha256` (issue #2744). Does **not** cover a revision advance, which always requires the sidecar (issue #3515). |
+| `./build.sh --help`             | Show usage.                                                                                                                                                                                                                                    |
 
 ## Pre-PR auto-bump (`bump-deps.sh`)
 
@@ -124,7 +161,11 @@ The Vibe Coder worker invokes [`./bump-deps.sh`](../bump-deps.sh) before
 
 - **Internal (`stSoftwareAU/*`, including NEAT-AI-core):** advances `deno.json`
   `neatCore.rev` to NEAT-AI-core `Develop` HEAD by re-running `./build.sh`. No
-  quarantine — internal deps bump immediately.
+  quarantine — internal deps bump immediately. The advance is anchored by the
+  release sidecar and `./build.sh` rewrites `neatCore.assetSha256` to the new
+  rev's hash, so the bump completes without anyone hand-maintaining the pin; if
+  the target release serves no sidecar the advance fails loud (issue #3515) and
+  the bump is reverted.
 - **External (jsr:@std/_, npm:_, https://deno.land/*):** runs
   `deno outdated --update --latest --minimum-dependency-age=<min>` with a
   quarantine window (default 24h, see `VIBE_BUMP_QUARANTINE_HOURS`). The

--- a/docs/archive/pr-summaries/pr-summary-3517.md
+++ b/docs/archive/pr-summaries/pr-summary-3517.md
@@ -1,0 +1,68 @@
+# Docs: rev-scoped `assetSha256` pin and sidecar anchor
+
+## Summary
+
+The core-dependency docs still described the pre-#3504 semantics — that
+`neatCore.assetSha256` is verified on **every** download and that
+`--allow-unverified` can bootstrap any unattested download. Both are wrong now
+that the pin is scoped to its recorded rev (#3514) and a revision advance
+requires the release sidecar (#3515). Closes #3517.
+
+- **`docs/CORE_DEPENDENCY_POLICY.md`**
+  - Guard table: `neatCore.assetSha256` runs on **same-rev downloads only**; the
+    release sidecar is named as the required anchor on a revision advance.
+  - New "Same rev vs revision advance" section states the two-case model
+    explicitly — same rev ⇒ the committed pin is the tamper check; advance ⇒ the
+    sidecar is required, verified, and its hash rewritten into `deno.json` as
+    the new pin, with missing/mismatching sidecars failing loud and **no**
+    trust-on-first-use.
+  - `--allow-unverified` narrowed in both the modes table and the prose to the
+    same-rev, no-pin bootstrap case; it explicitly does not cover an advance.
+  - Records that NEAT-AI-core CI publishes `wasm_activation-pkg.tar.gz.sha256`
+    on every `wasm-bundle-<SHA>` release, and that historical sidecar-less
+    releases legitimately fail loud when targeted by an advance (with the two
+    ways out).
+  - `bump-deps.sh` section now explains why the internal bump succeeds:
+    `./build.sh` rewrites the pin after the sidecar verifies the new tarball.
+- **`CONTRIBUTING.md`** — the pin is described as per-revision and rewritten by
+  `./build.sh` on an advance, not a value contributors hand-maintain across
+  bumps.
+
+## Evidence
+
+Documentation-only change plus doc-sync tests — no web interface to screenshot.
+
+```mermaid
+flowchart TD
+  DL["Download wasm_activation-pkg.tar.gz"] --> Q{"target rev ==<br/>deno.json neatCore.rev?"}
+  Q -- "yes (same rev)" --> PIN{"assetSha256 pin matches?"}
+  PIN -- "yes" --> OK["Extract + write content manifest"]
+  PIN -- "no" --> FAIL["Fail loud — nothing extracted"]
+  Q -- "no (revision advance)" --> SC{"sidecar present<br/>and matches?"}
+  SC -- "yes" --> REC["Record sidecar-verified hash into<br/>deno.json neatCore.assetSha256"] --> OK
+  SC -- "no" --> FAIL
+```
+
+Verification run:
+
+- `deno test --allow-read test/scripts/ContributingCorePin.ts test/scripts/CoreDependencyPolicy.ts`
+  → 11 passed. Both new assertions failed against the old wording before the
+  docs were edited (per-revision pin description absent; `--allow-unverified`
+  row silent on a revision advance).
+- `markdownlint-cli2` → 0 errors; `deno fmt --check` clean.
+- `./quality.sh` → passes.
+
+## Test Plan
+
+Doc-sync tests (the same category as the existing `ContributingCorePin.ts`
+checks) that fail if the stale wording returns:
+
+- `test/scripts/ContributingCorePin.ts`
+  - `CONTRIBUTING.md describes assetSha256 as a per-revision pin rewritten by ./build.sh`
+  - `CONTRIBUTING.md does not claim assetSha256 is verified on every download`
+- `test/scripts/CoreDependencyPolicy.ts`
+  - `policy guard table scopes assetSha256 to same-rev downloads` — parses the
+    guard-table row and rejects an "every download" scope.
+  - `policy doc narrows --allow-unverified to the bootstrap case` — requires
+    both the modes-table row and the prose to state the revision-advance
+    carve-out.

--- a/test/scripts/ContributingCorePin.ts
+++ b/test/scripts/ContributingCorePin.ts
@@ -84,6 +84,44 @@ Deno.test("CONTRIBUTING.md neatCore example agrees with deno.json on repo", asyn
   );
 });
 
+/**
+ * Issue #3517 — the `assetSha256` pin is scoped to the rev it was recorded
+ * against (#3514) and is rewritten by `./build.sh` on a revision advance
+ * (#3515). CONTRIBUTING.md must not tell contributors the pin is checked on
+ * every download, nor that they hand-maintain it across bumps.
+ */
+Deno.test("CONTRIBUTING.md describes assetSha256 as a per-revision pin rewritten by ./build.sh", async () => {
+  const doc = await Deno.readTextFile(CONTRIBUTING);
+  const scoped = doc.split(/\n\s*\n/).filter((block) =>
+    block.includes("assetSha256") && /per[-\s]revision/i.test(block)
+  );
+  assert(
+    scoped.length > 0,
+    "CONTRIBUTING.md must describe neatCore.assetSha256 as a per-revision pin " +
+      "(it attests only the rev it was recorded against — Issue #3514)",
+  );
+  assert(
+    scoped.some((block) =>
+      /build\.sh/.test(block) && /rewrit|updates|regenerat/i.test(block)
+    ),
+    "CONTRIBUTING.md must state that ./build.sh rewrites neatCore.assetSha256 " +
+      "rather than contributors hand-maintaining it across bumps",
+  );
+});
+
+Deno.test("CONTRIBUTING.md does not claim assetSha256 is verified on every download", async () => {
+  const doc = await Deno.readTextFile(CONTRIBUTING);
+  const claims = doc.split(/\n\s*\n/).filter((block) =>
+    block.includes("assetSha256") && /every download/i.test(block)
+  );
+  assertEquals(
+    claims,
+    [],
+    "The assetSha256 pin is enforced only for same-rev downloads (Issue #3514) — " +
+      "CONTRIBUTING.md must not claim it is verified on every download",
+  );
+});
+
 Deno.test("CONTRIBUTING.md does not claim core follows latest Develop", async () => {
   const doc = await Deno.readTextFile(CONTRIBUTING);
   // The branch-tracking claim contradicts the immutable-SHA pinning policy.

--- a/test/scripts/CoreDependencyPolicy.ts
+++ b/test/scripts/CoreDependencyPolicy.ts
@@ -71,6 +71,76 @@ function extractDocNeatCore(
 }
 
 /**
+ * Read the cells of the markdown table row whose first cell mentions `needle`.
+ * Returns null when no such row exists, so callers can assert on absence.
+ */
+function tableRowCells(doc: string, needle: string): string[] | null {
+  for (const line of doc.split("\n")) {
+    if (!line.startsWith("|")) continue;
+    const cells = line.split("|").slice(1, -1).map((cell) => cell.trim());
+    if (cells.length > 1 && cells[0].includes(needle)) return cells;
+  }
+  return null;
+}
+
+/**
+ * Issue #3517 — the `assetSha256` pin is enforced only when the target rev
+ * equals `neatCore.rev` (#3514); the release sidecar is the anchor on a
+ * revision advance (#3515). The guard table must not advertise the pin as a
+ * whole-of-download check.
+ */
+Deno.test("policy guard table scopes assetSha256 to same-rev downloads", async () => {
+  const doc = await Deno.readTextFile(POLICY_DOC);
+  const cells = tableRowCells(doc, "neatCore.assetSha256");
+  assert(
+    cells,
+    `${POLICY_DOC} must document neatCore.assetSha256 in the guard table`,
+  );
+
+  const whenItRuns = cells[1];
+  assert(
+    !/every download/i.test(whenItRuns),
+    `The assetSha256 pin is not verified on every download — guard table says "${whenItRuns}"`,
+  );
+  assert(
+    /same[-\s]rev/i.test(whenItRuns),
+    `The assetSha256 guard row must say it runs on same-rev downloads only — got "${whenItRuns}"`,
+  );
+});
+
+/**
+ * Issue #3517 — `--allow-unverified` no longer covers a revision advance
+ * (#3515): an advance always requires the sidecar, with no override. Both the
+ * modes table and the bootstrap prose must say so.
+ */
+Deno.test("policy doc narrows --allow-unverified to the bootstrap case", async () => {
+  const doc = await Deno.readTextFile(POLICY_DOC);
+  const cells = tableRowCells(doc, "--allow-unverified");
+  assert(
+    cells,
+    `${POLICY_DOC} must document ./build.sh --allow-unverified in the modes table`,
+  );
+  assert(
+    /revision advance/i.test(cells[1]),
+    "The --allow-unverified modes-table row must state that it does not cover a " +
+      `revision advance (Issue #3515) — got "${cells[1]}"`,
+  );
+
+  const bootstrapProse = doc.split(/\n\s*\n/).filter((block) =>
+    !block.startsWith("|") && block.includes("--allow-unverified")
+  );
+  assert(
+    bootstrapProse.length > 0,
+    `${POLICY_DOC} must explain --allow-unverified in prose, not only in the modes table`,
+  );
+  assert(
+    bootstrapProse.some((block) => /revision advance/i.test(block)),
+    "The --allow-unverified prose must state that a revision advance is never " +
+      "allowed to proceed unverified (Issue #3515)",
+  );
+});
+
+/**
  * WHAT-test: the pin documented in CORE_DEPENDENCY_POLICY.md must agree with the
  * authoritative pin in deno.json on the values a machine can compare — `repo`
  * and `ref`. This fails only when the two genuinely disagree (e.g. the doc still


### PR DESCRIPTION
# Docs: rev-scoped `assetSha256` pin and sidecar anchor

## Summary

The core-dependency docs still described the pre-#3504 semantics — that
`neatCore.assetSha256` is verified on **every** download and that
`--allow-unverified` can bootstrap any unattested download. Both are wrong now
that the pin is scoped to its recorded rev (#3514) and a revision advance
requires the release sidecar (#3515). Closes #3517.

- **`docs/CORE_DEPENDENCY_POLICY.md`**
  - Guard table: `neatCore.assetSha256` runs on **same-rev downloads only**; the
    release sidecar is named as the required anchor on a revision advance.
  - New "Same rev vs revision advance" section states the two-case model
    explicitly — same rev ⇒ the committed pin is the tamper check; advance ⇒ the
    sidecar is required, verified, and its hash rewritten into `deno.json` as
    the new pin, with missing/mismatching sidecars failing loud and **no**
    trust-on-first-use.
  - `--allow-unverified` narrowed in both the modes table and the prose to the
    same-rev, no-pin bootstrap case; it explicitly does not cover an advance.
  - Records that NEAT-AI-core CI publishes `wasm_activation-pkg.tar.gz.sha256`
    on every `wasm-bundle-<SHA>` release, and that historical sidecar-less
    releases legitimately fail loud when targeted by an advance (with the two
    ways out).
  - `bump-deps.sh` section now explains why the internal bump succeeds:
    `./build.sh` rewrites the pin after the sidecar verifies the new tarball.
- **`CONTRIBUTING.md`** — the pin is described as per-revision and rewritten by
  `./build.sh` on an advance, not a value contributors hand-maintain across
  bumps.

## Evidence

Documentation-only change plus doc-sync tests — no web interface to screenshot.

```mermaid
flowchart TD
  DL["Download wasm_activation-pkg.tar.gz"] --> Q{"target rev ==<br/>deno.json neatCore.rev?"}
  Q -- "yes (same rev)" --> PIN{"assetSha256 pin matches?"}
  PIN -- "yes" --> OK["Extract + write content manifest"]
  PIN -- "no" --> FAIL["Fail loud — nothing extracted"]
  Q -- "no (revision advance)" --> SC{"sidecar present<br/>and matches?"}
  SC -- "yes" --> REC["Record sidecar-verified hash into<br/>deno.json neatCore.assetSha256"] --> OK
  SC -- "no" --> FAIL
```

Verification run:

- `deno test --allow-read test/scripts/ContributingCorePin.ts test/scripts/CoreDependencyPolicy.ts`
  → 11 passed. Both new assertions failed against the old wording before the
  docs were edited (per-revision pin description absent; `--allow-unverified`
  row silent on a revision advance).
- `markdownlint-cli2` → 0 errors; `deno fmt --check` clean.
- `./quality.sh` → passes.

## Test Plan

Doc-sync tests (the same category as the existing `ContributingCorePin.ts`
checks) that fail if the stale wording returns:

- `test/scripts/ContributingCorePin.ts`
  - `CONTRIBUTING.md describes assetSha256 as a per-revision pin rewritten by ./build.sh`
  - `CONTRIBUTING.md does not claim assetSha256 is verified on every download`
- `test/scripts/CoreDependencyPolicy.ts`
  - `policy guard table scopes assetSha256 to same-rev downloads` — parses the
    guard-table row and rejects an "every download" scope.
  - `policy doc narrows --allow-unverified to the bootstrap case` — requires
    both the modes-table row and the prose to state the revision-advance
    carve-out.



## Milestone
This PR is part of the **#3504 build.sh checks stale assetSha256 pin on new rev, blocking internal bumps** milestone and targets the `milestone/3504-build-sh-checks-stale-assetsha256-pin-on-new` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-ms6nomzz-b8dc74`<!-- vibe-worker-issue-3517 -->