### PR TITLE
Regression test for the build.sh bump-to-new-rev path (Issue #3516)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -224,7 +224,9 @@ verify_pinned_asset_sha256() {
   if [[ "$pinned_rev" != "$target_rev" ]]; then
     local pinned_short="${pinned_rev:0:7}"
     local target_short="${target_rev:0:7}"
-    echo "Skipping deno.json neatCore.assetSha256 check: target rev ${target_short:-<unset>} differs from pinned rev ${pinned_short:-<unset>} (the pin records the pinned rev's tarball hash)."
+    # stderr, not stdout: select_tarball_anchor captures stdout as the anchor
+    # label, and this note is a diagnostic rather than part of that label.
+    echo "Skipping deno.json neatCore.assetSha256 check: target rev ${target_short:-<unset>} differs from pinned rev ${pinned_short:-<unset>} (the pin records the pinned rev's tarball hash)." >&2
     return 2
   fi
   if ! verify_tarball_sha256 "$file" "$pinned_sha256" "deno.json neatCore.assetSha256"; then
@@ -264,6 +266,111 @@ guard_unverified_extract() {
     return 0
   fi
   return 1
+}
+
+# select_tarball_anchor — compose the two SHA-256 anchors into a single
+# extract-or-refuse decision for the downloaded tarball (issue #3516).
+# Extracted from the download flow so a revision advance is testable without
+# a network fetch. Ordering matters: the release sidecar is the only anchor
+# that can attest a *new* revision, while the deno.json pin is scoped to the
+# rev it was recorded against (see verify_pinned_asset_sha256), so on an
+# advance the stale pin is skipped rather than compared.
+#   $1 = tarball path
+#   $2 = sidecar path ("" when the release published no sidecar)
+#   $3 = pinned sha-256 ("" when unset)
+#   $4 = pinned rev ("" when unset)
+#   $5 = target rev
+#   $6 = allow_unverified ("true" when the operator passed --allow-unverified)
+# Returns:
+#   0 = anchored; the anchor label is printed on stdout
+#   1 = an applicable anchor MISMATCHED — abort (verify_tarball_sha256 has
+#       already reported which source caught it)
+#   2 = no anchor, but an --allow-unverified same-rev bootstrap is permitted
+#   3 = no anchor and extraction must be refused
+select_tarball_anchor() {
+  local file="$1"
+  local sidecar_path="$2"
+  local pinned_sha256="$3"
+  local pinned_rev="$4"
+  local target_rev="$5"
+  local allow_unverified="$6"
+
+  # A revision advance is a *pinned* rev changing, not the first-ever pin
+  # being set (empty pinned rev is fresh setup — issue #3515).
+  local is_rev_advance=false
+  if [[ -n "$pinned_rev" && "$pinned_rev" != "$target_rev" ]]; then
+    is_rev_advance=true
+  fi
+
+  local verified_via=""
+  if [[ -n "$sidecar_path" && -s "$sidecar_path" ]]; then
+    local sidecar_name
+    sidecar_name="$(basename "$sidecar_path")"
+    # Standard `shasum -a 256` output is `<hash>  <filename>`. We only
+    # consume the leading 64 hex chars to be lenient about whitespace.
+    local expected_sidecar
+    expected_sidecar="$(awk '{print $1}' <"$sidecar_path" | head -n1)"
+    if ! verify_tarball_sha256 "$file" "$expected_sidecar" \
+      "release sidecar ${sidecar_name}"; then
+      return 1
+    fi
+    verified_via="sidecar ${sidecar_name}"
+  fi
+
+  local pin_status=0
+  verify_pinned_asset_sha256 "$file" "$pinned_sha256" "$pinned_rev" \
+    "$target_rev" || pin_status=$?
+  if [[ "$pin_status" -eq 1 ]]; then
+    return 1
+  fi
+  if [[ "$pin_status" -eq 0 ]]; then
+    if [[ -n "$verified_via" ]]; then
+      verified_via="${verified_via} and deno.json neatCore.assetSha256"
+    else
+      verified_via="deno.json neatCore.assetSha256"
+    fi
+  fi
+
+  if [[ -n "$verified_via" ]]; then
+    printf '%s\n' "$verified_via"
+    return 0
+  fi
+  if guard_unverified_extract "" "$allow_unverified" "$is_rev_advance"; then
+    return 2
+  fi
+  return 3
+}
+
+# update_core_pin — record the downloaded rev and tarball hash back into the
+# deno.json neatCore block (issue #2744) so subsequent runs verify against
+# them. A no-op when both already match. Values are passed via the
+# environment, never interpolated into the eval source, so a hostile rev/hash
+# cannot inject code (both are validated as hex before reaching here).
+#   $1 = config path  $2 = target rev  $3 = downloaded sha-256
+#   $4 = pinned rev ("" when unset)  $5 = pinned sha-256 ("" when unset)
+update_core_pin() {
+  local config_path="$1"
+  local target_rev="$2"
+  local asset_sha256="$3"
+  local pinned_rev="$4"
+  local pinned_sha256="$5"
+  if [[ "$pinned_rev" == "$target_rev" ]] \
+    && [[ "$pinned_sha256" == "$asset_sha256" ]]; then
+    return 0
+  fi
+  echo "Updating ${config_path} neatCore.rev: ${pinned_rev:-<unset>} -> ${target_rev}"
+  echo "Updating ${config_path} neatCore.assetSha256: ${pinned_sha256:-<unset>} -> ${asset_sha256}"
+  NEAT_CONFIG_PATH="$config_path" \
+  NEAT_TARGET_REV="$target_rev" \
+  NEAT_ASSET_SHA256="$asset_sha256" \
+  deno eval '
+const path = Deno.env.get("NEAT_CONFIG_PATH");
+const config = JSON.parse(Deno.readTextFileSync(path));
+config.neatCore = config.neatCore ?? {};
+config.neatCore.rev = Deno.env.get("NEAT_TARGET_REV");
+config.neatCore.assetSha256 = Deno.env.get("NEAT_ASSET_SHA256");
+Deno.writeTextFileSync(path, JSON.stringify(config, null, 2) + "\n");
+'
 }
 
 # assert_safe_tar_entries — reject path-traversal and absolute-path entries
@@ -610,40 +717,25 @@ if [[ "$sidecar_ok" != true ]]; then
   fi
 fi
 
-verified_via=""
-if [[ "$sidecar_ok" == true && -s "$sidecar_path" ]]; then
-  # Standard `shasum -a 256` output is `<hash>  <filename>`. We only
-  # consume the leading 64 hex chars to be lenient about whitespace.
-  expected_sidecar="$(awk '{print $1}' <"$sidecar_path" | head -n1)"
-  if ! verify_tarball_sha256 \
-    "$tmp_dir/$ASSET_NAME" \
-    "$expected_sidecar" \
-    "release sidecar ${SIDECAR_NAME}"; then
-    exit 1
-  fi
-  verified_via="sidecar ${SIDECAR_NAME}"
+if [[ "$sidecar_ok" != true ]]; then
+  sidecar_path=""
 fi
 
-pin_status=0
-verify_pinned_asset_sha256 \
+anchor_status=0
+verified_via="$(select_tarball_anchor \
   "$tmp_dir/$ASSET_NAME" \
+  "$sidecar_path" \
   "$PINNED_ASSET_SHA256" \
   "$PINNED_REV" \
-  "$TARGET_REV" || pin_status=$?
-if [[ "$pin_status" -eq 1 ]]; then
-  exit 1
-fi
-if [[ "$pin_status" -eq 0 ]]; then
-  if [[ -n "$verified_via" ]]; then
-    verified_via="${verified_via} and deno.json neatCore.assetSha256"
-  else
-    verified_via="deno.json neatCore.assetSha256"
-  fi
-fi
+  "$TARGET_REV" \
+  "$ALLOW_UNVERIFIED")" || anchor_status=$?
 
-if [[ -n "$verified_via" ]]; then
+if [[ "$anchor_status" -eq 0 ]]; then
   echo "Tarball SHA-256 verified via ${verified_via}."
-elif ! guard_unverified_extract "$verified_via" "$ALLOW_UNVERIFIED" "$IS_REV_ADVANCE"; then
+elif [[ "$anchor_status" -eq 1 ]]; then
+  # verify_tarball_sha256 already named the source that caught the mismatch.
+  exit 1
+elif [[ "$anchor_status" -eq 3 ]]; then
   if [[ "$IS_REV_ADVANCE" == true ]]; then
     echo "ERROR: revision advance (${PINNED_REV:0:7} -> ${TARGET_REV:0:7}) has no SHA-256 anchor for ${ASSET_NAME}." >&2
     echo "       A revision advance requires the release sidecar ${SIDECAR_NAME} on the" >&2
@@ -714,21 +806,12 @@ fi
 # verify against it (issue #2744). Values are passed via the environment,
 # never interpolated into the eval source, so a hostile rev/hash cannot
 # inject code (both are already validated as hex above).
-if [[ "$PINNED_REV" != "$TARGET_REV" ]] \
-  || [[ "$PINNED_ASSET_SHA256" != "$DOWNLOADED_ASSET_SHA256" ]]; then
-  echo "Updating deno.json neatCore.rev: ${PINNED_REV:-<unset>} -> ${TARGET_REV}"
-  echo "Updating deno.json neatCore.assetSha256: ${PINNED_ASSET_SHA256:-<unset>} -> ${DOWNLOADED_ASSET_SHA256}"
-  NEAT_TARGET_REV="$TARGET_REV" \
-  NEAT_ASSET_SHA256="$DOWNLOADED_ASSET_SHA256" \
-  deno eval '
-const path = "deno.json";
-const config = JSON.parse(Deno.readTextFileSync(path));
-config.neatCore = config.neatCore ?? {};
-config.neatCore.rev = Deno.env.get("NEAT_TARGET_REV");
-config.neatCore.assetSha256 = Deno.env.get("NEAT_ASSET_SHA256");
-Deno.writeTextFileSync(path, JSON.stringify(config, null, 2) + "\n");
-'
-fi
+update_core_pin \
+  "deno.json" \
+  "$TARGET_REV" \
+  "$DOWNLOADED_ASSET_SHA256" \
+  "$PINNED_REV" \
+  "$PINNED_ASSET_SHA256"
 
 refresh_fingerprint "$TARGET_REV"
 

--- a/docs/archive/pr-summaries/pr-summary-3516.md
+++ b/docs/archive/pr-summaries/pr-summary-3516.md
@@ -1,0 +1,129 @@
+# Regression test: build.sh bump-to-new-rev path
+
+## Summary
+
+`test/scripts/BuildScriptContentHash.ts` only ever exercised **same-rev**
+downloads, which is why #3504 shipped: a stale `deno.json`
+`neatCore.assetSha256` pin was compared against a *different* revision's tarball
+and blocked every internal bump. This PR adds the missing regression coverage
+for the rev-advance decision. Closes #3516.
+
+The anchor decision was inline in the download flow, so it could not be
+exercised without a network fetch. It is now extracted into two pure shell
+functions in `build.sh` — behaviour is unchanged, only its shape:
+
+- **`select_tarball_anchor`** — composes the release sidecar check, the
+  rev-scoped `deno.json` pin (#3514) and `guard_unverified_extract` (#3515) into
+  one extract-or-refuse decision. Reuses the existing `guard_unverified_extract`
+  signature rather than inventing a second one.
+- **`update_core_pin`** — the `deno.json` `neatCore` write-back, now taking the
+  config path as an argument so it can run against a temp copy.
+
+One supporting change: the "Skipping deno.json neatCore.assetSha256 check…" note
+moved from stdout to stderr, because `select_tarball_anchor` returns the anchor
+label on stdout. It is a diagnostic, so stderr is the correct sink; users still
+see it and the #3514 tests (which assert on `stdout + stderr`) are unaffected.
+
+### Anchor decision
+
+```mermaid
+flowchart TD
+    A[Downloaded tarball] --> B{Sidecar present?}
+    B -- yes --> C{Sidecar hash matches?}
+    C -- no --> X[rc 1: abort<br/>'release sidecar …']
+    C -- yes --> D[anchor = sidecar]
+    B -- no --> E
+    D --> E{Pin applies?<br/>target rev == pinned rev}
+    E -- "no (rev advance)" --> F[Pin skipped — never compared]
+    E -- yes --> G{Pin matches?}
+    G -- no --> Y[rc 1: abort<br/>'deno.json neatCore.assetSha256']
+    G -- yes --> H[anchor += pin]
+    F --> I{Any anchor?}
+    H --> I
+    I -- yes --> J[rc 0: extract]
+    I -- no --> K{Rev advance?}
+    K -- yes --> L[rc 3: refuse<br/>--allow-unverified does NOT apply]
+    K -- no --> M{--allow-unverified?}
+    M -- yes --> N[rc 2: bootstrap]
+    M -- no --> O[rc 3: refuse]
+```
+
+## Evidence
+
+Backend/CLI change — no web interface to screenshot.
+
+**Acceptance criterion spot-check.** The criterion is "fails if the
+`TARGET_REV == PINNED_REV` condition on the pin check is reverted". Reverting
+that guard locally (`if [[ "$pinned_rev" != "$target_rev" ]]` → `if false`) turns
+the suite red exactly as intended:
+
+```
+FAILURES
+
+revision advance: a stale pin is not compared when the sidecar anchors the new rev (issue #3504)
+revision advance: no sidecar refuses to extract, even with --allow-unverified
+
+FAILED | 5 passed | 2 failed
+```
+
+With the guard in place:
+
+```
+running 7 tests from ./test/scripts/BuildScriptRevAdvance.ts
+revision advance: a stale pin is not compared when the sidecar anchors the new rev (issue #3504) ... ok
+same rev: the pin still bites when the tarball hash differs ... ok
+revision advance: no sidecar refuses to extract, even with --allow-unverified ... ok
+revision advance: a mismatching sidecar fails loud ... ok
+same rev with no anchor keeps its --allow-unverified bootstrap (issue #2744) ... ok
+write-back on a successful advance records the new rev and hash ... ok
+write-back is a no-op when the rev and hash are already current ... ok
+
+ok | 7 passed | 0 failed
+```
+
+**No network, no repo mutation.** The sidecar is a local file, the tarball a
+stand-in blob, both under a `makeTempDir` scratch dir; the write-back runs
+against a temp copy of `deno.json`. `git status` is clean of `deno.json` and
+`wasm_activation/pkg` after the run.
+
+## Test Plan
+
+New `test/scripts/BuildScriptRevAdvance.ts` (picked up automatically by the
+`test/**/*.ts` include in `deno.json` — no registration change needed), covering
+the five cases from the issue plus two guard-rails:
+
+| # | Test | Asserts |
+| - | ---- | ------- |
+| 1 | stale pin not compared on an advance (#3504) | rc 0, sidecar label on stdout, pin **not** reported as an anchor |
+| 2 | pin still bites on the pinned rev | rc 1, `deno.json neatCore.assetSha256` source label |
+| 3 | advance with no sidecar fails loud | rc 3 with **and** without `--allow-unverified` (#3515) |
+| 4 | advance with a mismatching sidecar fails | rc 1, `release sidecar …` source label |
+| 5 | write-back on a successful advance | temp `deno.json` ends with the new `rev` + `assetSha256`, unrelated keys preserved |
+| + | same-rev bootstrap preserved (#2744) | rc 2 under `--allow-unverified`, rc 3 without — guards against over-tightening |
+| + | write-back is a no-op when already current | `deno.json` left byte-identical |
+
+WHAT-tests only: exit codes, error source labels and resulting `deno.json`
+contents. No grepping of `build.sh` source text — the header comment in
+`BuildScriptContentHash.ts` records that those HOW-tests were deliberately
+removed under #2886.
+
+Supporting change: the sourced-function harness duplicated between
+`BuildScriptContentHash.ts` and `BuildScriptPinScope.ts` is now
+`test/scripts/_buildShHarness.ts`. `BuildScriptPinScope.ts` imports it instead
+of carrying an identical copy; its expectations are unchanged.
+
+### Deno regression avoided
+
+The write-back helper keeps using `deno eval` with values passed through the
+environment; no Node tooling was introduced to make it testable.
+
+## Pre-PR Security Self-Check
+
+- **Input validation** — `select_tarball_anchor` re-uses `verify_tarball_sha256`,
+  which rejects anything that is not a 64-char hex digest before comparing.
+- **Injection surface** — `update_core_pin` passes the rev and hash via the
+  environment, never interpolated into the `deno eval` source, so a hostile
+  rev/hash cannot inject code. This is the pre-existing property, preserved.
+- **Fail loud** — every refusal path returns non-zero and names the source that
+  caught it; no fault is reconciled as success.
+- **Secrets** — none staged; the tests touch only temp directories.

--- a/docs/archive/pr-summaries/pr-summary-3516.md
+++ b/docs/archive/pr-summaries/pr-summary-3516.md
@@ -4,7 +4,7 @@
 
 `test/scripts/BuildScriptContentHash.ts` only ever exercised **same-rev**
 downloads, which is why #3504 shipped: a stale `deno.json`
-`neatCore.assetSha256` pin was compared against a *different* revision's tarball
+`neatCore.assetSha256` pin was compared against a _different_ revision's tarball
 and blocked every internal bump. This PR adds the missing regression coverage
 for the rev-advance decision. Closes #3516.
 
@@ -54,8 +54,8 @@ Backend/CLI change — no web interface to screenshot.
 
 **Acceptance criterion spot-check.** The criterion is "fails if the
 `TARGET_REV == PINNED_REV` condition on the pin check is reverted". Reverting
-that guard locally (`if [[ "$pinned_rev" != "$target_rev" ]]` → `if false`) turns
-the suite red exactly as intended:
+that guard locally (`if [[ "$pinned_rev" != "$target_rev" ]]` → `if false`)
+turns the suite red exactly as intended:
 
 ```
 FAILURES
@@ -86,21 +86,37 @@ stand-in blob, both under a `makeTempDir` scratch dir; the write-back runs
 against a temp copy of `deno.json`. `git status` is clean of `deno.json` and
 `wasm_activation/pkg` after the run.
 
+### Pre-existing failures on this milestone branch (not caused by this PR)
+
+`./quality.sh` reports 13 unrelated failures on the branch point, all of which
+reproduce without this PR's files and were already red on #3539's own
+`Test Results` check:
+
+| Failing tests                                              | Root cause                                                                                                   |
+| ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| 4 × `ErrorGuidedStructuralEvolution/*` discovery-selection | Already tracked by #3531                                                                                     |
+| 2 × `BuildFingerprint` / `WasmPublishIncluded`             | `wasm_activation/pkg/.gitignore` was clobbered to a bare `*` by the bundle refresh in #3539 — filed as #3544 |
+| 6 × `WasmActivationTrapGuardIssue2658`                     | The core rev bump to `7eaa3322` moved synapse-index validation to construction — filed as #3545              |
+
+#3544 is the more urgent of the two new ones: a bare `*` excludes the whole
+vendored bundle from `deno publish`, so JSR consumers would 404 on
+`wasm_activation.js`.
+
 ## Test Plan
 
 New `test/scripts/BuildScriptRevAdvance.ts` (picked up automatically by the
 `test/**/*.ts` include in `deno.json` — no registration change needed), covering
 the five cases from the issue plus two guard-rails:
 
-| # | Test | Asserts |
-| - | ---- | ------- |
-| 1 | stale pin not compared on an advance (#3504) | rc 0, sidecar label on stdout, pin **not** reported as an anchor |
-| 2 | pin still bites on the pinned rev | rc 1, `deno.json neatCore.assetSha256` source label |
-| 3 | advance with no sidecar fails loud | rc 3 with **and** without `--allow-unverified` (#3515) |
-| 4 | advance with a mismatching sidecar fails | rc 1, `release sidecar …` source label |
-| 5 | write-back on a successful advance | temp `deno.json` ends with the new `rev` + `assetSha256`, unrelated keys preserved |
-| + | same-rev bootstrap preserved (#2744) | rc 2 under `--allow-unverified`, rc 3 without — guards against over-tightening |
-| + | write-back is a no-op when already current | `deno.json` left byte-identical |
+| # | Test                                         | Asserts                                                                            |
+| - | -------------------------------------------- | ---------------------------------------------------------------------------------- |
+| 1 | stale pin not compared on an advance (#3504) | rc 0, sidecar label on stdout, pin **not** reported as an anchor                   |
+| 2 | pin still bites on the pinned rev            | rc 1, `deno.json neatCore.assetSha256` source label                                |
+| 3 | advance with no sidecar fails loud           | rc 3 with **and** without `--allow-unverified` (#3515)                             |
+| 4 | advance with a mismatching sidecar fails     | rc 1, `release sidecar …` source label                                             |
+| 5 | write-back on a successful advance           | temp `deno.json` ends with the new `rev` + `assetSha256`, unrelated keys preserved |
+| + | same-rev bootstrap preserved (#2744)         | rc 2 under `--allow-unverified`, rc 3 without — guards against over-tightening     |
+| + | write-back is a no-op when already current   | `deno.json` left byte-identical                                                    |
 
 WHAT-tests only: exit codes, error source labels and resulting `deno.json`
 contents. No grepping of `build.sh` source text — the header comment in
@@ -119,8 +135,9 @@ environment; no Node tooling was introduced to make it testable.
 
 ## Pre-PR Security Self-Check
 
-- **Input validation** — `select_tarball_anchor` re-uses `verify_tarball_sha256`,
-  which rejects anything that is not a 64-char hex digest before comparing.
+- **Input validation** — `select_tarball_anchor` re-uses
+  `verify_tarball_sha256`, which rejects anything that is not a 64-char hex
+  digest before comparing.
 - **Injection surface** — `update_core_pin` passes the rev and hash via the
   environment, never interpolated into the `deno eval` source, so a hostile
   rev/hash cannot inject code. This is the pre-existing property, preserved.

--- a/test/scripts/BuildScriptPinScope.ts
+++ b/test/scripts/BuildScriptPinScope.ts
@@ -1,4 +1,5 @@
 import { assert, assertEquals } from "@std/assert";
+import { runSourcedFns } from "./_buildShHarness.ts";
 
 /**
  * Tests that build.sh scopes the deno.json `neatCore.assetSha256` pin to the
@@ -12,62 +13,6 @@ import { assert, assertEquals } from "@std/assert";
  */
 
 const PIN_FNS = ["verify_tarball_sha256", "verify_pinned_asset_sha256"];
-
-/**
- * Source the named build.sh functions into a sub-shell and run an invocation
- * against them, so the real bash logic is exercised with test data.
- */
-async function runSourcedFns(
-  fnNames: string[],
-  invocation: string,
-): Promise<{ stdout: string; stderr: string; code: number }> {
-  // A temp file (rather than process substitution) is used because
-  // `source <(...)` does not reliably define functions across all bash
-  // builds (e.g. macOS bash 3.2).
-  const fnTmp = await Deno.makeTempFile({ prefix: "neat-fn-", suffix: ".sh" });
-  try {
-    const extracted = await Promise.all(
-      fnNames.map((fnName) =>
-        new Deno.Command("awk", {
-          args: [`/^${fnName}\\(\\)/,/^}$/`, "./build.sh"],
-          stdout: "piped",
-          cwd: Deno.cwd(),
-        }).output()
-      ),
-    );
-    const parts: Uint8Array[] = extracted.map((ex, i) => {
-      assert(
-        ex.stdout.length > 0,
-        `build.sh must define a top-level ${fnNames[i]}() function`,
-      );
-      return ex.stdout;
-    });
-    const joined = new Uint8Array(
-      parts.reduce((n, p) => n + p.length, 0),
-    );
-    let offset = 0;
-    for (const p of parts) {
-      joined.set(p, offset);
-      offset += p.length;
-    }
-    await Deno.writeFile(fnTmp, joined);
-
-    const cmd = new Deno.Command("bash", {
-      args: ["-c", `set -uo pipefail\nsource '${fnTmp}'\n${invocation}\n`],
-      stdout: "piped",
-      stderr: "piped",
-      cwd: Deno.cwd(),
-    });
-    const out = await cmd.output();
-    return {
-      stdout: new TextDecoder().decode(out.stdout),
-      stderr: new TextDecoder().decode(out.stderr),
-      code: out.code,
-    };
-  } finally {
-    await Deno.remove(fnTmp);
-  }
-}
 
 const REV_A = "a".repeat(40);
 const REV_B = "b".repeat(40);

--- a/test/scripts/BuildScriptRevAdvance.ts
+++ b/test/scripts/BuildScriptRevAdvance.ts
@@ -1,0 +1,315 @@
+import { assert, assertEquals, assertStringIncludes } from "@std/assert";
+import { runSourcedFns } from "./_buildShHarness.ts";
+
+/**
+ * Regression tests for the build.sh bump-to-a-new-revision path (issue #3516).
+ *
+ * `BuildScriptContentHash.ts` only ever exercises *same-rev* downloads, which
+ * is why #3504 shipped: a stale `deno.json` `neatCore.assetSha256` pin was
+ * compared against a different revision's tarball and blocked every internal
+ * bump. These tests drive the composed anchor decision
+ * (`select_tarball_anchor`) and the pin write-back (`update_core_pin`) across
+ * a revision advance.
+ *
+ * No network access: the sidecar is a local file and the tarball a stand-in
+ * blob, both under a temp dir. The write-back runs against a temp copy of
+ * `deno.json`, so the repo's real pin is untouched.
+ */
+
+/** build.sh helpers the anchor decision is composed from, in definition order. */
+const ANCHOR_FNS = [
+  "verify_tarball_sha256",
+  "verify_pinned_asset_sha256",
+  "guard_unverified_extract",
+  "select_tarball_anchor",
+];
+
+const REV_OLD = "a".repeat(40);
+const REV_NEW = "b".repeat(40);
+const SIDECAR_NAME = "wasm_activation-pkg.tar.gz.sha256";
+
+/** select_tarball_anchor exit codes (see the build.sh header comment). */
+const ANCHORED = 0;
+const MISMATCH = 1;
+const BOOTSTRAP = 2;
+const REFUSED = 3;
+
+/** Write a stand-in tarball and return its path plus its real SHA-256. */
+async function makeTarball(
+  dir: string,
+  content: string,
+): Promise<{ path: string; sha256: string }> {
+  const path = `${dir}/wasm_activation-pkg.tar.gz`;
+  await Deno.writeTextFile(path, content);
+  const out = await new Deno.Command("shasum", {
+    args: ["-a", "256", path],
+    stdout: "piped",
+  }).output();
+  const sha256 = new TextDecoder().decode(out.stdout).trim().split(/\s+/)[0];
+  return { path, sha256 };
+}
+
+/** Write a release sidecar in `shasum -a 256` output format. */
+async function makeSidecar(dir: string, sha256: string): Promise<string> {
+  const path = `${dir}/${SIDECAR_NAME}`;
+  await Deno.writeTextFile(path, `${sha256}  wasm_activation-pkg.tar.gz\n`);
+  return path;
+}
+
+/**
+ * Invoke `select_tarball_anchor` with the given arguments.
+ *
+ * @param sidecarPath "" when the release published no sidecar.
+ */
+function selectAnchor(opts: {
+  tarball: string;
+  sidecarPath: string;
+  pinnedSha256: string;
+  pinnedRev: string;
+  targetRev: string;
+  allowUnverified?: boolean;
+}) {
+  return runSourcedFns(
+    ANCHOR_FNS,
+    `select_tarball_anchor '${opts.tarball}' '${opts.sidecarPath}' ` +
+      `'${opts.pinnedSha256}' '${opts.pinnedRev}' '${opts.targetRev}' ` +
+      `'${opts.allowUnverified ? "true" : "false"}'`,
+  );
+}
+
+async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "neat-rev-advance-" });
+  try {
+    await fn(dir);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+}
+
+Deno.test({
+  name:
+    "revision advance: a stale pin is not compared when the sidecar anchors the new rev (issue #3504)",
+  permissions: { run: true, read: true, write: true },
+  fn: async () => {
+    await withTempDir(async (dir) => {
+      // The tarball is the NEW rev's bundle; the pin still records the OLD
+      // rev's hash. Comparing it would mismatch and block the bump.
+      const { path, sha256 } = await makeTarball(dir, "bundle-for-rev-new");
+      const sidecarPath = await makeSidecar(dir, sha256);
+
+      const result = await selectAnchor({
+        tarball: path,
+        sidecarPath,
+        pinnedSha256: "c".repeat(64),
+        pinnedRev: REV_OLD,
+        targetRev: REV_NEW,
+      });
+
+      assertEquals(
+        result.code,
+        ANCHORED,
+        `a matching sidecar must anchor a revision advance despite the stale ` +
+          `pin; stdout=${result.stdout} stderr=${result.stderr}`,
+      );
+      assertStringIncludes(result.stdout, SIDECAR_NAME);
+      assert(
+        !result.stdout.includes("neatCore.assetSha256"),
+        `the stale pin must not be reported as an anchor; got: ${result.stdout}`,
+      );
+    });
+  },
+});
+
+Deno.test({
+  name: "same rev: the pin still bites when the tarball hash differs",
+  permissions: { run: true, read: true, write: true },
+  fn: async () => {
+    await withTempDir(async (dir) => {
+      const { path } = await makeTarball(dir, "tampered-bundle");
+
+      const result = await selectAnchor({
+        tarball: path,
+        sidecarPath: "",
+        pinnedSha256: "0".repeat(64),
+        pinnedRev: REV_OLD,
+        targetRev: REV_OLD,
+      });
+
+      assertEquals(
+        result.code,
+        MISMATCH,
+        `a same-rev pin mismatch must abort; stdout=${result.stdout}`,
+      );
+      assertStringIncludes(result.stderr, "deno.json neatCore.assetSha256");
+      assertStringIncludes(result.stderr, "SHA-256 mismatch");
+    });
+  },
+});
+
+Deno.test({
+  name:
+    "revision advance: no sidecar refuses to extract, even with --allow-unverified",
+  permissions: { run: true, read: true, write: true },
+  fn: async () => {
+    await withTempDir(async (dir) => {
+      const { path } = await makeTarball(dir, "bundle-for-rev-new");
+      const noSidecar = {
+        tarball: path,
+        sidecarPath: "",
+        pinnedSha256: "c".repeat(64),
+        pinnedRev: REV_OLD,
+        targetRev: REV_NEW,
+      };
+
+      const strict = await selectAnchor(noSidecar);
+      assertEquals(
+        strict.code,
+        REFUSED,
+        `an unanchored revision advance must refuse; stdout=${strict.stdout}`,
+      );
+
+      const permissive = await selectAnchor({
+        ...noSidecar,
+        allowUnverified: true,
+      });
+      assertEquals(
+        permissive.code,
+        REFUSED,
+        "--allow-unverified must not rescue an unanchored revision advance " +
+          "(issue #3515)",
+      );
+    });
+  },
+});
+
+Deno.test({
+  name: "revision advance: a mismatching sidecar fails loud",
+  permissions: { run: true, read: true, write: true },
+  fn: async () => {
+    await withTempDir(async (dir) => {
+      const { path } = await makeTarball(dir, "bundle-for-rev-new");
+      // The sidecar attests some other blob — a substituted release asset.
+      const sidecarPath = await makeSidecar(dir, "d".repeat(64));
+
+      const result = await selectAnchor({
+        tarball: path,
+        sidecarPath,
+        pinnedSha256: "",
+        pinnedRev: REV_OLD,
+        targetRev: REV_NEW,
+        allowUnverified: true,
+      });
+
+      assertEquals(
+        result.code,
+        MISMATCH,
+        `a mismatching sidecar must abort; stdout=${result.stdout}`,
+      );
+      assertStringIncludes(result.stderr, `release sidecar ${SIDECAR_NAME}`);
+      assertStringIncludes(result.stderr, "SHA-256 mismatch");
+    });
+  },
+});
+
+Deno.test({
+  name:
+    "same rev with no anchor keeps its --allow-unverified bootstrap (issue #2744)",
+  permissions: { run: true, read: true, write: true },
+  fn: async () => {
+    await withTempDir(async (dir) => {
+      const { path } = await makeTarball(dir, "fresh-setup-bundle");
+      const fresh = {
+        tarball: path,
+        sidecarPath: "",
+        pinnedSha256: "",
+        pinnedRev: "",
+        targetRev: REV_NEW,
+      };
+
+      const strict = await selectAnchor(fresh);
+      assertEquals(strict.code, REFUSED, "no anchor and no opt-in must refuse");
+
+      const permissive = await selectAnchor({
+        ...fresh,
+        allowUnverified: true,
+      });
+      assertEquals(
+        permissive.code,
+        BOOTSTRAP,
+        "a same-rev/fresh-setup run must still bootstrap under " +
+          "--allow-unverified",
+      );
+    });
+  },
+});
+
+Deno.test({
+  name: "write-back on a successful advance records the new rev and hash",
+  permissions: { run: true, read: true, write: true },
+  fn: async () => {
+    await withTempDir(async (dir) => {
+      const configPath = `${dir}/deno.json`;
+      const newSha256 = "e".repeat(64);
+      await Deno.writeTextFile(
+        configPath,
+        JSON.stringify(
+          {
+            name: "@stsoftware/neat",
+            neatCore: { rev: REV_OLD, assetSha256: "c".repeat(64) },
+          },
+          null,
+          2,
+        ) + "\n",
+      );
+
+      const result = await runSourcedFns(
+        ["update_core_pin"],
+        `update_core_pin '${configPath}' '${REV_NEW}' '${newSha256}' ` +
+          `'${REV_OLD}' '${"c".repeat(64)}'`,
+      );
+      assertEquals(
+        result.code,
+        0,
+        `write-back must succeed; stderr=${result.stderr}`,
+      );
+
+      const updated = JSON.parse(await Deno.readTextFile(configPath));
+      assertEquals(updated.neatCore.rev, REV_NEW);
+      assertEquals(updated.neatCore.assetSha256, newSha256);
+      assertEquals(
+        updated.name,
+        "@stsoftware/neat",
+        "unrelated deno.json keys must be preserved",
+      );
+    });
+  },
+});
+
+Deno.test({
+  name: "write-back is a no-op when the rev and hash are already current",
+  permissions: { run: true, read: true, write: true },
+  fn: async () => {
+    await withTempDir(async (dir) => {
+      const configPath = `${dir}/deno.json`;
+      const sha256 = "e".repeat(64);
+      const original = JSON.stringify(
+        { neatCore: { rev: REV_NEW, assetSha256: sha256 } },
+        null,
+        2,
+      ) + "\n";
+      await Deno.writeTextFile(configPath, original);
+
+      const result = await runSourcedFns(
+        ["update_core_pin"],
+        `update_core_pin '${configPath}' '${REV_NEW}' '${sha256}' ` +
+          `'${REV_NEW}' '${sha256}'`,
+      );
+      assertEquals(result.code, 0);
+      assertEquals(
+        await Deno.readTextFile(configPath),
+        original,
+        "an already-current pin must leave deno.json byte-identical",
+      );
+    });
+  },
+});

--- a/test/scripts/_buildShHarness.ts
+++ b/test/scripts/_buildShHarness.ts
@@ -1,0 +1,71 @@
+import { assert } from "@std/assert";
+
+/**
+ * Shared harness for the `test/scripts/BuildScript*.ts` suites: source named
+ * top-level functions out of `build.sh` into a sub-shell and drive them with
+ * test data, so the real bash logic is exercised without a network fetch.
+ */
+
+export interface ShellResult {
+  stdout: string;
+  stderr: string;
+  code: number;
+}
+
+/**
+ * Source the named build.sh functions into a sub-shell and run an invocation
+ * against them.
+ *
+ * @param fnNames Top-level function names to extract, in definition order.
+ * @param invocation Bash to run once the functions are defined.
+ */
+export async function runSourcedFns(
+  fnNames: string[],
+  invocation: string,
+): Promise<ShellResult> {
+  // A temp file (rather than process substitution) is used because
+  // `source <(...)` does not reliably define functions across all bash
+  // builds (e.g. macOS bash 3.2).
+  const fnTmp = await Deno.makeTempFile({ prefix: "neat-fn-", suffix: ".sh" });
+  try {
+    const extracted = await Promise.all(
+      fnNames.map((fnName) =>
+        new Deno.Command("awk", {
+          args: [`/^${fnName}\\(\\)/,/^}$/`, "./build.sh"],
+          stdout: "piped",
+          cwd: Deno.cwd(),
+        }).output()
+      ),
+    );
+    const parts: Uint8Array[] = extracted.map((ex, i) => {
+      assert(
+        ex.stdout.length > 0,
+        `build.sh must define a top-level ${fnNames[i]}() function`,
+      );
+      return ex.stdout;
+    });
+    const joined = new Uint8Array(parts.reduce((n, p) => n + p.length, 0));
+    let offset = 0;
+    for (const p of parts) {
+      joined.set(p, offset);
+      offset += p.length;
+    }
+    await Deno.writeFile(fnTmp, joined);
+
+    const cmd = new Deno.Command("bash", {
+      args: ["-c", `set -uo pipefail\nsource '${fnTmp}'\n${invocation}\n`],
+      stdout: "piped",
+      stderr: "piped",
+      stdin: "null",
+      cwd: Deno.cwd(),
+    });
+    const out = await cmd.output();
+    return {
+      stdout: new TextDecoder().decode(out.stdout),
+      stderr: new TextDecoder().decode(out.stderr),
+      code: out.code,
+    };
+  } finally {
+    await Deno.remove(fnTmp);
+  }
+}


### PR DESCRIPTION
# Regression test: build.sh bump-to-new-rev path

## Summary

`test/scripts/BuildScriptContentHash.ts` only ever exercised **same-rev**
downloads, which is why #3504 shipped: a stale `deno.json`
`neatCore.assetSha256` pin was compared against a _different_ revision's tarball
and blocked every internal bump. This PR adds the missing regression coverage
for the rev-advance decision. Closes #3516.

The anchor decision was inline in the download flow, so it could not be
exercised without a network fetch. It is now extracted into two pure shell
functions in `build.sh` — behaviour is unchanged, only its shape:

- **`select_tarball_anchor`** — composes the release sidecar check, the
  rev-scoped `deno.json` pin (#3514) and `guard_unverified_extract` (#3515) into
  one extract-or-refuse decision. Reuses the existing `guard_unverified_extract`
  signature rather than inventing a second one.
- **`update_core_pin`** — the `deno.json` `neatCore` write-back, now taking the
  config path as an argument so it can run against a temp copy.

One supporting change: the "Skipping deno.json neatCore.assetSha256 check…" note
moved from stdout to stderr, because `select_tarball_anchor` returns the anchor
label on stdout. It is a diagnostic, so stderr is the correct sink; users still
see it and the #3514 tests (which assert on `stdout + stderr`) are unaffected.

### Anchor decision

```mermaid
flowchart TD
    A[Downloaded tarball] --> B{Sidecar present?}
    B -- yes --> C{Sidecar hash matches?}
    C -- no --> X[rc 1: abort<br/>'release sidecar …']
    C -- yes --> D[anchor = sidecar]
    B -- no --> E
    D --> E{Pin applies?<br/>target rev == pinned rev}
    E -- "no (rev advance)" --> F[Pin skipped — never compared]
    E -- yes --> G{Pin matches?}
    G -- no --> Y[rc 1: abort<br/>'deno.json neatCore.assetSha256']
    G -- yes --> H[anchor += pin]
    F --> I{Any anchor?}
    H --> I
    I -- yes --> J[rc 0: extract]
    I -- no --> K{Rev advance?}
    K -- yes --> L[rc 3: refuse<br/>--allow-unverified does NOT apply]
    K -- no --> M{--allow-unverified?}
    M -- yes --> N[rc 2: bootstrap]
    M -- no --> O[rc 3: refuse]
```

## Evidence

Backend/CLI change — no web interface to screenshot.

**Acceptance criterion spot-check.** The criterion is "fails if the
`TARGET_REV == PINNED_REV` condition on the pin check is reverted". Reverting
that guard locally (`if [[ "$pinned_rev" != "$target_rev" ]]` → `if false`)
turns the suite red exactly as intended:

```
FAILURES

revision advance: a stale pin is not compared when the sidecar anchors the new rev (issue #3504)
revision advance: no sidecar refuses to extract, even with --allow-unverified

FAILED | 5 passed | 2 failed
```

With the guard in place:

```
running 7 tests from ./test/scripts/BuildScriptRevAdvance.ts
revision advance: a stale pin is not compared when the sidecar anchors the new rev (issue #3504) ... ok
same rev: the pin still bites when the tarball hash differs ... ok
revision advance: no sidecar refuses to extract, even with --allow-unverified ... ok
revision advance: a mismatching sidecar fails loud ... ok
same rev with no anchor keeps its --allow-unverified bootstrap (issue #2744) ... ok
write-back on a successful advance records the new rev and hash ... ok
write-back is a no-op when the rev and hash are already current ... ok

ok | 7 passed | 0 failed
```

**No network, no repo mutation.** The sidecar is a local file, the tarball a
stand-in blob, both under a `makeTempDir` scratch dir; the write-back runs
against a temp copy of `deno.json`. `git status` is clean of `deno.json` and
`wasm_activation/pkg` after the run.

### Pre-existing failures on this milestone branch (not caused by this PR)

`./quality.sh` reports 13 unrelated failures on the branch point, all of which
reproduce without this PR's files and were already red on #3539's own
`Test Results` check:

| Failing tests                                              | Root cause                                                                                                   |
| ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
| 4 × `ErrorGuidedStructuralEvolution/*` discovery-selection | Already tracked by #3531                                                                                     |
| 2 × `BuildFingerprint` / `WasmPublishIncluded`             | `wasm_activation/pkg/.gitignore` was clobbered to a bare `*` by the bundle refresh in #3539 — filed as #3544 |
| 6 × `WasmActivationTrapGuardIssue2658`                     | The core rev bump to `7eaa3322` moved synapse-index validation to construction — filed as #3545              |

#3544 is the more urgent of the two new ones: a bare `*` excludes the whole
vendored bundle from `deno publish`, so JSR consumers would 404 on
`wasm_activation.js`.

## Test Plan

New `test/scripts/BuildScriptRevAdvance.ts` (picked up automatically by the
`test/**/*.ts` include in `deno.json` — no registration change needed), covering
the five cases from the issue plus two guard-rails:

| # | Test                                         | Asserts                                                                            |
| - | -------------------------------------------- | ---------------------------------------------------------------------------------- |
| 1 | stale pin not compared on an advance (#3504) | rc 0, sidecar label on stdout, pin **not** reported as an anchor                   |
| 2 | pin still bites on the pinned rev            | rc 1, `deno.json neatCore.assetSha256` source label                                |
| 3 | advance with no sidecar fails loud           | rc 3 with **and** without `--allow-unverified` (#3515)                             |
| 4 | advance with a mismatching sidecar fails     | rc 1, `release sidecar …` source label                                             |
| 5 | write-back on a successful advance           | temp `deno.json` ends with the new `rev` + `assetSha256`, unrelated keys preserved |
| + | same-rev bootstrap preserved (#2744)         | rc 2 under `--allow-unverified`, rc 3 without — guards against over-tightening     |
| + | write-back is a no-op when already current   | `deno.json` left byte-identical                                                    |

WHAT-tests only: exit codes, error source labels and resulting `deno.json`
contents. No grepping of `build.sh` source text — the header comment in
`BuildScriptContentHash.ts` records that those HOW-tests were deliberately
removed under #2886.

Supporting change: the sourced-function harness duplicated between
`BuildScriptContentHash.ts` and `BuildScriptPinScope.ts` is now
`test/scripts/_buildShHarness.ts`. `BuildScriptPinScope.ts` imports it instead
of carrying an identical copy; its expectations are unchanged.

### Deno regression avoided

The write-back helper keeps using `deno eval` with values passed through the
environment; no Node tooling was introduced to make it testable.

## Pre-PR Security Self-Check

- **Input validation** — `select_tarball_anchor` re-uses
  `verify_tarball_sha256`, which rejects anything that is not a 64-char hex
  digest before comparing.
- **Injection surface** — `update_core_pin` passes the rev and hash via the
  environment, never interpolated into the `deno eval` source, so a hostile
  rev/hash cannot inject code. This is the pre-existing property, preserved.
- **Fail loud** — every refusal path returns non-zero and names the source that
  caught it; no fault is reconciled as success.
- **Secrets** — none staged; the tests touch only temp directories.



## Milestone
This PR is part of the **#3504 build.sh checks stale assetSha256 pin on new rev, blocking internal bumps** milestone and targets the `milestone/3504-build-sh-checks-stale-assetsha256-pin-on-new` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-ms6qbr2e-69b7e1`<!-- vibe-worker-issue-3516 -->