### PR TITLE
chore(audit): slice A — core evolution & training top-level options (#3505)

### DIFF
--- a/docs/OPTION_AUDIT_SLICE_A.md
+++ b/docs/OPTION_AUDIT_SLICE_A.md
@@ -1,0 +1,168 @@
+# Option audit — slice A: core evolution & training top-level options
+
+Slice A of the [#3505](https://github.com/stSoftwareAU/NEAT-AI/issues/3505)
+option-removal audit (Issue #3519). It classifies the **46 non-`discovery*`
+top-level scalar and flag options** declared in
+[`src/config/NeatArguments.ts`](../src/config/NeatArguments.ts) against real
+consumer usage.
+
+Out of scope here: `discovery*` keys (slice B, #3520), all nested config objects
+(slices C–F), and `fitnessSampleRate` (already removed by #3502).
+
+The companion doc [`OPTION_USAGE_AUDIT.md`](OPTION_USAGE_AUDIT.md) describes the
+scan harness and the search traps this slice had to work around.
+
+## Result
+
+| Verdict                       | Count |
+| ----------------------------- | ----: |
+| `IN USE`                      |    24 |
+| `KEEP (load-bearing default)` |    18 |
+| `QUALIFIES`                   |     4 |
+| **Total**                     |    46 |
+
+Four options qualify for removal, filed as three removal issues: #3552
+(`maxConns` + `maximumNumberOfNodes`, which share one code path), #3553
+(`enableRepetitiveTraining`) and #3554 (`dnaSharingMode`).
+
+## Method
+
+Consumers were confirmed from `deno.json`: `stSoftwareAU/GRQ` pins
+`jsr:@stsoftware/neat-ai@6.0.0` and `stSoftwareAU/NEAT-AI-Examples` pins
+`@5.9.43`.
+
+Each key was resolved twice, against fresh clones and against the code-search
+index:
+
+```bash
+# Local pass — primary evidence, complete and unmetered.
+git -C GRQ                grep -n -E "(^|[^A-Za-z0-9_])<key>[[:space:]]*[:=]" -- '*.ts' '*.js' '*.json' '*.sh'
+git -C NEAT-AI-Examples   grep -n -E "(^|[^A-Za-z0-9_])<key>[[:space:]]*[:=]" -- '*.ts' '*.js' '*.json' '*.sh'
+
+# Cross-check — per-repo only, never a bare --owner.
+gh search code "<key>" --repo stSoftwareAU/GRQ --limit 20
+gh search code "<key>" --repo stSoftwareAU/NEAT-AI-Examples --limit 20
+```
+
+A key with no local hit was re-checked as a plain substring across the whole
+clone (docs included) before any `QUALIFIES` verdict, then cross-checked with
+code search. `QUALIFIES` was only awarded where all three passes were empty
+**and** the default was read to be inert.
+
+### Two search faults this slice hit and corrected
+
+Both are worth recording, because each one silently manufactures false
+`QUALIFIES` verdicts:
+
+1. **`ripgrep` is not on the non-interactive `PATH` here** — it resolves only as
+   a shell function. The first sweep paired `rg` with `2>/dev/null`, so the
+   exit-127 "command not found" was swallowed and **every one of the 46 keys
+   read as unused**, including `populationSize`. Fixed by switching to
+   `git grep` (the tool the harness itself auto-detects) and never suppressing
+   stderr. This is the [fail-loud rule](../AGENTS.md) in miniature: absence of a
+   hit is not evidence of absence when the search never ran.
+2. **A bare `gh search code --owner stSoftwareAU` saturates its result window**
+   with NEAT-AI's own hits, so consumer hits fall off the end. Every query in
+   this slice is `--repo`-scoped.
+
+### Controls
+
+The `populationSize` positive control was run through **both** search paths
+before any verdict was recorded, and both were re-run after the `rg` fault was
+fixed:
+
+- `git grep` — hits in both clones (`GRQ/src/Learn.ts:436`,
+  `NEAT-AI-Examples/adaptive_mutation/adaptive_mutation.ts:408`).
+- `gh search code --repo` — 20 hits in each consumer.
+- `scripts/audit-option-usage.ts --controls-only` — passed, which also confirms
+  the negative control (`dnaSharingMode` reported not set).
+
+## `QUALIFIES` — 4 keys, 3 removal issues
+
+| Key                        | Default                   | Issue | Why the default is inert                                                                                                                                            |
+| -------------------------- | ------------------------- | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `maxConns`                 | `Number.MAX_SAFE_INTEGER` | #3552 | Only reader is `Mutator.ts` `creature.synapses.length >= config.maxConns`, which can never be true. The adjacent `maxSynapses` bound does the real capping.         |
+| `maximumNumberOfNodes`     | `Number.MAX_SAFE_INTEGER` | #3552 | Only reader is `Mutator.ts` `creature.neurons.length < config.maximumNumberOfNodes`, which is always true.                                                          |
+| `enableRepetitiveTraining` | `false`                   | #3553 | Only reader is `NeatScheduling.ts`; with the flag off the branch always returns, so deleting the flag preserves behaviour exactly.                                  |
+| `dnaSharingMode`           | `"default"`               | #3554 | `DEFAULT_DNA_SHARING_PRESET` is defined to equal the per-knob defaults already applied in `createNeatConfig()` — asserted by `test/transfer/KnobTuningStrategy.ts`. |
+
+Each removal issue carries a reviewer caveat, because none of the three is a
+pure dead-knob deletion: `maxConns` / `maximumNumberOfNodes` are functional when
+set and NEAT-AI's own tests set them; `enableRepetitiveTraining` is set `true`
+by three internal tests that would need reworking; and `dnaSharingMode` is the
+read-side of an exported strategy API and the audit harness's own negative
+control.
+
+`dnaSharingMode` is the one that needs a human's eye at review. It is inert
+today, and the #2496 bake-off
+([`dna-sharing-bake-off-results.md`](dna-sharing-bake-off-results.md)) measured
+`KnobTuningStrategy("aggressive")` at **zero lift** and deliberately does not
+flip the knob. But it is also the read-side of an **exported** strategy API, so
+its removal issue has to take `KnobTuningStrategy`,
+`AGGRESSIVE_DNA_SHARING_PRESET`, and the preset lookup with it. That is a
+feature deletion, not a dead-knob deletion.
+
+## `KEEP (load-bearing default)` — 18 keys
+
+Nobody sets these, but the default drives live behaviour, so the knob stays.
+
+| Key                                       | Default                 | What the default drives                                                    |
+| ----------------------------------------- | ----------------------- | -------------------------------------------------------------------------- |
+| `dataSetPartitionBreak`                   | `2000`                  | Real dataset partition size.                                               |
+| `debug`                                   | `\|\| getGlobalDebug()` | ORs in a live global switch; also the export-validation diagnostics hatch. |
+| `maxCRISPRsPerGeneration`                 | `1`                     | Caps CRISPR applications per generation — and GRQ _does_ set `CRISPRs`.    |
+| `maxDedupRetries`                         | `16`                    | Dedup retry budget.                                                        |
+| `trainingTaskTimeoutMinutes`              | `5` min                 | Per-task wall-clock cap (#3053); `0` would disable it.                     |
+| `skipTrainingAfterConsecutiveRegressions` | `2`                     | Regression bypass fires after two regressions (#2382).                     |
+| `subnetworkIndexSize`                     | `50_000`                | Sizes the shared subnetwork LRU index (#2531).                             |
+| `trainingBatchSize`                       | `100`                   | Live batch size.                                                           |
+| `disableRandomSamples`                    | `feedbackLoop === true` | Derived from `feedbackLoop`, which **is** in use in NEAT-AI-Examples.      |
+| `maximumBiasAdjustmentScale`              | `1`                     | A ±1 per-iteration bias clamp, not an identity multiplier.                 |
+| `maximumWeightAdjustmentScale`            | `1`                     | A ±1 per-iteration weight clamp.                                           |
+| `globalBreedingRate`                      | `rng.random()`          | Randomised per run — removing it would fix a currently-varying behaviour.  |
+| `diversityBreedingRate`                   | preset                  | Supplied by the DNA-sharing preset.                                        |
+| `geneticCompatibilityThreshold`           | preset (`0.3`)          | Nine live readers.                                                         |
+| `interSpeciesCrossoverThreshold`          | preset (`0.1`)          | Selects the input-weight crossover path.                                   |
+| `syntheticAlignmentThreshold`             | `0.2`                   | Grafting alignment fallback — an AGENTS.md documented invariant.           |
+| `allowPoolBorrowing`                      | `!== false` → `true`    | Heavy-pool borrowing is **on** by default (#2329).                         |
+| `tolerateCorruptParents`                  | `!== false` → `true`    | Corrupt-parent tolerance is **on** by default.                             |
+
+## `IN USE` — 24 keys
+
+| Key                               | Evidence                                                                                    |
+| --------------------------------- | ------------------------------------------------------------------------------------------- |
+| `populationSize`                  | `GRQ/src/Learn.ts:436`; `NEAT-AI-Examples/adaptive_mutation/adaptive_mutation.ts:408`       |
+| `costName`                        | `GRQ/src/Learn.ts:162`; `NEAT-AI-Examples/mnist_classification/exploration_campaign.ts:526` |
+| `creativeThinkingConnectionCount` | `GRQ/src/Learn.ts:430`                                                                      |
+| `creatures`                       | `GRQ/src/Learn.ts:428`                                                                      |
+| `CRISPRs`                         | `GRQ/src/Learn.ts:429`                                                                      |
+| `customCost`                      | `GRQ/src/fx/EvolveApp.ts:374`                                                               |
+| `feedbackLoop`                    | `NEAT-AI-Examples/crispr_injection/crispr_injection.ts` (+21 more files)                    |
+| `focusList`                       | `GRQ/src/Learn.ts:440`                                                                      |
+| `focusRate`                       | `GRQ/src/Learn.ts:441`                                                                      |
+| `costOfGrowth`                    | `GRQ/src/Learn.ts:437`; `NEAT-AI-Examples/adaptive_mutation/adaptive_mutation.ts:420`       |
+| `elitism`                         | `GRQ/src/Learn.ts:545`                                                                      |
+| `timeoutMinutes`                  | `GRQ/src/Learn.ts:432`; `NEAT-AI-Examples/adaptive_mutation/adaptive_mutation.ts:417`       |
+| `trainPerGen`                     | `GRQ/src/Learn.ts:442`                                                                      |
+| `mutationAmount`                  | `GRQ/src/Learn.ts:548`; `NEAT-AI-Examples/adaptive_mutation/adaptive_mutation.ts:421`       |
+| `mutationRate`                    | `GRQ/src/Learn.ts:551`; `NEAT-AI-Examples/adaptive_mutation/adaptive_mutation.ts:420`       |
+| `threads`                         | `GRQ/src/Learn.ts:438`; `NEAT-AI-Examples/adaptive_mutation/adaptive_mutation.ts:425`       |
+| `heavyTaskWorkerCount`            | `GRQ/src/Learn.ts:110`                                                                      |
+| `selection`                       | `GRQ/src/Learn.ts:542`                                                                      |
+| `iterations`                      | `NEAT-AI-Examples/adaptive_mutation/adaptive_mutation.ts:410`                               |
+| `verbose`                         | `GRQ/src/Learn.ts:439`; `NEAT-AI-Examples/adaptive_mutation/adaptive_mutation.ts:423`       |
+| `log`                             | `GRQ/src/Learn.ts:434`; `NEAT-AI-Examples/adaptive_mutation/adaptive_mutation.ts:424`       |
+| `trainingSampleRate`              | `GRQ/src/Learn.ts:444`; `NEAT-AI-Examples/mnist_classification/exploration_campaign.ts:103` |
+| `targetError`                     | `GRQ/src/Learn.ts:433`; `NEAT-AI-Examples/adaptive_mutation/adaptive_mutation.ts:411`       |
+| `sparseRatio`                     | `GRQ/src/Learn.ts:445`                                                                      |
+
+Of the injection points the slice was told to hold to a higher bar, all but
+`debug` came back `IN USE` on their own evidence: `costName`, `customCost`,
+`selection`, `feedbackLoop`, `focusList`, `creatures`, and `CRISPRs`. `debug` is
+`KEEP`, not a removal candidate.
+
+## Dedup
+
+Checked #3446–#3449 (deprecated-api) and #3509–#3512 (dead-code sweep): none
+touches a slice-A option key, so no existing issue absorbs these findings. An
+open-issue search for each `QUALIFIES` key found no prior removal issue.

--- a/docs/README.md
+++ b/docs/README.md
@@ -120,6 +120,10 @@ Drop-in API and configuration material.
   harness (`scripts/audit-option-usage.ts`): how every option key is enumerated
   from source and checked against consumer repositories, the built-in controls,
   and the search traps that would otherwise corrupt the audit.
+- **[OPTION_AUDIT_SLICE_A.md](OPTION_AUDIT_SLICE_A.md)** — slice A of the #3505
+  audit: the 46 non-`discovery*` top-level options classified `IN USE` /
+  `KEEP (load-bearing default)` / `QUALIFIES`, with the per-key evidence and the
+  two search faults that had to be corrected first.
 - **[TIMEOUTS.md](TIMEOUTS.md)** — `timeoutMinutes` semantics and the absolute
   **T+15** hard cap: the two deadlines, what each phase does at the cap (abandon
   in-flight work, keep partial results, return the best creature), how the

--- a/docs/archive/pr-summaries/pr-summary-3519.md
+++ b/docs/archive/pr-summaries/pr-summary-3519.md
@@ -1,0 +1,121 @@
+# Slice A of the #3505 option audit — core evolution & training top-level options
+
+## Summary
+
+Classified all **46** non-`discovery*` top-level scalar and flag options
+declared in `src/config/NeatArguments.ts` against real consumer usage in
+`stSoftwareAU/GRQ` and `stSoftwareAU/NEAT-AI-Examples`, and filed a removal
+issue for every qualifying key. Closes #3519.
+
+| Verdict                       | Count |
+| ----------------------------- | ----: |
+| `IN USE`                      |    24 |
+| `KEEP (load-bearing default)` |    18 |
+| `QUALIFIES`                   |     4 |
+
+Four options qualify, filed as three removal issues:
+
+| Key                        | Default                            | Issue |
+| -------------------------- | ---------------------------------- | ----- |
+| `maxConns`                 | `Number.MAX_SAFE_INTEGER` (no cap) | #3552 |
+| `maximumNumberOfNodes`     | `Number.MAX_SAFE_INTEGER` (no cap) | #3552 |
+| `enableRepetitiveTraining` | `false` (flag off)                 | #3553 |
+| `dnaSharingMode`           | `"default"` preset                 | #3554 |
+
+None is a pure dead-knob deletion, so each issue carries an explicit reviewer
+caveat rather than presenting the removal as mechanical.
+
+This PR is **documentation only** — no `src/` change. The audit's deliverable is
+the classification; the code deletions ride the three removal issues.
+
+### Files changed
+
+- `docs/OPTION_AUDIT_SLICE_A.md` — new: the full per-key evidence table.
+- `docs/README.md` — index entry for the new doc.
+- `docs/archive/pr-summaries/pr-summary-3519.md` — this file.
+
+## Evidence
+
+No UI and no runtime surface to screenshot — the issue itself notes the audit
+has no runtime surface. The evidence is the search itself, run twice per key
+against fresh consumer clones and against the code-search index.
+
+```mermaid
+flowchart TD
+    A[46 slice-A keys from NeatArguments.ts] --> B[git grep over fresh GRQ + Examples clones]
+    B -- hit --> C[IN USE — record path]
+    B -- no hit --> D[Plain-substring re-check, docs included]
+    D -- hit --> C
+    D -- no hit --> E["gh search code --repo, per repo, never --owner"]
+    E -- hit --> C
+    E -- no hit --> F[Read the default and its code path]
+    F -- inert --> G[QUALIFIES → removal issue]
+    F -- drives behaviour --> H["KEEP (load-bearing default)"]
+```
+
+### Controls
+
+`populationSize` is the positive control: a sweep that reports it unused is a
+broken sweep, not a finding. It was verified through **both** search paths after
+the fault below was fixed:
+
+- `git grep` — `GRQ/src/Learn.ts:436` and
+  `NEAT-AI-Examples/adaptive_mutation/adaptive_mutation.ts:408`.
+- `gh search code --repo` — 20 hits in each consumer.
+- `scripts/audit-option-usage.ts --controls-only` — passed, which also
+  re-confirms the `dnaSharingMode` negative control.
+
+### A search fault the control caught
+
+Worth recording, because it is the exact failure mode #3519 warned about:
+`ripgrep` is **not on the non-interactive `PATH`** on the worker — it resolves
+only as a shell function. The first sweep paired `rg` with `2>/dev/null`, so the
+exit-127 "command not found" was swallowed and **all 46 keys read as unused,
+`populationSize` included**. Every verdict in that pass was invalid.
+
+Fixed by switching to `git grep` (the tool `scripts/audit-option-usage.ts`
+itself auto-detects) and never suppressing stderr; the corrected sweep also
+fails loud if the positive control returns zero. This is the never-fail-silently
+rule in miniature — absence of a hit is not evidence of absence when the search
+never ran.
+
+The second trap, a bare `gh search code --owner stSoftwareAU` saturating its
+result window with NEAT-AI's own hits, was avoided from the start: every query
+is `--repo`-scoped.
+
+## Test Plan
+
+No tests added or modified. The change is documentation only, and the honest
+test for a classification would have to grep the doc for its own contents — an
+explicitly forbidden "how" test under `AGENTS.md`. The existing
+`test/scripts/AuditOptionUsage.ts` already pins the harness behaviour this slice
+relied on, including the `--owner`-never-used assertion and the pinned key
+count.
+
+Verification performed instead:
+
+- `./quality.sh < /dev/null` — lint, format and type-check clean; **8066 tests
+  passed, 4 failed**.
+- The 4 failures are all in `test/ErrorGuidedStructuralEvolution/`
+  (`DiscoveryRobustness.ts`, `InvalidDataDetection.ts` ×2, `MinimalCreature.ts`)
+  and are **pre-existing on this branch's HEAD**, not caused by this PR.
+  Confirmed by stashing the change and re-running `MinimalCreature.ts` on the
+  clean tree — it fails identically. This PR touches only `docs/`, so it cannot
+  reach the discovery selection path.
+- `deno test test/docs/ApiConfigurationDefaults.ts test/scripts/AuditOptionUsage.ts`
+  — 61 passed, 0 failed. These are the tests that cover the option-defaults
+  documentation and the audit harness this slice relied on.
+- `deno fmt --check` on all three changed files — clean.
+- `deno run --allow-read --allow-write --allow-run --allow-env scripts/audit-option-usage.ts --clone-root "$HOME/auto-issue-work" --controls-only`
+  — both controls pass.
+- Per-repo `gh search code` sweep over the 21 keys with no local hit — exit 0,
+  no unresolved probes, all zero.
+
+## Definition of done
+
+- [x] Every key in this slice classified — 24 + 18 + 4 = 46, none skipped.
+- [x] Classification table posted as a comment on #3505.
+- [x] A removal issue filed for every `QUALIFIES` key (#3552, #3553, #3554),
+      linked from that comment.
+- [x] Dedup checked against #3446–#3449 and #3509–#3512 — none touches a slice-A
+      key; no prior removal issue exists for any qualifying key.


### PR DESCRIPTION
# Slice A of the #3505 option audit — core evolution & training top-level options

## Summary

Classified all **46** non-`discovery*` top-level scalar and flag options
declared in `src/config/NeatArguments.ts` against real consumer usage in
`stSoftwareAU/GRQ` and `stSoftwareAU/NEAT-AI-Examples`, and filed a removal
issue for every qualifying key. Closes #3519.

| Verdict                       | Count |
| ----------------------------- | ----: |
| `IN USE`                      |    24 |
| `KEEP (load-bearing default)` |    18 |
| `QUALIFIES`                   |     4 |

Four options qualify, filed as three removal issues:

| Key                        | Default                            | Issue |
| -------------------------- | ---------------------------------- | ----- |
| `maxConns`                 | `Number.MAX_SAFE_INTEGER` (no cap) | #3552 |
| `maximumNumberOfNodes`     | `Number.MAX_SAFE_INTEGER` (no cap) | #3552 |
| `enableRepetitiveTraining` | `false` (flag off)                 | #3553 |
| `dnaSharingMode`           | `"default"` preset                 | #3554 |

None is a pure dead-knob deletion, so each issue carries an explicit reviewer
caveat rather than presenting the removal as mechanical.

This PR is **documentation only** — no `src/` change. The audit's deliverable is
the classification; the code deletions ride the three removal issues.

### Files changed

- `docs/OPTION_AUDIT_SLICE_A.md` — new: the full per-key evidence table.
- `docs/README.md` — index entry for the new doc.
- `docs/archive/pr-summaries/pr-summary-3519.md` — this file.

## Evidence

No UI and no runtime surface to screenshot — the issue itself notes the audit
has no runtime surface. The evidence is the search itself, run twice per key
against fresh consumer clones and against the code-search index.

```mermaid
flowchart TD
    A[46 slice-A keys from NeatArguments.ts] --> B[git grep over fresh GRQ + Examples clones]
    B -- hit --> C[IN USE — record path]
    B -- no hit --> D[Plain-substring re-check, docs included]
    D -- hit --> C
    D -- no hit --> E["gh search code --repo, per repo, never --owner"]
    E -- hit --> C
    E -- no hit --> F[Read the default and its code path]
    F -- inert --> G[QUALIFIES → removal issue]
    F -- drives behaviour --> H["KEEP (load-bearing default)"]
```

### Controls

`populationSize` is the positive control: a sweep that reports it unused is a
broken sweep, not a finding. It was verified through **both** search paths after
the fault below was fixed:

- `git grep` — `GRQ/src/Learn.ts:436` and
  `NEAT-AI-Examples/adaptive_mutation/adaptive_mutation.ts:408`.
- `gh search code --repo` — 20 hits in each consumer.
- `scripts/audit-option-usage.ts --controls-only` — passed, which also
  re-confirms the `dnaSharingMode` negative control.

### A search fault the control caught

Worth recording, because it is the exact failure mode #3519 warned about:
`ripgrep` is **not on the non-interactive `PATH`** on the worker — it resolves
only as a shell function. The first sweep paired `rg` with `2>/dev/null`, so the
exit-127 "command not found" was swallowed and **all 46 keys read as unused,
`populationSize` included**. Every verdict in that pass was invalid.

Fixed by switching to `git grep` (the tool `scripts/audit-option-usage.ts`
itself auto-detects) and never suppressing stderr; the corrected sweep also
fails loud if the positive control returns zero. This is the never-fail-silently
rule in miniature — absence of a hit is not evidence of absence when the search
never ran.

The second trap, a bare `gh search code --owner stSoftwareAU` saturating its
result window with NEAT-AI's own hits, was avoided from the start: every query
is `--repo`-scoped.

## Test Plan

No tests added or modified. The change is documentation only, and the honest
test for a classification would have to grep the doc for its own contents — an
explicitly forbidden "how" test under `AGENTS.md`. The existing
`test/scripts/AuditOptionUsage.ts` already pins the harness behaviour this slice
relied on, including the `--owner`-never-used assertion and the pinned key
count.

Verification performed instead:

- `./quality.sh < /dev/null` — lint, format and type-check clean; **8066 tests
  passed, 4 failed**.
- The 4 failures are all in `test/ErrorGuidedStructuralEvolution/`
  (`DiscoveryRobustness.ts`, `InvalidDataDetection.ts` ×2, `MinimalCreature.ts`)
  and are **pre-existing on this branch's HEAD**, not caused by this PR.
  Confirmed by stashing the change and re-running `MinimalCreature.ts` on the
  clean tree — it fails identically. This PR touches only `docs/`, so it cannot
  reach the discovery selection path.
- `deno test test/docs/ApiConfigurationDefaults.ts test/scripts/AuditOptionUsage.ts`
  — 61 passed, 0 failed. These are the tests that cover the option-defaults
  documentation and the audit harness this slice relied on.
- `deno fmt --check` on all three changed files — clean.
- `deno run --allow-read --allow-write --allow-run --allow-env scripts/audit-option-usage.ts --clone-root "$HOME/auto-issue-work" --controls-only`
  — both controls pass.
- Per-repo `gh search code` sweep over the 21 keys with no local hit — exit 0,
  no unresolved probes, all zero.

## Definition of done

- [x] Every key in this slice classified — 24 + 18 + 4 = 46, none skipped.
- [x] Classification table posted as a comment on #3505.
- [x] A removal issue filed for every `QUALIFIES` key (#3552, #3553, #3554),
      linked from that comment.
- [x] Dedup checked against #3446–#3449 and #3509–#3512 — none touches a slice-A
      key; no prior removal issue exists for any qualifying key.



## Milestone
This PR is part of the **#3505 chore: audit NEAT-AI options unused by GRQ/NEAT-AI-Examples for removal** milestone and targets the `milestone/3505-chore-audit-neat-ai-options-unused-by-grq-nea` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-ms6wziv5-28150c`<!-- vibe-worker-issue-3519 -->