### PR TITLE
Audit: consolidate the #3505 option-audit result, dedup and close out (Issue #3525)

### DIFF
--- a/docs/OPTION_AUDIT_CONSOLIDATED.md
+++ b/docs/OPTION_AUDIT_CONSOLIDATED.md
@@ -1,0 +1,371 @@
+# Option audit — consolidated result (#3505 roll-up)
+
+Final roll-up of the
+[#3505](https://github.com/stSoftwareAU/NEAT-AI/issues/3505) option-removal
+audit (Issue #3525). It merges the six slice classification tables into one,
+reconciles them against the #3518 key inventory, resolves the cross-slice
+overlaps, and sequences the removal issues.
+
+Per-key evidence stays in the slice write-ups — this document does not restate
+it:
+
+| Slice | Scope                                                                  | Write-up                                             | Issue |
+| ----- | ---------------------------------------------------------------------- | ---------------------------------------------------- | ----- |
+| A     | Core evolution & training top-level options                            | [`OPTION_AUDIT_SLICE_A.md`](OPTION_AUDIT_SLICE_A.md) | #3519 |
+| B     | `discovery*` top-level options                                         | [`OPTION_AUDIT_SLICE_B.md`](OPTION_AUDIT_SLICE_B.md) | #3520 |
+| C     | Population & selection nested configs                                  | [`OPTION_AUDIT_SLICE_C.md`](OPTION_AUDIT_SLICE_C.md) | #3521 |
+| D     | Training, regularisation & data-shaping nested configs                 | [`OPTION_AUDIT_SLICE_D.md`](OPTION_AUDIT_SLICE_D.md) | #3522 |
+| E     | Runtime & infrastructure configs and injection points                  | [`OPTION_AUDIT_SLICE_E.md`](OPTION_AUDIT_SLICE_E.md) | #3523 |
+| F     | Experimental configs (MCMC, hyperparameter evolution, OPD, specialist) | [`OPTION_AUDIT_SLICE_F.md`](OPTION_AUDIT_SLICE_F.md) | #3524 |
+
+## Headline
+
+**289 classifications, zero unclassified keys, 15 issues, zero duplicates.** Of
+the 289 rows, **68 are `IN USE`**, **121 are `KEEP (load-bearing default)`** and
+**100 `QUALIFY`** — but that last number is dominated by the nested fields of
+four experimental configs and badly overstates the removable surface.
+
+Counted by _option_ rather than by row, **20 of 120 qualify**, and only 10 of
+those are proposed for outright removal:
+
+| Outcome                                  | Options | Issues                                                        |
+| ---------------------------------------- | ------: | ------------------------------------------------------------- |
+| Removal proposed                         |      10 | #3552, #3553, #3554, #3556, #3558, #3562, #3566, #3568, #3569 |
+| **Decision** recommending KEEP           |       7 | #3559, #3560, #3563, #3565, #3570                             |
+| Already decided `NOT_PLANNED` by a human |       3 | #1943 (commented, not re-filed)                               |
+
+That is the audit's real result, and it is close to the "few options qualify"
+outcome the brief called a legitimate finding. `KEEP` outnumbers `IN USE` almost
+two to one: the **defaults**, not the consumers, drive most of NEAT-AI's
+behaviour, which is exactly why "no consumer sets it" was never sufficient
+grounds for removal.
+
+```mermaid
+flowchart LR
+    H["#3518 harness<br/>enumerateOptionKeys()"] --> INV["289 rows<br/>119 top-level + 170 nested"]
+    A["Slices A–F<br/>#3519–#3524"] --> TAB["Merged table<br/>optionAuditRollup.ts"]
+    INV --> REC{"reconcile()"}
+    TAB --> REC
+    REC -->|"gap"| GAP["❌ exit 1<br/>file a follow-up"]
+    REC -->|"zero gaps"| OK["✅ #3505 closed out"]
+```
+
+## Coverage check — mechanical, not by eye
+
+The brief required the coverage check to be a diff against the harness, not a
+reading of the six slice comments. It is
+[`scripts/option-audit-rollup.ts`](../scripts/option-audit-rollup.ts), backed by
+the merged table in
+[`scripts/lib/optionAuditRollup.ts`](../scripts/lib/optionAuditRollup.ts) and
+run on every CI build by
+[`test/scripts/OptionAuditRollup.ts`](../test/scripts/OptionAuditRollup.ts):
+
+```bash
+deno run --allow-read scripts/option-audit-rollup.ts
+# 🔎 289 enumerated rows (119 top-level, 170 nested) · 289 classified
+# ✅ zero coverage gaps — every option key is classified
+```
+
+A key the harness enumerates but the table does not classify exits **1** and
+names the gap. It cannot be mistaken for a clean audit, and the roll-up may not
+close #3505 while one exists.
+
+### The one gap it found: `mutation`
+
+`NeatArguments` has **119** top-level fields, not the 118 quoted in #3518 and
+#3525. The original figure came from a grep that skipped
+`readonly mutation: readonly MutationInterface[]`; the parser-backed harness
+sees the real 119, and its CI test pins that number. Every slice brief was
+written from the 118-key list, so **no slice classified `mutation`**.
+
+This roll-up classified it with the slice method — `git grep`, exit code
+checked, both controls run first (`populationSize` 390 hits, `dnaSharingMode`
+0):
+
+**`mutation` is `IN USE`.** GRQ sets it in four `NeatOptions` literals —
+`src/exchange/EvolveApp.ts:418`, `src/fx/EvolveApp.ts:365`,
+`src/industry/EvolveApp.ts:415` and `src/location/EvolveApp.ts:471` — from its
+`--mutation=ALL|FFW` operator flag. No removal issue is needed and no follow-up
+is filed, because the gap closed as a live option rather than a missed
+candidate.
+
+### `fitnessSampleRate` and `seed`
+
+`fitnessSampleRate` is the audit's one legitimate exclusion — removed by #3502
+before the audit began, and absent from the current source, so the harness does
+not enumerate it.
+
+`seed` is a second, previously unrecorded exclusion. Slice E flagged it as
+missing from slice A's table, but it is **not a `NeatArguments` field at all**:
+it is input-only on `NeatOptions`, resolved at `NeatConfig.ts:208-217` into
+`rng`, which _is_ enumerated and classified `KEEP`. Slice E verified `seed` as
+`KEEP` on its own evidence, so the pair is settled either way.
+
+### Reconciling the counts with the slice comments
+
+The roll-up counts one classification per row the harness enumerates. The slices
+counted "parent keys + fields" under slightly different conventions, so the
+per-slice totals shift:
+
+| Slice     | Slice comment | Roll-up | Why                                                                                                                                               |
+| --------- | ------------: | ------: | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| A         |            46 |      46 | —                                                                                                                                                 |
+| B         |            36 |      43 | B classified its 3 nested configs at parent level; the harness enumerates `DiscoveryCacheConfig` (4) + `DiskSpaceConfig` (3) fields individually. |
+| C         |            59 |      56 | `adaptiveMutationThresholds` is declared inline in `NeatArguments`, so its 3 fields are not separate nested rows.                                 |
+| D         |            69 |      63 | Same for `plateauDetection`'s 6 inline fields.                                                                                                    |
+| E         |            33 |      37 | `RustScorerConfig` has no `NeatOptions` key (−1 parent row) but two interfaces, so `RequiredRustScorerConfig`'s 5 fields are enumerated too (+5). |
+| F         |            43 |      43 | —                                                                                                                                                 |
+| roll-up   |             — |       1 | `mutation`.                                                                                                                                       |
+| **Total** |       **286** | **289** |                                                                                                                                                   |
+
+No slice lost a key in the merge; the deltas are all enumeration conventions.
+
+## Merged classification table
+
+One row per option key, plus a row for every nested field whose verdict differs
+from its parent's. Nested fields not listed inherit their parent's verdict — a
+field can only reach `NeatOptions` through its parent object, so it cannot be
+set independently. Generated by
+`deno run --allow-read scripts/option-audit-rollup.ts`.
+
+| Verdict     | Classifications |
+| ----------- | --------------: |
+| `QUALIFIES` |             100 |
+| `KEEP`      |             121 |
+| `IN USE`    |              68 |
+| **Total**   |         **289** |
+
+| Key                                           | Slice   | Verdict     | Issue | Note                                                                                      |
+| --------------------------------------------- | ------- | ----------- | ----- | ----------------------------------------------------------------------------------------- |
+| `costName`                                    | A       | `IN USE`    | —     |                                                                                           |
+| `creativeThinkingConnectionCount`             | A       | `IN USE`    | —     |                                                                                           |
+| `creatureStore`                               | E       | `IN USE`    | —     |                                                                                           |
+| `dataSetPartitionBreak`                       | A       | `KEEP`      | —     |                                                                                           |
+| `debug`                                       | A       | `KEEP`      | —     |                                                                                           |
+| `experimentStore`                             | E       | `IN USE`    | —     |                                                                                           |
+| `creatures`                                   | A       | `IN USE`    | —     |                                                                                           |
+| `CRISPRs`                                     | A       | `IN USE`    | —     |                                                                                           |
+| `maxCRISPRsPerGeneration`                     | A       | `KEEP`      | —     |                                                                                           |
+| `customCost`                                  | A       | `IN USE`    | —     |                                                                                           |
+| `feedbackLoop`                                | A       | `IN USE`    | —     |                                                                                           |
+| `focusList`                                   | A       | `IN USE`    | —     |                                                                                           |
+| `focusRate`                                   | A       | `IN USE`    | —     |                                                                                           |
+| `costOfGrowth`                                | A       | `IN USE`    | —     |                                                                                           |
+| `elitism`                                     | A       | `IN USE`    | —     |                                                                                           |
+| `maxDedupRetries`                             | A       | `KEEP`      | —     |                                                                                           |
+| `timeoutMinutes`                              | A       | `IN USE`    | —     |                                                                                           |
+| `trainPerGen`                                 | A       | `IN USE`    | —     |                                                                                           |
+| `trainingTaskTimeoutMinutes`                  | A       | `KEEP`      | —     |                                                                                           |
+| `maxConns`                                    | A       | `QUALIFIES` | #3552 |                                                                                           |
+| `maximumNumberOfNodes`                        | A       | `QUALIFIES` | #3552 |                                                                                           |
+| `mutationAmount`                              | A       | `IN USE`    | —     |                                                                                           |
+| `mutationRate`                                | A       | `IN USE`    | —     |                                                                                           |
+| `populationSize`                              | A       | `IN USE`    | —     |                                                                                           |
+| `threads`                                     | A       | `IN USE`    | —     |                                                                                           |
+| `heavyTaskWorkerCount`                        | A       | `IN USE`    | —     |                                                                                           |
+| `selection`                                   | A       | `IN USE`    | —     |                                                                                           |
+| `mutation`                                    | roll-up | `IN USE`    | —     | Gap found by this roll-up. GRQ `src/{exchange,fx,industry,location}/EvolveApp.ts` set it. |
+| `iterations`                                  | A       | `IN USE`    | —     |                                                                                           |
+| `verbose`                                     | A       | `IN USE`    | —     |                                                                                           |
+| `enableRepetitiveTraining`                    | A       | `QUALIFIES` | #3553 |                                                                                           |
+| `skipTrainingAfterConsecutiveRegressions`     | A       | `KEEP`      | —     |                                                                                           |
+| `subnetworkIndexSize`                         | A       | `KEEP`      | —     |                                                                                           |
+| `trainingBatchSize`                           | A       | `KEEP`      | —     |                                                                                           |
+| `log`                                         | A       | `IN USE`    | —     |                                                                                           |
+| `traceStore`                                  | E       | `IN USE`    | —     |                                                                                           |
+| `disableRandomSamples`                        | A       | `KEEP`      | —     |                                                                                           |
+| `trainingSampleRate`                          | A       | `IN USE`    | —     |                                                                                           |
+| `targetError`                                 | A       | `IN USE`    | —     |                                                                                           |
+| `maximumBiasAdjustmentScale`                  | A       | `KEEP`      | —     |                                                                                           |
+| `maximumWeightAdjustmentScale`                | A       | `KEEP`      | —     |                                                                                           |
+| `sparseRatio`                                 | A       | `IN USE`    | —     |                                                                                           |
+| `globalBreedingRate`                          | A       | `KEEP`      | —     |                                                                                           |
+| `diversityBreedingRate`                       | A       | `KEEP`      | —     |                                                                                           |
+| `geneticCompatibilityThreshold`               | A       | `KEEP`      | —     |                                                                                           |
+| `interSpeciesCrossoverThreshold`              | A       | `KEEP`      | —     |                                                                                           |
+| `syntheticAlignmentThreshold`                 | A       | `KEEP`      | —     |                                                                                           |
+| `discoverySampleRate`                         | B       | `IN USE`    | —     |                                                                                           |
+| `discoveryRecordTimeOutMinutes`               | B       | `IN USE`    | —     |                                                                                           |
+| `discoveryMinRecordCoverage`                  | B       | `KEEP`      | —     |                                                                                           |
+| `discoveryAnalysisTimeoutMinutes`             | B       | `IN USE`    | —     |                                                                                           |
+| `discoveryHardDeadlineTS`                     | B       | `KEEP`      | —     |                                                                                           |
+| `discoveryBatchSize`                          | B       | `IN USE`    | —     |                                                                                           |
+| `discoveryBufferSize`                         | B       | `IN USE`    | —     |                                                                                           |
+| `discoveryRustFlushRecords`                   | B       | `IN USE`    | —     |                                                                                           |
+| `discoveryRustFlushBytes`                     | B       | `KEEP`      | —     |                                                                                           |
+| `discoveryMaxNeurons`                         | B       | `IN USE`    | —     |                                                                                           |
+| `discoveryAnalysisChunkSize`                  | B       | `KEEP`      | —     |                                                                                           |
+| `discoveryAnalysisPerChunkMaxMs`              | B       | `KEEP`      | —     |                                                                                           |
+| `discoveryDrainEveryNBatches`                 | B       | `IN USE`    | —     |                                                                                           |
+| `discoveryFocusNeuronUUIDs`                   | B       | `IN USE`    | —     |                                                                                           |
+| `discoveryDisableEvaluationSummaryLogging`    | B       | `IN USE`    | —     |                                                                                           |
+| `checkpointEveryGeneration`                   | B       | `IN USE`    | —     |                                                                                           |
+| `discoveryDisableCleanup`                     | B       | `IN USE`    | —     |                                                                                           |
+| `discoveryBaseDirectory`                      | B       | `IN USE`    | —     |                                                                                           |
+| `discoverySkipRecordPhase`                    | B       | `IN USE`    | —     |                                                                                           |
+| `discoveryCacheDir`                           | B       | `IN USE`    | —     |                                                                                           |
+| `discoveryFailureCacheDir`                    | B       | `IN USE`    | —     |                                                                                           |
+| `discoverySuccessCacheDir`                    | B       | `IN USE`    | —     |                                                                                           |
+| `discoveryFailureCacheBypassOnDrought`        | B       | `KEEP`      | —     |                                                                                           |
+| `discoveryReplayMaxSingles`                   | B       | `KEEP`      | —     |                                                                                           |
+| `discoveryReplayMaxPairwise`                  | B       | `KEEP`      | —     |                                                                                           |
+| `discoveryReplayMaxTriples`                   | B       | `KEEP`      | —     |                                                                                           |
+| `discoveryReplayVerifyScores`                 | B       | `IN USE`    | —     |                                                                                           |
+| `discoveryReplayConcurrency`                  | B       | `KEEP`      | —     |                                                                                           |
+| `discoveryReplayRescoreBaseline`              | B       | `IN USE`    | —     |                                                                                           |
+| `discoveryReplayDiagnostics`                  | B       | `QUALIFIES` | #3556 |                                                                                           |
+| `discoveryReplayTimeoutMinutes`               | B       | `KEEP`      | —     |                                                                                           |
+| `discoveryReplayMinTimeMinutes`               | B       | `KEEP`      | —     |                                                                                           |
+| `discoveryMinCandidatesPerCategory`           | B       | `KEEP`      | —     |                                                                                           |
+| `adaptiveMutationThresholds`                  | C       | `KEEP`      | —     |                                                                                           |
+| `plateauDetection`                            | D       | `KEEP`      | —     | Borderline: flag defaults false, but three exported presets turn it on.                   |
+| `stabilityAdaptation`                         | D       | `QUALIFIES` | #3562 | No implementation exists — parsed, never read.                                            |
+| `weightRegularisation`                        | D       | `KEEP`      | —     |                                                                                           |
+| `biasRegularisation`                          | D       | `KEEP`      | —     |                                                                                           |
+| `ensembleDiversity`                           | C       | `QUALIFIES` | #3558 | No implementation exists — parsed, never read.                                            |
+| `quantumStep`                                 | D       | `KEEP`      | —     |                                                                                           |
+| `fineTunePopulation`                          | C       | `KEEP`      | —     |                                                                                           |
+| `predictiveCoding`                            | D       | `IN USE`    | —     | GRQ sets only `.enabled`; the other four defaults then drive inference.                   |
+| `wasmCache`                                   | E       | `KEEP`      | —     | GRQ's 50 `wasmCache` hits are its own unrelated cap — a false IN USE.                     |
+| `discoveryCache`                              | B       | `KEEP`      | —     |                                                                                           |
+| `discoveryDiskSpace`                          | B       | `KEEP`      | —     |                                                                                           |
+| `memory`                                      | E       | `IN USE`    | —     | GRQ sets `enabled` + `nativeBudgetBytes`; seven defaults are live.                        |
+| `workerThreadCap`                             | E       | `IN USE`    | —     | Env-only (DISCOVERY_*_MB) — zero camelCase hits, still load-bearing.                      |
+| `logger`                                      | E       | `KEEP`      | —     | Kept on the resolution path, not the injection.                                           |
+| `rng`                                         | E       | `KEEP`      | —     | Checked as a pair with input-only `seed`; both stay.                                      |
+| `outputRanges`                                | D       | `IN USE`    | —     |                                                                                           |
+| `onTrainingEvent`                             | E       | `IN USE`    | —     |                                                                                           |
+| `hyperparameterEvolution`                     | F       | `QUALIFIES` | #3569 |                                                                                           |
+| `adaptivePopulation`                          | C       | `KEEP`      | —     | Borderline: flag defaults false, but FAST_CONVERGENCE_PRESET turns it on.                 |
+| `crossValidation`                             | D       | `QUALIFIES` | #1943 | Commented on the existing #1943 rather than filing a duplicate.                           |
+| `dataFuzzing`                                 | D       | `QUALIFIES` | #1943 | Commented on the existing #1943 rather than filing a duplicate.                           |
+| `dataQuantisation`                            | D       | `QUALIFIES` | #1943 | Commented on the existing #1943 rather than filing a duplicate.                           |
+| `maxConcurrentDiscoveries`                    | B       | `KEEP`      | —     |                                                                                           |
+| `allowPoolBorrowing`                          | A       | `KEEP`      | —     |                                                                                           |
+| `mcmc`                                        | F       | `QUALIFIES` | #3570 | Decision — GRQ's evolution-mode sweep declares intent but never wires it.                 |
+| `opd`                                         | F       | `QUALIFIES` | #3570 | Decision — filed jointly with `mcmc`.                                                     |
+| `specialist`                                  | F       | `QUALIFIES` | #3568 | Option surface is unreadable at any value.                                                |
+| `parallelEvaluation`                          | E       | `KEEP`      | —     |                                                                                           |
+| `squashEffectiveness`                         | D       | `KEEP`      | —     |                                                                                           |
+| `squashBudget`                                | D       | `QUALIFIES` | #3563 | Decision, audit recommends KEEP — live lever, adoption is a GRQ task.                     |
+| `fitnessSharing`                              | C       | `KEEP`      | —     |                                                                                           |
+| `novelty`                                     | C       | `QUALIFIES` | #3559 | Decision, audit recommends KEEP — implemented and documented.                             |
+| `randomImmigrants`                            | C       | `QUALIFIES` | #3560 | Decision, audit recommends KEEP — implemented and documented.                             |
+| `speciesStagnation`                           | C       | `KEEP`      | —     |                                                                                           |
+| `compatibilityGating`                         | C       | `KEEP`      | —     |                                                                                           |
+| `selectionPressure`                           | C       | `KEEP`      | —     |                                                                                           |
+| `tolerateCorruptParents`                      | A       | `KEEP`      | —     |                                                                                           |
+| `dnaSharingMode`                              | A       | `QUALIFIES` | #3554 | Slice F confirmed `DnaSharingPreset.ts` is covered here and filed nothing.                |
+| `memory.enabled`                              | E       | `IN USE`    | —     |                                                                                           |
+| `memory.proactiveGc`                          | E       | `QUALIFIES` | #3565 |                                                                                           |
+| `memory.nativeBudgetBytes`                    | E       | `IN USE`    | —     |                                                                                           |
+| `memory.maxAnalysisMemoryMb`                  | E       | `QUALIFIES` | #3565 |                                                                                           |
+| `parallelEvaluation.maxConcurrentEvaluations` | E       | `QUALIFIES` | #3566 |                                                                                           |
+| `predictiveCoding.enabled`                    | D       | `IN USE`    | —     |                                                                                           |
+| `RustScorerConfig.env`                        | E       | `KEEP`      | —     |                                                                                           |
+| `RustScorerConfig`                            | E       | `IN USE`    | —     | No NeatOptions key — resolved from NEAT_AI_RUST_SCORER_* env.                             |
+
+## Deduplication
+
+### Across slices
+
+Three option keys span a slice boundary and could have drawn two removal issues
+each. None did — every one resolves to a single issue, verified by
+`gh issue list --search "<key> in:title" --state all` per key and by the
+`no option key is claimed by two removal issues` test.
+
+| Overlap                                 | Slices | Resolution                                                                                                            |
+| --------------------------------------- | ------ | --------------------------------------------------------------------------------------------------------------------- |
+| `dnaSharingMode` / `DnaSharingPreset`   | A ↔ F  | Slice A filed **#3554**; slice F recorded the overlap and filed nothing. One issue.                                   |
+| `seed` / `rng`                          | A ↔ E  | Neither qualifies, so no issue exists to duplicate. `rng` is `KEEP` (slice E); `seed` is not a `NeatArguments` field. |
+| `discoveryCache` / `discoveryDiskSpace` | B ↔ E  | Both are `KEEP` on slice B's evidence; slice E did not reclassify them. No issue exists.                              |
+
+Two further cross-slice mentions were checked and are not duplicates:
+`stabilityAdaptation` and `squashBudget` appear in slice E's and F's prose only
+as "unrelated slice-D findings", and `ensembleDiversity` appears in slice D's
+prose only as the precedent for #3562.
+
+### Against the adjacent campaigns
+
+Both campaigns were re-checked at roll-up time, after the slices ran:
+
+- **#3446–#3449 (deprecated-api)** — all four still **open**, and all four
+  concern `HYPOT` / `HYPOTv2` / `MEAN` activations and `focusNeuronErrorShares`.
+  None of those is an option key in the harness inventory, so no overlap exists.
+- **#3509–#3512 (dead-code sweep)** — all four now **closed**. Orphan barrels,
+  superseded modules, redundant exports and two unused WASM constants; no option
+  key among them. #3511's redundant-export list names `ImmigrantInjectionResult`
+  but deliberately excludes it, and that is the `export` keyword rather than the
+  `randomImmigrants` option — recorded on #3560, not treated as absorbing.
+- **#1942 / #1943** — both closed `NOT_PLANNED`. #1943's premise is unchanged,
+  so slice D **commented there** instead of filing a duplicate. #1942's premise
+  has gone stale (its `adaptivePopulation` claim is false today), so #3558 and
+  #3562 supersede its still-valid thirds and cross-reference it.
+
+All 14 new issues are open and unique: no option key maps to two of them.
+
+## Removal ordering
+
+Every removal deletes from `src/config/NeatConfig.ts`, `NeatArguments.ts` and
+`NeatOptions.ts`, so **all 14 conflict there by construction**. That is a
+trivial rebase. The orderings below are the ones where two PRs would edit the
+same non-config code or the same documentation block, and those should be
+sequenced rather than merged in parallel.
+
+```mermaid
+flowchart TD
+    subgraph P["src/presets/Presets.ts + docs/troubleshooting/TRAINING.md"]
+        direction LR
+        I3558["#3558 ensembleDiversity"] --> I3562["#3562 stabilityAdaptation"]
+    end
+    subgraph M["src/NEAT/Mutator.ts + src/breed/Breed.ts + ParallelBreeding.ts"]
+        direction LR
+        I3552["#3552 maxConns"] --> I3559["#3559 novelty"] --> I3569["#3569 hyperparamEvolution"] --> I3570["#3570 mcmc + opd"]
+    end
+    subgraph N["src/NEAT/Neat.ts + NeatEvolution.ts + NeatConfigValidation.ts"]
+        direction LR
+        I3559b["#3559 novelty"] --> I3560["#3560 randomImmigrants"] --> I3570b["#3570 mcmc + opd"]
+    end
+    subgraph R["src/config/parsers/RuntimeParsers.ts"]
+        direction LR
+        I3565["#3565 memory brakes"] --> I3566["#3566 maxConcurrentEvaluations"]
+    end
+```
+
+| Order | Chain                             | Shared path                                                                                                         | Why                                                                                                                                                                                                |
+| ----- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1     | #3558 → #3562                     | `src/presets/Presets.ts`, `docs/troubleshooting/TRAINING.md`, `docs/config/RECIPES.md`, `docs/api/CONFIGURATION.md` | Both delete a `LARGE_NETWORK_PRESET` entry and adjacent rows in the same three docs. Land #3558 first — it is the unambiguous one.                                                                 |
+| 2     | #3552 → #3559 → #3569 → #3570     | `src/NEAT/Mutator.ts`, `src/breed/Breed.ts`, `src/breed/ParallelBreeding.ts`                                        | #3552 edits `Mutator.ts` growth caps; #3569 and #3570 delete gated blocks from the same files; #3559 touches `Breed.ts`.                                                                           |
+| 3     | #3559 → #3560 → #3570             | `src/NEAT/Neat.ts`, `src/NEAT/NeatEvolution.ts`, `src/config/NeatConfigValidation.ts`                               | Three per-generation hook removals in the same functions.                                                                                                                                          |
+| 4     | #3565 → #3566                     | `src/config/parsers/RuntimeParsers.ts`                                                                              | Both delete parser entries from the same runtime-parser block.                                                                                                                                     |
+| —     | #3553, #3554, #3556, #3563, #3568 | own module only                                                                                                     | Independent — `NeatScheduling.ts`, `transfer/KnobTuningStrategy.ts`, `discovery/DiscoveryReplayRunner.ts`, config-only, and `NEAT/Specialist*`/`Genus`/`Species` respectively. Merge in any order. |
+
+Chains 2 and 3 share #3559 and #3570, so in practice they collapse into one
+sequence: **#3552 → #3559 → #3560 → #3569 → #3570**.
+
+**Decisions gate their own removals.** #3559, #3560, #3563, #3565 and #3570 ask
+for a keep-or-remove call before any code is deleted. If a decision lands as
+KEEP, its position in the chain simply drops out.
+
+## Definition of done
+
+- [x] Single consolidated table covering every option key — 289 rows above.
+- [x] Zero unclassified keys — one gap found (`mutation`), classified `IN USE`
+      in this roll-up rather than left to disappear. No follow-up needed.
+- [x] Cross-slice and cross-campaign duplicates closed — none existed; one issue
+      per key, verified mechanically.
+- [x] Removal issues sequenced.
+
+## If a removal PR breaks a consumer
+
+This document stays the audit trail after #3505 closes. A consolidation error
+that mislabelled a load-bearing option as `QUALIFIES` surfaces when the removal
+PR lands and GRQ or NEAT-AI-Examples fails its own `deno check` / test workflow.
+Report any such breakage on #3505, note it here, and reclassify the key in
+`scripts/lib/optionAuditRollup.ts` so the record matches reality.
+
+The two verdicts most exposed to that risk are the ones the slices called
+borderline: `adaptivePopulation` (slice C) and `plateauDetection` (slice D) are
+`KEEP` with flags that default `false`, kept because exported presets turn them
+on. Both were called conservatively — a false `KEEP` costs only under-delivery,
+whereas a false `QUALIFIES` proposes deleting live code.

--- a/docs/README.md
+++ b/docs/README.md
@@ -142,6 +142,15 @@ Drop-in API and configuration material.
   `RustScorerConfig`, and the 6 injection points, and why two of them are
   load-bearing in production despite zero camelCase hits in either consumer —
   they are set entirely from environment variables.
+- **[OPTION_AUDIT_SLICE_F.md](OPTION_AUDIT_SLICE_F.md)** — slice F of the #3505
+  audit: the 4 experimental research configs (`mcmc`, `hyperparameterEvolution`,
+  `opd`, `specialist`) and all 39 of their fields, every one `QUALIFIES`, plus
+  the GRQ evolution-mode sweep that advertises three of them without wiring any.
+- **[OPTION_AUDIT_CONSOLIDATED.md](OPTION_AUDIT_CONSOLIDATED.md)** — the #3505
+  roll-up: the six slice tables merged into one, the mechanical coverage check
+  that diffs them against the harness inventory, the one gap it found
+  (`mutation`), the cross-slice and cross-campaign deduplication, and the order
+  the removal issues must land in.
 - **[TIMEOUTS.md](TIMEOUTS.md)** — `timeoutMinutes` semantics and the absolute
   **T+15** hard cap: the two deadlines, what each phase does at the cap (abandon
   in-flight work, keep partial results, return the best creature), how the

--- a/docs/archive/pr-summaries/pr-summary-3524.md
+++ b/docs/archive/pr-summaries/pr-summary-3524.md
@@ -41,8 +41,9 @@ That does not make the keys `IN USE` — a flag parsed and dropped is not a
 consumer setting an option — but it is the only adoption signal anywhere, so
 `mcmc` + `opd` are filed as a **decision** issue (**#3570**, the #3563 pattern)
 rather than a deletion. `hyperparameterEvolution` has no such signal and is
-filed as a straight **removal** (**#3569**). The GRQ-side half-wiring is a
-separate root cause in a separate repo: **stSoftwareAU/GRQ#3793**.
+filed as a straight **removal** (**#3569**). The consumer-side half-wiring is a
+separate root cause and is filed in the downstream production repo's own
+tracker.
 
 **3. A default-on flag nested inside a default-off feature.**
 `mcmc.diversityAwareMCMC.enabled` defaults to `true`. Read on its own that looks
@@ -110,18 +111,18 @@ flowchart TD
     H --> D2["#3569 removal<br/>no adopter, declared or otherwise"]
     S --> D3["#3568 removal<br/>no read site at any value"]
 
-    D1 -.-> GRQ["stSoftwareAU/GRQ#3793<br/>wire the sweep bits or drop them"]
+    D1 -.-> GRQ["downstream production repo<br/>wire the sweep bits or drop them"]
 ```
 
 ### Issues filed
 
-| Feature                   | Issue                 | Shape                                               |
-| ------------------------- | --------------------- | --------------------------------------------------- |
-| `specialist`              | #3568                 | Removal — option surface unreadable at any value    |
-| `hyperparameterEvolution` | #3569                 | Removal — feature complete, flag never turned on    |
-| `mcmc` + `opd`            | #3570                 | Decision — inert today, GRQ's sweep declares intent |
-| GRQ sweep half-wiring     | stSoftwareAU/GRQ#3793 | Wire bits G/O/S onto `NeatOptions` or drop them     |
-| `dnaSharingMode`          | #3554 (slice A)       | Not re-filed — slice A owns it                      |
+| Feature                   | Issue           | Shape                                               |
+| ------------------------- | --------------- | --------------------------------------------------- |
+| `specialist`              | #3568           | Removal — option surface unreadable at any value    |
+| `hyperparameterEvolution` | #3569           | Removal — feature complete, flag never turned on    |
+| `mcmc` + `opd`            | #3570           | Decision — inert today, GRQ's sweep declares intent |
+| GRQ sweep half-wiring     | downstream repo | Wire bits G/O/S onto `NeatOptions` or drop them     |
+| `dnaSharingMode`          | #3554 (slice A) | Not re-filed — slice A owns it                      |
 
 Classification table posted on #3505:
 [comment](https://github.com/stSoftwareAU/NEAT-AI/issues/3505#issuecomment-5129320935).

--- a/docs/archive/pr-summaries/pr-summary-3525.md
+++ b/docs/archive/pr-summaries/pr-summary-3525.md
@@ -1,0 +1,140 @@
+# PR summary — #3505 option-audit roll-up
+
+## Summary
+
+Final roll-up of the #3505 option-removal audit: merges the six slice
+classification tables (#3519–#3524) into one, reconciles them **mechanically**
+against the #3518 harness inventory, deduplicates the removal issues, and
+sequences them. Closes #3525.
+
+The audit's own failure-detection brief demanded the coverage check be a diff
+against the harness rather than a reading of six issue comments, so the merged
+table is committed as **data** (`scripts/lib/optionAuditRollup.ts`) and the diff
+runs in CI on every build. A key the harness enumerates but the table does not
+classify is a gap: the CLI exits **1** and names it, and the test fails. An
+unclassified option can never read as a clean audit.
+
+**Result: 289 classifications, zero unclassified keys, 15 issues, zero
+duplicates.**
+
+| Verdict                       | Classifications |
+| ----------------------------- | --------------: |
+| `IN USE`                      |              68 |
+| `KEEP (load-bearing default)` |             121 |
+| `QUALIFIES`                   |             100 |
+| **Total**                     |         **289** |
+
+Counted by _option_ rather than by row, 20 of 120 qualify — 10 proposed for
+removal, 7 filed as decisions recommending KEEP, 3 already decided `NOT_PLANNED`
+by a human on #1943. `KEEP` outnumbers `IN USE` almost two to one: the defaults,
+not the consumers, drive most of NEAT-AI's behaviour.
+
+### The gap it found: `mutation`
+
+`NeatArguments` has **119** top-level fields, not the 118 quoted in #3518 and
+#3525. The original figure came from a grep that skipped
+`readonly mutation: readonly MutationInterface[]` — the harness's own pinned
+test already records the real 119. Every slice brief was written from the
+118-key list, so **no slice classified `mutation`**.
+
+Re-probed here with the slice method (`git grep`, exit code checked, both
+controls run first): `mutation` is **`IN USE`** — GRQ sets it in four
+`NeatOptions` literals from its `--mutation=ALL|FFW` operator flag. The gap
+closed as a live option rather than a missed removal candidate, so no follow-up
+issue was needed.
+
+`seed` is recorded as a second, previously unnoticed exclusion: slice E flagged
+it as absent from slice A's table, but it is not a `NeatArguments` field at all
+— it is input-only on `NeatOptions` and resolves into `rng`, which _is_
+enumerated and classified `KEEP`.
+
+### Unrelated CI fix
+
+`docs/archive/pr-summaries/pr-summary-3524.md` (merged with slice F) carried a
+private-repo issue slug and was failing
+`test/docs/ArchiveDocsNoPrivateRepoSlugs.ts` on the milestone branch. Reworded
+to concept level as that gate's own message instructs. Without this the branch
+cannot go green.
+
+## Evidence
+
+No web interface to screenshot — this is a scripts/docs change. The evidence is
+the reconciliation run itself, which is reproducible:
+
+```
+$ deno run --allow-read scripts/option-audit-rollup.ts
+🔎 289 enumerated rows (119 top-level, 170 nested) · 289 classified
+✅ zero coverage gaps — every option key is classified
+```
+
+```mermaid
+flowchart LR
+    H["#3518 harness<br/>enumerateOptionKeys()"] --> INV["289 rows<br/>119 top-level + 170 nested"]
+    A["Slices A–F<br/>#3519–#3524"] --> TAB["Merged table<br/>optionAuditRollup.ts"]
+    INV --> REC{"reconcile()"}
+    TAB --> REC
+    REC -->|"gap"| GAP["❌ exit 1<br/>file a follow-up"]
+    REC -->|"zero gaps"| OK["✅ #3505 closed out"]
+```
+
+Deduplication was run per key rather than asserted —
+`gh issue list --search
+"<key>" --state all` across the three named overlap
+pairs (`dnaSharingMode`/`DnaSharingPreset`, `seed`/`rng`,
+`discoveryCache`/`discoveryDiskSpace`) and against #3446–#3449 / #3509–#3512.
+Every option key maps to exactly one issue; #3509–#3512 have all closed since
+the slices ran and touch no option key.
+
+The consolidated result is posted on
+[#3505](https://github.com/stSoftwareAU/NEAT-AI/issues/3505#issuecomment-5129844109),
+which stays the audit trail after closure. Full write-up:
+[`docs/OPTION_AUDIT_CONSOLIDATED.md`](../../OPTION_AUDIT_CONSOLIDATED.md).
+
+### Removal ordering
+
+All 14 removals edit `NeatConfig.ts` / `NeatArguments.ts` / `NeatOptions.ts`, so
+they conflict there by construction — a trivial rebase. The chains that touch
+the same non-config code or doc block, and so must be sequenced:
+
+| Order | Chain                         | Shared path                                                                               |
+| ----- | ----------------------------- | ----------------------------------------------------------------------------------------- |
+| 1     | #3558 → #3562                 | `src/presets/Presets.ts` (both delete a `LARGE_NETWORK_PRESET` entry) + three shared docs |
+| 2     | #3552 → #3559 → #3569 → #3570 | `src/NEAT/Mutator.ts`, `src/breed/Breed.ts`, `ParallelBreeding.ts`                        |
+| 3     | #3559 → #3560 → #3570         | `src/NEAT/Neat.ts`, `NeatEvolution.ts`, `NeatConfigValidation.ts`                         |
+| 4     | #3565 → #3566                 | `src/config/parsers/RuntimeParsers.ts`                                                    |
+
+## Test Plan
+
+New: `test/scripts/OptionAuditRollup.ts` — 10 tests calling the real
+`enumerateOptionKeys()` and `reconcile()` against the live source tree, not
+greps over markdown:
+
+- `reconcile - every enumerated option key is classified` — the gate. Fails with
+  the offending key names if a config change outruns the roll-up.
+- `reconcile - classifies the whole enumerated surface` /
+  `top-level coverage
+  matches NeatArguments exactly` — asserts all 289 rows
+  resolve, and pins the `mutation` gap key so the 118-vs-119 fault cannot
+  silently return.
+- `reconcile - no roll-up entry describes a key that no longer exists` — catches
+  drift in the other direction, when a key is deleted from source.
+- `rollup - every QUALIFIES verdict carries a removal issue` — no orphan removal
+  candidate.
+- `rollup - no option key is claimed by two removal issues` and
+  `the named
+  cross-slice overlaps resolve to one issue each` — the duplicate
+  tripwire.
+- `toConsolidatedMarkdown - reports a gap loudly when one exists` — injects a
+  synthetic unclassified key and asserts it is reported rather than dropped,
+  which is the fail-loud behaviour the whole roll-up rests on.
+
+`./quality.sh --skip-discovery --skip-wasm < /dev/null` passes: **8088 passed (5
+steps) | 0 failed | 4 ignored (8m33s)**, with `deno fmt`, `deno lint`, the
+bash-syntax gate and `deno check` clean.
+
+### Security self-check
+
+Scripts are read-only over the repo's own `src/config/` (`--allow-read`;
+`--allow-write` only for the optional `--out` path). No network, no subprocess,
+no external input, no secrets staged. Markdown cells escape `|` so a key name
+cannot break out of the rendered table.

--- a/scripts/lib/optionAuditReconcile.ts
+++ b/scripts/lib/optionAuditReconcile.ts
@@ -1,0 +1,181 @@
+/**
+ * Mechanical coverage check for the #3505 roll-up (Issue #3525).
+ *
+ * Diffs the #3518 harness key inventory against the merged classification
+ * table in `optionAuditRollup.ts`. A key the harness enumerates but the table
+ * does not classify is a **gap**, and a gap is reported loudly rather than
+ * rendered as an absent table row — the roll-up must not close #3505 while one
+ * exists.
+ */
+
+import type { OptionKeyRow } from "./optionInventory.ts";
+import type { RollupEntry, Verdict } from "./optionAuditRollup.ts";
+
+/** One enumerated key with the verdict the merged table gives it. */
+export interface ClassifiedRow {
+  row: OptionKeyRow;
+  entry: RollupEntry;
+  verdict: Verdict;
+  issue?: number;
+}
+
+/** A key the harness found that the merged table does not classify. */
+export interface Gap {
+  reason: "unclassified top-level key" | "unclassified config interface";
+  detail: string;
+}
+
+/** Result of diffing the inventory against the merged table. */
+export interface ReconcileResult {
+  classified: ClassifiedRow[];
+  gaps: Gap[];
+  /** Roll-up entries describing a key or interface the source no longer has. */
+  orphans: string[];
+}
+
+/** Verdict for one field of `entry`, honouring its overrides. */
+function fieldVerdict(
+  entry: RollupEntry,
+  field: string,
+): { verdict: Verdict; issue?: number } {
+  const override = entry.fieldOverrides?.[field];
+  if (override) return { verdict: override.verdict, issue: override.issue };
+  const verdict = entry.fieldDefault ?? entry.verdict;
+  // A field inherits its parent's issue only when it also inherits the parent's
+  // QUALIFIES verdict — a KEEP field of a QUALIFIES parent carries no issue.
+  return {
+    verdict,
+    issue: verdict === "QUALIFIES" ? entry.issue : undefined,
+  };
+}
+
+/**
+ * Diff the enumerated inventory against the merged classification table.
+ *
+ * Never throws on an unclassified key: it is collected as a gap so the caller
+ * can report every one of them at once and exit non-zero.
+ */
+export function reconcile(
+  rows: readonly OptionKeyRow[],
+  entries: readonly RollupEntry[],
+): ReconcileResult {
+  const byKey = new Map(entries.map((e) => [e.key, e]));
+  const byInterface = new Map<string, RollupEntry>();
+  for (const entry of entries) {
+    for (const iface of entry.interfaces ?? []) byInterface.set(iface, entry);
+  }
+
+  const classified: ClassifiedRow[] = [];
+  const gaps: Gap[] = [];
+  const seenKeys = new Set<string>();
+  const seenInterfaces = new Set<string>();
+
+  for (const row of rows) {
+    if (row.slice === "top-level") {
+      const entry = byKey.get(row.key);
+      if (!entry) {
+        gaps.push({ reason: "unclassified top-level key", detail: row.key });
+        continue;
+      }
+      seenKeys.add(entry.key);
+      classified.push({
+        row,
+        entry,
+        verdict: entry.verdict,
+        issue: entry.verdict === "QUALIFIES" ? entry.issue : undefined,
+      });
+      continue;
+    }
+
+    const iface = `${row.ownerFile}::${row.owner}`;
+    const entry = byInterface.get(iface);
+    if (!entry) {
+      gaps.push({ reason: "unclassified config interface", detail: iface });
+      continue;
+    }
+    seenKeys.add(entry.key);
+    seenInterfaces.add(iface);
+    classified.push({ row, entry, ...fieldVerdict(entry, row.key) });
+  }
+
+  const orphans: string[] = [];
+  for (const entry of entries) {
+    if (!entry.internal && !seenKeys.has(entry.key)) orphans.push(entry.key);
+    for (const iface of entry.interfaces ?? []) {
+      if (!seenInterfaces.has(iface)) orphans.push(iface);
+    }
+  }
+
+  return { classified, gaps, orphans: orphans.sort() };
+}
+
+const VERDICT_ORDER: Verdict[] = ["QUALIFIES", "KEEP", "IN USE"];
+
+function escapeCell(text: string): string {
+  return text.replaceAll("|", "\\|");
+}
+
+/** Render the merged classification table, gaps included, as markdown. */
+export function toConsolidatedMarkdown(result: ReconcileResult): string {
+  const out: string[] = [];
+
+  const counts = new Map<Verdict, number>();
+  for (const c of result.classified) {
+    counts.set(c.verdict, (counts.get(c.verdict) ?? 0) + 1);
+  }
+
+  out.push("| Verdict | Classifications |");
+  out.push("| --- | ---: |");
+  for (const verdict of VERDICT_ORDER) {
+    out.push(`| \`${verdict}\` | ${counts.get(verdict) ?? 0} |`);
+  }
+  out.push(`| **Total** | **${result.classified.length}** |`);
+  out.push("");
+
+  out.push("| Key | Slice | Verdict | Issue | Note |");
+  out.push("| --- | --- | --- | --- | --- |");
+  // One row per key, not per field: fields inherit unless overridden, and the
+  // overrides are rendered as their own rows so nothing is hidden.
+  const seen = new Set<string>();
+  for (const c of result.classified) {
+    const label = c.row.slice === "top-level"
+      ? c.row.key
+      : `${c.entry.key}.${c.row.key}`;
+    const isParentRow = c.row.slice === "top-level";
+    const isOverride = c.entry.fieldOverrides?.[c.row.key] !== undefined;
+    if (!isParentRow && !isOverride) continue;
+    if (seen.has(label)) continue;
+    seen.add(label);
+    const issue = c.issue ? `#${c.issue}` : "—";
+    const note = isParentRow ? c.entry.note ?? "" : "";
+    out.push(
+      `| \`${label}\` | ${c.entry.slice} | \`${c.verdict}\` | ${issue} | ${
+        escapeCell(note)
+      } |`,
+    );
+  }
+
+  // Internal configs have no NeatOptions key, so they have no top-level row.
+  for (const entry of new Set(result.classified.map((c) => c.entry))) {
+    if (!entry.internal || seen.has(entry.key)) continue;
+    seen.add(entry.key);
+    out.push(
+      `| \`${entry.key}\` | ${entry.slice} | \`${entry.verdict}\` | ${
+        entry.issue ? `#${entry.issue}` : "—"
+      } | ${escapeCell(entry.note ?? "")} |`,
+    );
+  }
+
+  if (result.gaps.length > 0) {
+    out.push("");
+    out.push(`## ⚠️ Coverage gaps — ${result.gaps.length}`);
+    out.push("");
+    out.push("| Gap | Detail |");
+    out.push("| --- | --- |");
+    for (const gap of result.gaps) {
+      out.push(`| ${gap.reason} | \`${escapeCell(gap.detail)}\` |`);
+    }
+  }
+
+  return out.join("\n");
+}

--- a/scripts/lib/optionAuditRollup.ts
+++ b/scripts/lib/optionAuditRollup.ts
@@ -1,0 +1,422 @@
+/**
+ * Merged classification table for the #3505 option-removal audit (Issue #3525).
+ *
+ * This is the consolidated result of slices A–F (#3519–#3524): every option key
+ * with its verdict and, where it qualifies, the removal issue that carries it.
+ * It is data rather than prose so the coverage check can be mechanical —
+ * `optionAuditReconcile.ts` diffs it against the #3518 harness key inventory,
+ * and a gap fails CI instead of quietly disappearing from a markdown table.
+ *
+ * Per-key evidence stays in the slice write-ups: `docs/OPTION_AUDIT_SLICE_A.md`
+ * … `docs/OPTION_AUDIT_SLICE_F.md`. The rendered merged table is
+ * `docs/OPTION_AUDIT_CONSOLIDATED.md`.
+ */
+
+/** The three verdicts the audit assigns. */
+export type Verdict = "IN USE" | "KEEP" | "QUALIFIES";
+
+/** A verdict plus the removal/decision issue that carries it, when it has one. */
+export interface FieldVerdict {
+  verdict: Verdict;
+  issue?: number;
+}
+
+/** One classified option key: a `NeatArguments` field or an internal config. */
+export interface RollupEntry {
+  /** Top-level `NeatArguments` key, or an internal config's interface name. */
+  key: string;
+  /** Audit slice that classified it. */
+  slice: "A" | "B" | "C" | "D" | "E" | "F" | "roll-up";
+  /** Verdict for the key itself. */
+  verdict: Verdict;
+  /** Removal or decision issue, required when `verdict` is `QUALIFIES`. */
+  issue?: number;
+  /**
+   * `File.ts::Interface` entries this key's value is shaped by. A nested field
+   * reaches `NeatOptions` only through its parent, so its verdict follows the
+   * parent unless `fieldDefault` / `fieldOverrides` say otherwise.
+   */
+  interfaces?: string[];
+  /** Verdict for fields not named in `fieldOverrides` (defaults to `verdict`). */
+  fieldDefault?: Verdict;
+  /** Fields whose verdict differs from `fieldDefault`. */
+  fieldOverrides?: Record<string, FieldVerdict>;
+  /** True when the config has no `NeatOptions` key (env-resolved internals). */
+  internal?: boolean;
+  /** Short note carried into the merged table. */
+  note?: string;
+}
+
+const inUse = (
+  key: string,
+  slice: RollupEntry["slice"],
+  rest: Partial<RollupEntry> = {},
+): RollupEntry => ({ key, slice, verdict: "IN USE", ...rest });
+
+const keep = (
+  key: string,
+  slice: RollupEntry["slice"],
+  rest: Partial<RollupEntry> = {},
+): RollupEntry => ({ key, slice, verdict: "KEEP", ...rest });
+
+const qualifies = (
+  key: string,
+  slice: RollupEntry["slice"],
+  issue: number,
+  rest: Partial<RollupEntry> = {},
+): RollupEntry => ({ key, slice, verdict: "QUALIFIES", issue, ...rest });
+
+/** Slice A (#3519) — 46 non-`discovery*` top-level options. */
+const SLICE_A: RollupEntry[] = [
+  qualifies("maxConns", "A", 3552),
+  qualifies("maximumNumberOfNodes", "A", 3552),
+  qualifies("enableRepetitiveTraining", "A", 3553),
+  qualifies("dnaSharingMode", "A", 3554, {
+    note:
+      "Slice F confirmed `DnaSharingPreset.ts` is covered here and filed nothing.",
+  }),
+  ...[
+    "dataSetPartitionBreak",
+    "debug",
+    "maxCRISPRsPerGeneration",
+    "maxDedupRetries",
+    "trainingTaskTimeoutMinutes",
+    "skipTrainingAfterConsecutiveRegressions",
+    "subnetworkIndexSize",
+    "trainingBatchSize",
+    "disableRandomSamples",
+    "maximumBiasAdjustmentScale",
+    "maximumWeightAdjustmentScale",
+    "globalBreedingRate",
+    "diversityBreedingRate",
+    "geneticCompatibilityThreshold",
+    "interSpeciesCrossoverThreshold",
+    "syntheticAlignmentThreshold",
+    "allowPoolBorrowing",
+    "tolerateCorruptParents",
+  ].map((k) => keep(k, "A")),
+  ...[
+    "populationSize",
+    "costName",
+    "creativeThinkingConnectionCount",
+    "creatures",
+    "CRISPRs",
+    "customCost",
+    "feedbackLoop",
+    "focusList",
+    "focusRate",
+    "costOfGrowth",
+    "elitism",
+    "timeoutMinutes",
+    "trainPerGen",
+    "mutationAmount",
+    "mutationRate",
+    "threads",
+    "heavyTaskWorkerCount",
+    "selection",
+    "iterations",
+    "verbose",
+    "log",
+    "trainingSampleRate",
+    "targetError",
+    "sparseRatio",
+  ].map((k) => inUse(k, "A")),
+];
+
+/** Slice B (#3520) — 36 `discovery*` top-level options. */
+const SLICE_B: RollupEntry[] = [
+  qualifies("discoveryReplayDiagnostics", "B", 3556),
+  ...[
+    "discoveryMinRecordCoverage",
+    "discoveryHardDeadlineTS",
+    "discoveryRustFlushBytes",
+    "discoveryAnalysisChunkSize",
+    "discoveryAnalysisPerChunkMaxMs",
+    "discoveryFailureCacheBypassOnDrought",
+    "discoveryReplayMaxSingles",
+    "discoveryReplayMaxPairwise",
+    "discoveryReplayMaxTriples",
+    "discoveryReplayConcurrency",
+    "discoveryReplayTimeoutMinutes",
+    "discoveryReplayMinTimeMinutes",
+    "maxConcurrentDiscoveries",
+    "discoveryMinCandidatesPerCategory",
+  ].map((k) => keep(k, "B")),
+  keep("discoveryCache", "B", {
+    interfaces: ["src/config/DiscoveryCacheConfig.ts::DiscoveryCacheConfig"],
+  }),
+  keep("discoveryDiskSpace", "B", {
+    interfaces: ["src/config/DiskSpaceConfig.ts::DiskSpaceConfig"],
+  }),
+  ...[
+    "discoverySampleRate",
+    "discoveryRecordTimeOutMinutes",
+    "discoveryAnalysisTimeoutMinutes",
+    "discoveryBatchSize",
+    "discoveryBufferSize",
+    "discoveryRustFlushRecords",
+    "discoveryMaxNeurons",
+    "discoveryDrainEveryNBatches",
+    "discoveryFocusNeuronUUIDs",
+    "discoveryDisableEvaluationSummaryLogging",
+    "checkpointEveryGeneration",
+    "discoveryDisableCleanup",
+    "discoveryBaseDirectory",
+    "discoverySkipRecordPhase",
+    "discoveryCacheDir",
+    "discoveryFailureCacheDir",
+    "discoverySuccessCacheDir",
+    "discoveryReplayVerifyScores",
+    "discoveryReplayRescoreBaseline",
+  ].map((k) => inUse(k, "B")),
+];
+
+/** Slice C (#3521) — 10 population & selection nested configs. */
+const SLICE_C: RollupEntry[] = [
+  qualifies("ensembleDiversity", "C", 3558, {
+    interfaces: [
+      "src/config/EnsembleDiversityConfig.ts::EnsembleDiversityConfig",
+    ],
+    note: "No implementation exists — parsed, never read.",
+  }),
+  qualifies("novelty", "C", 3559, {
+    interfaces: ["src/config/NoveltyConfig.ts::NoveltyConfig"],
+    note: "Decision, audit recommends KEEP — implemented and documented.",
+  }),
+  qualifies("randomImmigrants", "C", 3560, {
+    interfaces: [
+      "src/config/RandomImmigrantsConfig.ts::RandomImmigrantsConfig",
+    ],
+    note: "Decision, audit recommends KEEP — implemented and documented.",
+  }),
+  keep("selectionPressure", "C", {
+    interfaces: [
+      "src/config/SelectionPressureConfig.ts::SelectionPressureConfig",
+    ],
+  }),
+  keep("fitnessSharing", "C", {
+    interfaces: ["src/config/FitnessSharingConfig.ts::FitnessSharingConfig"],
+  }),
+  keep("speciesStagnation", "C", {
+    interfaces: [
+      "src/config/SpeciesStagnationConfig.ts::SpeciesStagnationConfig",
+    ],
+  }),
+  keep("compatibilityGating", "C", {
+    interfaces: [
+      "src/config/CompatibilityGatingConfig.ts::CompatibilityGatingConfig",
+    ],
+  }),
+  keep("adaptiveMutationThresholds", "C"),
+  keep("fineTunePopulation", "C", {
+    interfaces: [
+      "src/config/FineTunePopulationConfig.ts::FineTunePopulationConfig",
+    ],
+  }),
+  keep("adaptivePopulation", "C", {
+    interfaces: [
+      "src/config/AdaptivePopulationConfig.ts::AdaptivePopulationConfig",
+    ],
+    note:
+      "Borderline: flag defaults false, but FAST_CONVERGENCE_PRESET turns it on.",
+  }),
+];
+
+/** Slice D (#3522) — 12 training, regularisation & data-shaping nested configs. */
+const SLICE_D: RollupEntry[] = [
+  inUse("predictiveCoding", "D", {
+    interfaces: [
+      "src/config/PredictiveCodingConfig.ts::PredictiveCodingConfig",
+    ],
+    fieldDefault: "KEEP",
+    fieldOverrides: { enabled: { verdict: "IN USE" } },
+    note:
+      "GRQ sets only `.enabled`; the other four defaults then drive inference.",
+  }),
+  inUse("outputRanges", "D", {
+    interfaces: ["src/config/OutputRangeConfig.ts::OutputRange"],
+  }),
+  qualifies("stabilityAdaptation", "D", 3562, {
+    interfaces: [
+      "src/config/StabilityAdaptationConfig.ts::StabilityAdaptationConfig",
+    ],
+    note: "No implementation exists — parsed, never read.",
+  }),
+  qualifies("crossValidation", "D", 1943, {
+    interfaces: ["src/config/CrossValidationConfig.ts::CrossValidationConfig"],
+    note: "Commented on the existing #1943 rather than filing a duplicate.",
+  }),
+  qualifies("dataFuzzing", "D", 1943, {
+    interfaces: ["src/config/DataFuzzingConfig.ts::DataFuzzingConfig"],
+    note: "Commented on the existing #1943 rather than filing a duplicate.",
+  }),
+  qualifies("dataQuantisation", "D", 1943, {
+    interfaces: [
+      "src/config/DataQuantisationConfig.ts::DataQuantisationConfig",
+    ],
+    note: "Commented on the existing #1943 rather than filing a duplicate.",
+  }),
+  qualifies("squashBudget", "D", 3563, {
+    interfaces: ["src/config/SquashBudgetConfig.ts::SquashBudgetConfig"],
+    note:
+      "Decision, audit recommends KEEP — live lever, adoption is a GRQ task.",
+  }),
+  keep("weightRegularisation", "D", {
+    interfaces: [
+      "src/config/WeightRegularisationConfig.ts::WeightRegularisationConfig",
+    ],
+  }),
+  keep("biasRegularisation", "D", {
+    interfaces: [
+      "src/config/BiasRegularisationConfig.ts::BiasRegularisationConfig",
+    ],
+  }),
+  keep("squashEffectiveness", "D", {
+    interfaces: [
+      "src/config/SquashEffectivenessConfig.ts::SquashEffectivenessConfig",
+    ],
+  }),
+  keep("quantumStep", "D", {
+    interfaces: ["src/config/QuantumStepConfig.ts::QuantumStepConfig"],
+  }),
+  keep("plateauDetection", "D", {
+    note:
+      "Borderline: flag defaults false, but three exported presets turn it on.",
+  }),
+];
+
+/** Slice E (#3523) — runtime & infrastructure configs and injection points. */
+const SLICE_E: RollupEntry[] = [
+  inUse("memory", "E", {
+    interfaces: ["src/config/MemoryConfig.ts::MemoryConfig"],
+    fieldDefault: "KEEP",
+    fieldOverrides: {
+      enabled: { verdict: "IN USE" },
+      nativeBudgetBytes: { verdict: "IN USE" },
+      proactiveGc: { verdict: "QUALIFIES", issue: 3565 },
+      maxAnalysisMemoryMb: { verdict: "QUALIFIES", issue: 3565 },
+    },
+    note: "GRQ sets `enabled` + `nativeBudgetBytes`; seven defaults are live.",
+  }),
+  inUse("workerThreadCap", "E", {
+    interfaces: ["src/config/WorkerThreadCapConfig.ts::WorkerThreadCapConfig"],
+    note:
+      "Env-only (DISCOVERY_*_MB) — zero camelCase hits, still load-bearing.",
+  }),
+  keep("parallelEvaluation", "E", {
+    interfaces: [
+      "src/config/ParallelEvaluationConfig.ts::ParallelEvaluationConfig",
+    ],
+    fieldOverrides: {
+      maxConcurrentEvaluations: { verdict: "QUALIFIES", issue: 3566 },
+    },
+  }),
+  keep("wasmCache", "E", {
+    interfaces: ["src/config/WasmCacheConfig.ts::WasmCacheConfig"],
+    note:
+      "GRQ's 50 `wasmCache` hits are its own unrelated cap — a false IN USE.",
+  }),
+  ...["creatureStore", "experimentStore", "traceStore", "onTrainingEvent"].map((
+    k,
+  ) => inUse(k, "E")),
+  keep("logger", "E", {
+    note: "Kept on the resolution path, not the injection.",
+  }),
+  keep("rng", "E", {
+    note: "Checked as a pair with input-only `seed`; both stay.",
+  }),
+  {
+    key: "RustScorerConfig",
+    slice: "E",
+    verdict: "IN USE",
+    internal: true,
+    interfaces: [
+      "src/config/RustScorerConfig.ts::RustScorerConfig",
+      "src/config/RustScorerConfig.ts::RequiredRustScorerConfig",
+    ],
+    fieldOverrides: { env: { verdict: "KEEP" } },
+    note: "No NeatOptions key — resolved from NEAT_AI_RUST_SCORER_* env.",
+  },
+];
+
+/** Slice F (#3524) — 4 experimental / research configs, all `QUALIFIES`. */
+const SLICE_F: RollupEntry[] = [
+  qualifies("mcmc", "F", 3570, {
+    interfaces: [
+      "src/config/MCMCConfig.ts::MCMCConfig",
+      "src/config/MCMCConfig.ts::DiversityAwareMCMCConfig",
+    ],
+    note:
+      "Decision — GRQ's evolution-mode sweep declares intent but never wires it.",
+  }),
+  qualifies("opd", "F", 3570, {
+    interfaces: ["src/config/OpdConfig.ts::OpdConfig"],
+    note: "Decision — filed jointly with `mcmc`.",
+  }),
+  qualifies("hyperparameterEvolution", "F", 3569, {
+    interfaces: [
+      "src/config/HyperparameterConfig.ts::HyperparameterEvolutionConfig",
+      "src/config/HyperparameterConfig.ts::EvolvableHyperparameters",
+    ],
+  }),
+  qualifies("specialist", "F", 3568, {
+    interfaces: ["src/config/SpecialistConfig.ts::SpecialistConfig"],
+    note: "Option surface is unreadable at any value.",
+  }),
+];
+
+/**
+ * Keys the roll-up itself classified because no slice covered them.
+ *
+ * The six slice briefs were built from a grep that skipped `readonly mutation`
+ * — the "118 top-level fields" figure in #3518 and #3525. The parser-backed
+ * harness enumerates 119, and this is the difference. Re-probed with the
+ * slice method (`git grep`, exit code checked, controls run): GRQ sets it in
+ * four `NeatOptions` literals from its `--mutation=ALL|FFW` operator flag.
+ */
+const ROLLUP_GAP_FILLS: RollupEntry[] = [
+  inUse("mutation", "roll-up", {
+    note:
+      "Gap found by this roll-up. GRQ `src/{exchange,fx,industry,location}/EvolveApp.ts` set it.",
+  }),
+];
+
+/** The merged classification table — every option key, one entry each. */
+export const OPTION_AUDIT_ROLLUP: readonly RollupEntry[] = [
+  ...SLICE_A,
+  ...SLICE_B,
+  ...SLICE_C,
+  ...SLICE_D,
+  ...SLICE_E,
+  ...SLICE_F,
+  ...ROLLUP_GAP_FILLS,
+];
+
+/**
+ * Every issue number attached to each key, key-level and field-level.
+ *
+ * The duplicate tripwire: a key mapping to two issue numbers means two slices
+ * filed against the same option, which is the failure signature the roll-up
+ * brief names.
+ */
+export function removalIssuesByKey(
+  entries: readonly RollupEntry[],
+): Map<string, number[]> {
+  const byKey = new Map<string, Set<number>>();
+  const add = (key: string, issue: number | undefined) => {
+    if (issue === undefined) return;
+    const set = byKey.get(key) ?? new Set<number>();
+    set.add(issue);
+    byKey.set(key, set);
+  };
+
+  for (const entry of entries) {
+    add(entry.key, entry.issue);
+    for (const [field, fv] of Object.entries(entry.fieldOverrides ?? {})) {
+      add(`${entry.key}.${field}`, fv.issue);
+    }
+  }
+  return new Map(
+    [...byKey].map(([key, set]) => [key, [...set].sort((a, b) => a - b)]),
+  );
+}

--- a/scripts/option-audit-rollup.ts
+++ b/scripts/option-audit-rollup.ts
@@ -1,0 +1,100 @@
+#!/usr/bin/env -S deno run --allow-read --allow-write
+/**
+ * Roll-up reconciliation for the #3505 option-removal audit (Issue #3525).
+ *
+ * Re-runs the #3518 key enumeration and diffs it against the merged
+ * classification table, then prints (or writes) the consolidated markdown.
+ *
+ *     deno run --allow-read scripts/option-audit-rollup.ts
+ *     deno run --allow-read --allow-write scripts/option-audit-rollup.ts \
+ *       --out docs/OPTION_AUDIT_CONSOLIDATED.md
+ *
+ * Exit codes: 0 every key classified, 1 a coverage gap was found, 2 bad usage.
+ * A gap exits non-zero deliberately — an unclassified key must never read as a
+ * clean audit.
+ */
+
+import { enumerateOptionKeys } from "./lib/optionInventory.ts";
+import { OPTION_AUDIT_ROLLUP } from "./lib/optionAuditRollup.ts";
+import {
+  reconcile,
+  toConsolidatedMarkdown,
+} from "./lib/optionAuditReconcile.ts";
+
+const USAGE = `Usage: deno run --allow-read [--allow-write] \\
+  scripts/option-audit-rollup.ts [options]
+
+  --repo-root DIR  NEAT-AI checkout to enumerate keys from (default: .)
+  --out FILE       Write the merged table here instead of stdout
+  --help           Show this message`;
+
+async function main(): Promise<number> {
+  let repoRoot = ".";
+  let out = "";
+
+  for (let i = 0; i < Deno.args.length; i++) {
+    const arg = Deno.args[i];
+    const value = () => {
+      const next = Deno.args[++i];
+      if (next === undefined) throw new Error(`${arg} requires a value`);
+      return next;
+    };
+    switch (arg) {
+      case "--repo-root":
+        repoRoot = value();
+        break;
+      case "--out":
+        out = value();
+        break;
+      case "--help":
+      case "-h":
+        console.log(USAGE);
+        return 0;
+      default:
+        console.error(`❌ unknown option: ${arg}\n\n${USAGE}`);
+        return 2;
+    }
+  }
+
+  const rows = await enumerateOptionKeys(repoRoot);
+  const result = reconcile(rows, OPTION_AUDIT_ROLLUP);
+  const markdown = toConsolidatedMarkdown(result);
+
+  if (out) {
+    await Deno.writeTextFile(out, `${markdown}\n`);
+    console.log(`📝 wrote ${out}`);
+  } else {
+    console.log(markdown);
+  }
+
+  const topLevel = rows.filter((r) => r.slice === "top-level").length;
+  console.error(
+    `\n🔎 ${rows.length} enumerated rows (${topLevel} top-level, ${
+      rows.length - topLevel
+    } nested) · ${result.classified.length} classified`,
+  );
+
+  if (result.orphans.length > 0) {
+    console.error(
+      `⚠️  ${result.orphans.length} roll-up entr${
+        result.orphans.length === 1 ? "y describes a key" : "ies describe keys"
+      } the source no longer has: ${result.orphans.join(", ")}`,
+    );
+  }
+
+  if (result.gaps.length > 0) {
+    console.error(`\n❌ ${result.gaps.length} coverage gap(s):`);
+    for (const gap of result.gaps) {
+      console.error(`   ${gap.reason}: ${gap.detail}`);
+    }
+    console.error("\nFile each gap as a follow-up before closing #3505.");
+    return 1;
+  }
+
+  console.error("✅ zero coverage gaps — every option key is classified");
+  return 0;
+}
+
+if (import.meta.main) {
+  Deno.exit(await main());
+}

--- a/test/scripts/OptionAuditRollup.ts
+++ b/test/scripts/OptionAuditRollup.ts
@@ -1,0 +1,132 @@
+import { assert, assertEquals } from "@std/assert";
+import { enumerateOptionKeys } from "../../scripts/lib/optionInventory.ts";
+import {
+  OPTION_AUDIT_ROLLUP,
+  removalIssuesByKey,
+} from "../../scripts/lib/optionAuditRollup.ts";
+import {
+  reconcile,
+  toConsolidatedMarkdown,
+} from "../../scripts/lib/optionAuditReconcile.ts";
+
+/**
+ * Roll-up reconciliation for the #3505 option-removal audit (Issue #3525).
+ *
+ * The audit's own failure-detection brief requires the coverage check to be
+ * mechanical: diff the #3518 harness key inventory against the merged
+ * classification table rather than eyeballing the six slice comments. These
+ * tests are that check, run on every CI build so the roll-up cannot silently
+ * go stale when the config surface moves.
+ */
+
+const rows = await enumerateOptionKeys(".");
+const result = reconcile(rows, OPTION_AUDIT_ROLLUP);
+
+// -------------------------------------------------------------- coverage
+
+Deno.test("reconcile - every enumerated option key is classified", () => {
+  assertEquals(
+    result.gaps,
+    [],
+    `unclassified keys must be filed as follow-ups, not lost:\n${
+      result.gaps.map((g) => `  ${g.reason}: ${g.detail}`).join("\n")
+    }`,
+  );
+});
+
+Deno.test("reconcile - classifies the whole enumerated surface", () => {
+  assertEquals(result.classified.length, rows.length);
+  assert(
+    result.classified.every((c) => c.verdict !== undefined),
+    "every row resolves to a verdict",
+  );
+});
+
+Deno.test("reconcile - top-level coverage matches NeatArguments exactly", () => {
+  const topLevel = rows.filter((r) => r.slice === "top-level");
+  const covered = new Set(
+    result.classified.filter((c) => c.row.slice === "top-level").map((c) =>
+      c.row.key
+    ),
+  );
+  assertEquals(covered.size, topLevel.length);
+  // `mutation` is the key the six slice briefs missed: they were built from a
+  // grep that skipped `readonly mutation`, which is why #3518 quoted 118
+  // top-level fields where the parser sees 119. The roll-up classifies it.
+  assert(covered.has("mutation"), "the #3518 118-vs-119 gap key is covered");
+});
+
+Deno.test("reconcile - no roll-up entry describes a key that no longer exists", () => {
+  assertEquals(
+    result.orphans,
+    [],
+    `roll-up entries with no matching source key: ${result.orphans.join(", ")}`,
+  );
+});
+
+// ---------------------------------------------------------- removal issues
+
+Deno.test("rollup - every QUALIFIES verdict carries a removal issue", () => {
+  const unlinked = result.classified
+    .filter((c) => c.verdict === "QUALIFIES" && c.issue === undefined)
+    .map((c) => c.row.key);
+  assertEquals(unlinked, [], "QUALIFIES without a linked issue");
+});
+
+Deno.test("rollup - no option key is claimed by two removal issues", () => {
+  const duplicated = [...removalIssuesByKey(OPTION_AUDIT_ROLLUP)]
+    .filter(([, issues]) => issues.length > 1)
+    .map(([key, issues]) => `${key} → ${issues.join(", ")}`);
+  assertEquals(duplicated, [], "cross-slice duplicate removal issues");
+});
+
+Deno.test("rollup - the named cross-slice overlaps resolve to one issue each", () => {
+  const byKey = removalIssuesByKey(OPTION_AUDIT_ROLLUP);
+  // The three overlap pairs the roll-up brief names. `seed` is not a
+  // NeatArguments field at all (it is input-only, resolved into `rng`), so the
+  // A↔E pair reduces to `rng`, which no issue touches.
+  assertEquals(byKey.get("dnaSharingMode"), [3554]);
+  assertEquals(byKey.get("rng"), undefined);
+  assertEquals(byKey.get("discoveryCache"), undefined);
+  assertEquals(byKey.get("discoveryDiskSpace"), undefined);
+});
+
+Deno.test("rollup - verdict totals are internally consistent", () => {
+  const counts = new Map<string, number>();
+  for (const c of result.classified) {
+    counts.set(c.verdict, (counts.get(c.verdict) ?? 0) + 1);
+  }
+  const total = [...counts.values()].reduce((a, b) => a + b, 0);
+  assertEquals(total, rows.length);
+  assert((counts.get("IN USE") ?? 0) > 0, "some options are consumer-set");
+  assert((counts.get("QUALIFIES") ?? 0) > 0, "some options qualify");
+});
+
+// ---------------------------------------------------------------- report
+
+Deno.test("toConsolidatedMarkdown - renders every classified key", () => {
+  const md = toConsolidatedMarkdown(result);
+  for (const key of ["populationSize", "mutation", "specialist", "mcmc"]) {
+    assert(md.includes(`\`${key}\``), `${key} missing from the merged table`);
+  }
+  assert(md.includes("| `mutation`"), "the gap key has its own table row");
+  assert(md.includes("#3554"), "removal issue numbers are rendered");
+});
+
+Deno.test("toConsolidatedMarkdown - reports a gap loudly when one exists", () => {
+  const withGap = reconcile(
+    [...rows, {
+      slice: "top-level" as const,
+      ownerFile: "src/config/NeatArguments.ts",
+      owner: "NeatArguments",
+      key: "aKeyNobodyClassified",
+    }],
+    OPTION_AUDIT_ROLLUP,
+  );
+  assertEquals(withGap.gaps.length, 1);
+  assertEquals(withGap.gaps[0].detail, "aKeyNobodyClassified");
+  assert(
+    toConsolidatedMarkdown(withGap).includes("aKeyNobodyClassified"),
+    "a gap must appear in the report rather than being silently dropped",
+  );
+});


### PR DESCRIPTION
# PR summary — #3505 option-audit roll-up

## Summary

Final roll-up of the #3505 option-removal audit: merges the six slice
classification tables (#3519–#3524) into one, reconciles them **mechanically**
against the #3518 harness inventory, deduplicates the removal issues, and
sequences them. Closes #3525.

The audit's own failure-detection brief demanded the coverage check be a diff
against the harness rather than a reading of six issue comments, so the merged
table is committed as **data** (`scripts/lib/optionAuditRollup.ts`) and the diff
runs in CI on every build. A key the harness enumerates but the table does not
classify is a gap: the CLI exits **1** and names it, and the test fails. An
unclassified option can never read as a clean audit.

**Result: 289 classifications, zero unclassified keys, 15 issues, zero
duplicates.**

| Verdict                       | Classifications |
| ----------------------------- | --------------: |
| `IN USE`                      |              68 |
| `KEEP (load-bearing default)` |             121 |
| `QUALIFIES`                   |             100 |
| **Total**                     |         **289** |

Counted by _option_ rather than by row, 20 of 120 qualify — 10 proposed for
removal, 7 filed as decisions recommending KEEP, 3 already decided `NOT_PLANNED`
by a human on #1943. `KEEP` outnumbers `IN USE` almost two to one: the defaults,
not the consumers, drive most of NEAT-AI's behaviour.

### The gap it found: `mutation`

`NeatArguments` has **119** top-level fields, not the 118 quoted in #3518 and
#3525. The original figure came from a grep that skipped
`readonly mutation: readonly MutationInterface[]` — the harness's own pinned
test already records the real 119. Every slice brief was written from the
118-key list, so **no slice classified `mutation`**.

Re-probed here with the slice method (`git grep`, exit code checked, both
controls run first): `mutation` is **`IN USE`** — GRQ sets it in four
`NeatOptions` literals from its `--mutation=ALL|FFW` operator flag. The gap
closed as a live option rather than a missed removal candidate, so no follow-up
issue was needed.

`seed` is recorded as a second, previously unnoticed exclusion: slice E flagged
it as absent from slice A's table, but it is not a `NeatArguments` field at all
— it is input-only on `NeatOptions` and resolves into `rng`, which _is_
enumerated and classified `KEEP`.

### Unrelated CI fix

`docs/archive/pr-summaries/pr-summary-3524.md` (merged with slice F) carried a
private-repo issue slug and was failing
`test/docs/ArchiveDocsNoPrivateRepoSlugs.ts` on the milestone branch. Reworded
to concept level as that gate's own message instructs. Without this the branch
cannot go green.

## Evidence

No web interface to screenshot — this is a scripts/docs change. The evidence is
the reconciliation run itself, which is reproducible:

```
$ deno run --allow-read scripts/option-audit-rollup.ts
🔎 289 enumerated rows (119 top-level, 170 nested) · 289 classified
✅ zero coverage gaps — every option key is classified
```

```mermaid
flowchart LR
    H["#3518 harness<br/>enumerateOptionKeys()"] --> INV["289 rows<br/>119 top-level + 170 nested"]
    A["Slices A–F<br/>#3519–#3524"] --> TAB["Merged table<br/>optionAuditRollup.ts"]
    INV --> REC{"reconcile()"}
    TAB --> REC
    REC -->|"gap"| GAP["❌ exit 1<br/>file a follow-up"]
    REC -->|"zero gaps"| OK["✅ #3505 closed out"]
```

Deduplication was run per key rather than asserted —
`gh issue list --search
"<key>" --state all` across the three named overlap
pairs (`dnaSharingMode`/`DnaSharingPreset`, `seed`/`rng`,
`discoveryCache`/`discoveryDiskSpace`) and against #3446–#3449 / #3509–#3512.
Every option key maps to exactly one issue; #3509–#3512 have all closed since
the slices ran and touch no option key.

The consolidated result is posted on
[#3505](https://github.com/stSoftwareAU/NEAT-AI/issues/3505#issuecomment-5129844109),
which stays the audit trail after closure. Full write-up:
[`docs/OPTION_AUDIT_CONSOLIDATED.md`](../../OPTION_AUDIT_CONSOLIDATED.md).

### Removal ordering

All 14 removals edit `NeatConfig.ts` / `NeatArguments.ts` / `NeatOptions.ts`, so
they conflict there by construction — a trivial rebase. The chains that touch
the same non-config code or doc block, and so must be sequenced:

| Order | Chain                         | Shared path                                                                               |
| ----- | ----------------------------- | ----------------------------------------------------------------------------------------- |
| 1     | #3558 → #3562                 | `src/presets/Presets.ts` (both delete a `LARGE_NETWORK_PRESET` entry) + three shared docs |
| 2     | #3552 → #3559 → #3569 → #3570 | `src/NEAT/Mutator.ts`, `src/breed/Breed.ts`, `ParallelBreeding.ts`                        |
| 3     | #3559 → #3560 → #3570         | `src/NEAT/Neat.ts`, `NeatEvolution.ts`, `NeatConfigValidation.ts`                         |
| 4     | #3565 → #3566                 | `src/config/parsers/RuntimeParsers.ts`                                                    |

## Test Plan

New: `test/scripts/OptionAuditRollup.ts` — 10 tests calling the real
`enumerateOptionKeys()` and `reconcile()` against the live source tree, not
greps over markdown:

- `reconcile - every enumerated option key is classified` — the gate. Fails with
  the offending key names if a config change outruns the roll-up.
- `reconcile - classifies the whole enumerated surface` /
  `top-level coverage
  matches NeatArguments exactly` — asserts all 289 rows
  resolve, and pins the `mutation` gap key so the 118-vs-119 fault cannot
  silently return.
- `reconcile - no roll-up entry describes a key that no longer exists` — catches
  drift in the other direction, when a key is deleted from source.
- `rollup - every QUALIFIES verdict carries a removal issue` — no orphan removal
  candidate.
- `rollup - no option key is claimed by two removal issues` and
  `the named
  cross-slice overlaps resolve to one issue each` — the duplicate
  tripwire.
- `toConsolidatedMarkdown - reports a gap loudly when one exists` — injects a
  synthetic unclassified key and asserts it is reported rather than dropped,
  which is the fail-loud behaviour the whole roll-up rests on.

`./quality.sh --skip-discovery --skip-wasm < /dev/null` passes: **8088 passed (5
steps) | 0 failed | 4 ignored (8m33s)**, with `deno fmt`, `deno lint`, the
bash-syntax gate and `deno check` clean.

### Security self-check

Scripts are read-only over the repo's own `src/config/` (`--allow-read`;
`--allow-write` only for the optional `--out` path). No network, no subprocess,
no external input, no secrets staged. Markdown cells escape `|` so a key name
cannot break out of the rendered table.



## Milestone
This PR is part of the **#3505 chore: audit NEAT-AI options unused by GRQ/NEAT-AI-Examples for removal** milestone and targets the `milestone/3505-chore-audit-neat-ai-options-unused-by-grq-nea` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-ms7cp7kk-4ec71d`<!-- vibe-worker-issue-3525 -->