### PR TITLE
Coverage merge silently skips: .coverage-* shard dirs are hidden files and never uploaded (Issue #3550)

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -36,7 +36,7 @@ jobs:
   # Fan out the ~1k-file suite across N shards (Issue #3173). `deno test` has no
   # native --shard flag, so scripts/shard_test_files.ts partitions the sorted
   # test/**/*.ts list round-robin; each shard runs its slice, collecting a
-  # partial .coverage-<shard> dir and junit-<shard>.xml, then uploads both as a
+  # partial coverage-<shard> dir and junit-<shard>.xml, then uploads both as a
   # per-shard artifact for the merge job to aggregate. Smaller slices also
   # reduce per-job memory pressure (the OOM root cause is tracked separately).
   coverage:
@@ -89,7 +89,11 @@ jobs:
           set -Eeuo pipefail
           export NO_COLOR=true
           SHARD="${{ matrix.shard }}"
-          COV_DIR=".coverage-${SHARD}"
+          # Non-hidden on purpose (Issue #3550): actions/upload-artifact
+          # defaults to include-hidden-files: false, so a dot-prefixed
+          # `.coverage-<shard>/` was silently dropped from the artifact and the
+          # merge job saw no coverage at all.
+          COV_DIR="coverage-${SHARD}"
           JUNIT="junit-${SHARD}.xml"
 
           # Deterministically pick this shard's slice of test/**/*.ts. The same
@@ -226,7 +230,7 @@ jobs:
         with:
           name: shard-${{ matrix.shard }}
           path: |
-            .coverage-${{ matrix.shard }}/
+            coverage-${{ matrix.shard }}/
             junit-${{ matrix.shard }}.xml
             shard-status-${{ matrix.shard }}.txt
           retention-days: 7
@@ -357,12 +361,18 @@ jobs:
         run: |
           set -Eeuo pipefail
           shopt -s nullglob
-          cov_dirs=(.coverage-*/)
-          if [ "${#cov_dirs[@]}" -eq 0 ]; then
-            echo "No shard coverage directories found; skipping coverage report"
-            exit 0
-          fi
-          echo "Merging coverage from: ${cov_dirs[*]}"
+          # Fail loud when coverage went missing (Issue #3550). The gate exits
+          # 1 if any shard uploaded a status marker (so it ran tests) while no
+          # coverage-<shard>/ dir arrived, and 2 only when nothing at all was
+          # uploaded — the shard-status gate reports that case.
+          set +e
+          deno run --allow-read scripts/coverage_merge_gate.ts
+          GATE_EXIT=$?
+          set -e
+          if [ "$GATE_EXIT" -eq 2 ]; then exit 0; fi
+          if [ "$GATE_EXIT" -ne 0 ]; then exit "$GATE_EXIT"; fi
+
+          cov_dirs=(coverage-*/)
           # `deno coverage` accepts multiple input dirs and merges them into one
           # lcov report. Exclude ephemeral temp modules and *.test.* files as
           # before.
@@ -371,6 +381,13 @@ jobs:
             --output=.coverage.lcov \
             --exclude="^file:///tmp/" \
             --exclude="test\\.(js|mjs|ts|jsx|tsx)$"
+
+          # A successful merge that produced no lcov would silently skip the
+          # Codecov upload (its hashFiles guard) — fail loud instead.
+          if [ ! -s .coverage.lcov ]; then
+            echo "❌ deno coverage produced no lcov report from: ${cov_dirs[*]}"
+            exit 1
+          fi
 
       - name: Upload coverage to Codecov
         if: ${{ hashFiles('.coverage.lcov') != '' }}

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ logback.log
 !.gitignore
 !.markdownlint-cli2.jsonc
 coverage/
+# Per-shard coverage dirs are deliberately non-hidden so upload-artifact keeps
+# them (Issue #3550); ignore them so a local run never commits one.
+coverage-*/
 target/
 junit.xml
 !.github

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-3550.md
+++ b/docs/archive/pr-summaries/pr-summary-3550.md
@@ -1,0 +1,98 @@
+# Coverage merge silently skipped: shard dirs were hidden and never uploaded
+
+## Summary
+
+The sharded coverage workflow wrote each shard's partial coverage into
+`.coverage-<shard>/`. `actions/upload-artifact` defaults to
+`include-hidden-files: false`, so that dot-prefixed directory was dropped from
+the artifact — the merge job's glob came back empty, printed
+`No shard coverage directories found; skipping coverage report`, and exited 0.
+Coverage was silently lost while the run stayed green.
+
+This PR removes the footgun rather than working around it (option 1 in the
+issue) and adds the loud-failure guard:
+
+- Shards now write **non-hidden** `coverage-<shard>/` dirs and upload that path.
+- New unit-tested gate
+  [`scripts/coverage_merge_gate.ts`](../../../scripts/coverage_merge_gate.ts):
+  if any shard uploaded a `shard-status-<n>.txt` marker it ran tests, so at
+  least one `coverage-<shard>/` dir MUST exist — an empty glob exits **1**. Only
+  when nothing at all was uploaded does it exit **2** (skip), because the
+  existing shard-status gate already fails that build.
+- The merge step also asserts `.coverage.lcov` is non-empty, so a merge that
+  produced no report fails instead of silently skipping the Codecov upload
+  (whose `hashFiles` guard hid the problem).
+- `.gitignore` ignores `coverage-*/` so the now-visible local dirs are never
+  committed.
+
+Closes #3550.
+
+## Evidence
+
+Backend/CI change — no web interface to screenshot.
+
+```mermaid
+flowchart TD
+    G["Merge job: coverage_merge_gate.ts"] --> D{"coverage-*/ dirs?"}
+    D -->|"yes"| M["deno coverage → .coverage.lcov"]
+    D -->|"no, but shard-status-*.txt present"| F["❌ exit 1 — coverage lost"]
+    D -->|"no artifacts at all"| S["exit 2 — skip; shard-status gate fails build"]
+    M --> L{".coverage.lcov non-empty?"}
+    L -->|"yes"| U["Upload to Codecov"]
+    L -->|"no"| F2["❌ exit 1 — empty report"]
+```
+
+CLI behaviour of the new gate, run against a scratch directory:
+
+```text
+$ echo passed > shard-status-0.txt && deno run --allow-read scripts/coverage_merge_gate.ts
+❌ 1 shard(s) uploaded a shard-status marker but no coverage-<shard>/ directory
+   reached the merge job. Coverage would be silently lost — ...
+exit=1
+
+$ mkdir coverage-0 && deno run --allow-read scripts/coverage_merge_gate.ts
+Merging coverage from: coverage-0
+exit=0
+
+$ rm -r coverage-0 shard-status-0.txt && deno run --allow-read scripts/coverage_merge_gate.ts
+No shard artifacts of any kind were uploaded; the shard-status gate reports this
+failure. Skipping the coverage report.
+exit=2
+```
+
+`actionlint .github/workflows/coverage.yaml` passes with no findings.
+
+Docs: the shard/merge flow in
+[`docs/troubleshooting/CI.md`](../../troubleshooting/CI.md) is updated with a new
+"Coverage must never go missing silently" section explaining the hidden-file
+footgun and both guards.
+
+## Test Plan
+
+New — `test/ci/CoverageMergeGate.ts` (calls the real gate functions):
+
+- merges when shards reported status and coverage arrived
+- **fails loud** when shards reported status but no coverage arrived (the
+  regression: this is exactly the PR #3549 scenario, and it fails against the
+  old skip-and-exit-0 behaviour)
+- fails loud for a single status-without-coverage shard
+- skips only when nothing at all was uploaded
+- merges coverage that arrived without a status file
+- reports the directories being merged
+- `isCoverageShardDir` rejects hidden `.coverage-0` and non-shard names
+- `isShardStatusFile` recognises `shard-status-<n>.txt` only
+- scanning a real temp directory: a hidden `.coverage-0` is not counted (gate
+  fails), a real `coverage-0` is (gate merges)
+
+New — `test/ci/CoverageShardArtifactPaths.ts` (parses the committed workflow):
+
+- shard artifact upload lists no hidden paths and includes
+  {% raw %}`coverage-${{ matrix.shard }}/`{% endraw %}
+- `COV_DIR` is not dot-prefixed
+- merge job invokes the gate before `deno coverage`, does not swallow it with
+  `|| true`, and globs `coverage-*/`
+- merge job asserts a non-empty `.coverage.lcov`
+
+Existing `test/ci/*` workflow tests (shard matrix parity, OOM retry, job
+timeouts, actionlint) continue to pass; `./quality.sh` was run over the full
+suite.

--- a/docs/archive/pr-summaries/pr-summary-3550.md
+++ b/docs/archive/pr-summaries/pr-summary-3550.md
@@ -86,8 +86,8 @@ New — `test/ci/CoverageMergeGate.ts` (calls the real gate functions):
 
 New — `test/ci/CoverageShardArtifactPaths.ts` (parses the committed workflow):
 
-- shard artifact upload lists no hidden paths and includes {% raw
-  %}`coverage-${{ matrix.shard }}/`{% endraw %}
+- shard artifact upload lists no hidden paths
+- upload includes {% raw %}`coverage-${{ matrix.shard }}/`{% endraw %}
 - `COV_DIR` is not dot-prefixed
 - merge job invokes the gate before `deno coverage`, does not swallow it with
   `|| true`, and globs `coverage-*/`

--- a/docs/archive/pr-summaries/pr-summary-3550.md
+++ b/docs/archive/pr-summaries/pr-summary-3550.md
@@ -63,8 +63,8 @@ exit=2
 `actionlint .github/workflows/coverage.yaml` passes with no findings.
 
 Docs: the shard/merge flow in
-[`docs/troubleshooting/CI.md`](../../troubleshooting/CI.md) is updated with a new
-"Coverage must never go missing silently" section explaining the hidden-file
+[`docs/troubleshooting/CI.md`](../../troubleshooting/CI.md) is updated with a
+new "Coverage must never go missing silently" section explaining the hidden-file
 footgun and both guards.
 
 ## Test Plan
@@ -86,8 +86,8 @@ New — `test/ci/CoverageMergeGate.ts` (calls the real gate functions):
 
 New — `test/ci/CoverageShardArtifactPaths.ts` (parses the committed workflow):
 
-- shard artifact upload lists no hidden paths and includes
-  {% raw %}`coverage-${{ matrix.shard }}/`{% endraw %}
+- shard artifact upload lists no hidden paths and includes {% raw
+  %}`coverage-${{ matrix.shard }}/`{% endraw %}
 - `COV_DIR` is not dot-prefixed
 - merge job invokes the gate before `deno coverage`, does not swallow it with
   `|| true`, and globs `coverage-*/`

--- a/docs/troubleshooting/CI.md
+++ b/docs/troubleshooting/CI.md
@@ -18,15 +18,15 @@ every file runs on exactly one shard (no gaps, no double-runs).
 ```mermaid
 flowchart LR
     subgraph coverage["coverage job (matrix, fail-fast: false)"]
-        S0["shard 0<br/>slice → .coverage-0 + junit-0.xml"]
-        S1["shard 1<br/>slice → .coverage-1 + junit-1.xml"]
-        SN["shard N-1<br/>slice → .coverage-N-1 + junit-N-1.xml"]
+        S0["shard 0<br/>slice → coverage-0 + junit-0.xml"]
+        S1["shard 1<br/>slice → coverage-1 + junit-1.xml"]
+        SN["shard N-1<br/>slice → coverage-N-1 + junit-N-1.xml"]
     end
     S0 --> M
     S1 --> M
     SN --> M
     subgraph merge["merge job (needs: coverage, if: !cancelled)"]
-        M["Verify parity → merge .coverage-* (lcov)<br/>+ merge junit-*.xml → gate on shard statuses"]
+        M["Verify parity → merge coverage-* (lcov)<br/>+ merge junit-*.xml → gate on shard statuses"]
     end
     M --> C["1 Codecov coverage report<br/>1 consolidated Test Results check"]
 ```
@@ -35,7 +35,7 @@ flowchart LR
 runs its slice, and — if the runner OOM-kills the run — retries once while
 **staying parallel**: it keeps `--parallel` but caps the worker pool via
 `DENO_JOBS=2` and halves the V8 heap (Issue #3174). Each shard uploads its
-partial `.coverage-<shard>` dir, `junit-<shard>.xml`, and a
+partial `coverage-<shard>` dir, `junit-<shard>.xml`, and a
 `shard-status-<shard>.txt` marker; test _failures_ never fail the shard job (the
 merge job gates the build), so every shard always publishes its results.
 
@@ -88,15 +88,16 @@ stays serial on the retry with the reduced heap.
 flowchart TD
     A[Shard slice] --> B["Initial run<br/>--parallel, DENO_JOBS=auto, full heap"]
     B --> C{Exit code}
-    C -->|"0 / 1"| E["Record status<br/>upload .coverage-N + junit-N.xml"]
+    C -->|"0 / 1"| E["Record status<br/>upload coverage-N + junit-N.xml"]
     C -->|"134 / 137 / 143 (OOM)"| D["Scoped recovery<br/>--parallel, DENO_JOBS=2, half heap"]
     D --> E
     E --> M["Merge job<br/>merge coverage + JUnit, gate on shard statuses"]
 ```
 
-**Merge job:** re-verifies partition parity, merges the partial coverage dirs
-into one `.coverage.lcov` via `deno coverage`, merges the per-shard JUnit
-reports into a single `junit.xml` via
+**Merge job:** re-verifies partition parity, checks the
+[coverage merge gate](#-coverage-must-never-go-missing-silently-issue-3550),
+merges the partial coverage dirs into one `.coverage.lcov` via `deno coverage`,
+merges the per-shard JUnit reports into a single `junit.xml` via
 [`scripts/merge_junit.ts`](../../scripts/merge_junit.ts), publishes one
 consolidated Test Results check + Codecov upload, then fails the build if any
 shard reported test failures (`failed`) or a runner crash (`error`/missing
@@ -114,6 +115,45 @@ status).
 **Tuning shard count:** set the workflow-level `SHARD_TOTAL` env **and** the
 `coverage` job's `strategy.matrix.shard` list to the same value —
 `test/ci/CoverageShardMatrix.ts` fails CI if they diverge.
+
+### 🚨 Coverage must never go missing silently (Issue #3550)
+
+> [!IMPORTANT]
+> Shard coverage directories are **non-hidden** (`coverage-<shard>/`, never
+> `.coverage-<shard>/`). `actions/upload-artifact` defaults to
+> `include-hidden-files: false`, so a dot-prefixed directory is dropped from the
+> artifact without failing anything.
+
+That footgun cost real coverage: shards wrote `.coverage-<shard>/`, the artifact
+carried only `junit-<shard>.xml` + `shard-status-<shard>.txt`, the merge job's
+glob came back empty, and the step printed "skipping coverage report" and exited
+0 — a lost input reported as a clean run.
+
+Two guards now make the failure loud:
+
+1. [`scripts/coverage_merge_gate.ts`](../../scripts/coverage_merge_gate.ts) — if
+   any shard uploaded a status marker it ran tests, so at least one
+   `coverage-<shard>/` dir must exist. An empty glob then exits **1**. Only when
+   nothing at all was uploaded does it exit **2** (skip), because the
+   shard-status gate already reports that crash.
+2. The merge step asserts `.coverage.lcov` is non-empty, so a merge that
+   produced no report fails instead of silently skipping the Codecov upload.
+
+```mermaid
+flowchart TD
+    G["Merge job: coverage_merge_gate.ts"] --> D{"coverage-*/ dirs?"}
+    D -->|"yes"| M["deno coverage → .coverage.lcov"]
+    D -->|"no, but shard-status-*.txt present"| F["❌ exit 1 — coverage lost"]
+    D -->|"no artifacts at all"| S["exit 2 — skip; shard-status gate fails build"]
+    M --> L{".coverage.lcov non-empty?"}
+    L -->|"yes"| U["Upload to Codecov"]
+    L -->|"no"| F2["❌ exit 1 — empty report"]
+```
+
+The gate's decision logic is unit-tested in
+[`test/ci/CoverageMergeGate.ts`](../../test/ci/CoverageMergeGate.ts), and
+`test/ci/CoverageShardArtifactPaths.ts` fails CI if a hidden path is ever
+re-introduced into the shard artifact.
 
 ## 🔧 quality.sh failures
 

--- a/scripts/coverage_merge_gate.ts
+++ b/scripts/coverage_merge_gate.ts
@@ -1,0 +1,116 @@
+#!/usr/bin/env -S deno run --allow-read
+/**
+ * Decide whether the sharded coverage merge may proceed — and fail loud when
+ * coverage has gone missing (Issue #3550).
+ *
+ * Background: each shard writes a partial coverage directory and uploads it as
+ * an artifact. `actions/upload-artifact` defaults to
+ * `include-hidden-files: false`, so the old dot-prefixed `.coverage-<shard>/`
+ * directory was silently dropped and never reached the merge job. The merge
+ * step then found an empty glob, printed "skipping coverage report", and exited
+ * 0 — a missing input reported as a clean run.
+ *
+ * The rule: if any shard uploaded a status file it ran tests, so at least one
+ * coverage directory MUST be present. An empty glob in that case is a defect
+ * and exits non-zero. Only when nothing at all was uploaded (every shard
+ * crashed) does this step skip — the shard-status gate reports that failure.
+ *
+ * The pure decision function is unit-tested in `test/ci/CoverageMergeGate.ts`;
+ * the CLI wrapper is invoked from `.github/workflows/coverage.yaml`.
+ *
+ * CLI usage — scans a directory (default `.`) and exits 1 on a lost-coverage
+ * defect:
+ *
+ *   deno run --allow-read scripts/coverage_merge_gate.ts [--dir=.]
+ */
+
+/** Discovered merge inputs in the workspace. */
+export interface CoverageMergeInputs {
+  /** Non-hidden per-shard coverage directories, e.g. `coverage-3`. */
+  coverageDirs: string[];
+  /** Per-shard status markers, e.g. `shard-status-3.txt`. */
+  statusFiles: string[];
+}
+
+/** Outcome of the gate. */
+export interface CoverageMergeGateResult {
+  /** `merge` — run `deno coverage`; `skip` — nothing ran; `fail` — defect. */
+  status: "merge" | "skip" | "fail";
+  /** Human-readable explanation printed by the CLI. */
+  message: string;
+}
+
+/**
+ * A shard coverage directory. Dot-prefixed names are deliberately rejected:
+ * a hidden directory is dropped by `actions/upload-artifact`, so it can never
+ * be a legitimate merge input.
+ */
+export function isCoverageShardDir(name: string): boolean {
+  return /^coverage-\d+$/.test(name);
+}
+
+/** A per-shard status marker written by the shard job. */
+export function isShardStatusFile(name: string): boolean {
+  return /^shard-status-\d+\.txt$/.test(name);
+}
+
+/** Scan `dir` for the merge inputs, sorted for stable reporting. */
+export async function scanCoverageMergeInputs(
+  dir: string,
+): Promise<CoverageMergeInputs> {
+  const coverageDirs: string[] = [];
+  const statusFiles: string[] = [];
+  for await (const entry of Deno.readDir(dir)) {
+    if (entry.isDirectory && isCoverageShardDir(entry.name)) {
+      coverageDirs.push(entry.name);
+    } else if (entry.isFile && isShardStatusFile(entry.name)) {
+      statusFiles.push(entry.name);
+    }
+  }
+  coverageDirs.sort();
+  statusFiles.sort();
+  return { coverageDirs, statusFiles };
+}
+
+/**
+ * Decide the merge outcome. Missing coverage after any shard reported a status
+ * is a defect, never a quiet skip.
+ */
+export function evaluateCoverageMergeGate(
+  inputs: CoverageMergeInputs,
+): CoverageMergeGateResult {
+  const { coverageDirs, statusFiles } = inputs;
+  if (coverageDirs.length > 0) {
+    return {
+      status: "merge",
+      message: `Merging coverage from: ${coverageDirs.join(" ")}`,
+    };
+  }
+  if (statusFiles.length > 0) {
+    return {
+      status: "fail",
+      message:
+        `❌ ${statusFiles.length} shard(s) uploaded a shard-status marker but no ` +
+        `coverage-<shard>/ directory reached the merge job. Coverage would be ` +
+        `silently lost — check that the shard artifact upload includes the ` +
+        `coverage directory and that it is not a hidden (dot-prefixed) path.`,
+    };
+  }
+  return {
+    status: "skip",
+    message:
+      "No shard artifacts of any kind were uploaded; the shard-status gate " +
+      "reports this failure. Skipping the coverage report.",
+  };
+}
+
+if (import.meta.main) {
+  const dirArg = Deno.args.find((a) => a.startsWith("--dir="));
+  const dir = dirArg ? dirArg.slice("--dir=".length) : ".";
+  const result = evaluateCoverageMergeGate(await scanCoverageMergeInputs(dir));
+  console.log(result.message);
+  if (result.status === "fail") Deno.exit(1);
+  // `skip` is reported to the workflow via a distinct exit code so the step can
+  // tell "nothing to merge" apart from "merge these dirs" without re-globbing.
+  if (result.status === "skip") Deno.exit(2);
+}

--- a/test/ci/CoverageMergeGate.ts
+++ b/test/ci/CoverageMergeGate.ts
@@ -1,0 +1,129 @@
+import { assert, assertEquals } from "@std/assert";
+import {
+  evaluateCoverageMergeGate,
+  isCoverageShardDir,
+  isShardStatusFile,
+  scanCoverageMergeInputs,
+} from "../../scripts/coverage_merge_gate.ts";
+
+/**
+ * Unit tests for the coverage merge gate (Issue #3550).
+ *
+ * The sharded coverage workflow used to treat "no shard coverage directories
+ * found" as a clean skip: it printed a message, exited 0, and the Codecov
+ * upload was skipped by its `hashFiles` guard. Coverage was silently lost.
+ *
+ * The gate makes that case loud: when at least one shard uploaded a status it
+ * ran tests, so at least one coverage directory MUST be present — an empty
+ * glob is a defect, not a skip.
+ *
+ * These are "what" tests: they call the real decision function with test data
+ * and assert on the returned outcome.
+ */
+
+Deno.test("merge gate merges when shards reported status and coverage arrived", () => {
+  const result = evaluateCoverageMergeGate({
+    coverageDirs: ["coverage-0", "coverage-1"],
+    statusFiles: ["shard-status-0.txt", "shard-status-1.txt"],
+  });
+  assertEquals(result.status, "merge");
+});
+
+Deno.test("merge gate fails loud when shards reported status but no coverage arrived", () => {
+  const result = evaluateCoverageMergeGate({
+    coverageDirs: [],
+    statusFiles: ["shard-status-0.txt", "shard-status-1.txt"],
+  });
+  assertEquals(
+    result.status,
+    "fail",
+    "missing coverage after shards ran is a defect, not a skip",
+  );
+  assert(
+    result.message.includes("shard-status"),
+    `failure message should name the evidence that shards ran: ${result.message}`,
+  );
+});
+
+Deno.test("merge gate fails loud when a single shard reported status without coverage", () => {
+  const result = evaluateCoverageMergeGate({
+    coverageDirs: [],
+    statusFiles: ["shard-status-3.txt"],
+  });
+  assertEquals(result.status, "fail");
+});
+
+Deno.test("merge gate skips when no shard uploaded anything at all", () => {
+  // Every shard crashed before writing a status: the shard-status gate reports
+  // that failure, so the coverage step skips rather than double-reporting.
+  const result = evaluateCoverageMergeGate({
+    coverageDirs: [],
+    statusFiles: [],
+  });
+  assertEquals(result.status, "skip");
+});
+
+Deno.test("merge gate merges coverage that arrived without any status file", () => {
+  const result = evaluateCoverageMergeGate({
+    coverageDirs: ["coverage-2"],
+    statusFiles: [],
+  });
+  assertEquals(result.status, "merge");
+});
+
+Deno.test("merge gate reports the coverage directories it will merge", () => {
+  const result = evaluateCoverageMergeGate({
+    coverageDirs: ["coverage-5"],
+    statusFiles: ["shard-status-5.txt"],
+  });
+  assert(
+    result.message.includes("coverage-5"),
+    `merge message should name the directories: ${result.message}`,
+  );
+});
+
+Deno.test("coverage shard directories are recognised only when non-hidden", () => {
+  assert(isCoverageShardDir("coverage-0"));
+  assert(isCoverageShardDir("coverage-11"));
+  // The root cause of Issue #3550: a dot-prefixed directory is a hidden path,
+  // which actions/upload-artifact drops by default. Such a directory can never
+  // reach the merge job, so it must not be counted as coverage.
+  assert(
+    !isCoverageShardDir(".coverage-0"),
+    "hidden (dot-prefixed) shard dirs are never uploaded and must not count",
+  );
+  assert(!isCoverageShardDir("coverage"));
+  assert(!isCoverageShardDir("coverage-abc"));
+  assert(!isCoverageShardDir("coverage-0.lcov"));
+});
+
+Deno.test("shard status files are recognised by index", () => {
+  assert(isShardStatusFile("shard-status-0.txt"));
+  assert(isShardStatusFile("shard-status-7.txt"));
+  assert(!isShardStatusFile("shard-status.txt"));
+  assert(!isShardStatusFile("shard-status-0.json"));
+  assert(!isShardStatusFile("junit-0.xml"));
+});
+
+Deno.test("scanning a real directory drives the gate to fail loud on lost coverage", async () => {
+  const dir = await Deno.makeTempDir({ prefix: "coverage-merge-gate-" });
+  try {
+    await Deno.writeTextFile(`${dir}/shard-status-0.txt`, "passed");
+    await Deno.writeTextFile(`${dir}/junit-0.xml`, "<testsuites/>");
+    // A hidden coverage dir is exactly what the old workflow produced — it never
+    // survives the artifact upload, so scanning must not count it.
+    await Deno.mkdir(`${dir}/.coverage-0`);
+
+    const lost = await scanCoverageMergeInputs(dir);
+    assertEquals(lost.coverageDirs, []);
+    assertEquals(lost.statusFiles, ["shard-status-0.txt"]);
+    assertEquals(evaluateCoverageMergeGate(lost).status, "fail");
+
+    await Deno.mkdir(`${dir}/coverage-0`);
+    const found = await scanCoverageMergeInputs(dir);
+    assertEquals(found.coverageDirs, ["coverage-0"]);
+    assertEquals(evaluateCoverageMergeGate(found).status, "merge");
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});

--- a/test/ci/CoverageShardArtifactPaths.ts
+++ b/test/ci/CoverageShardArtifactPaths.ts
@@ -1,0 +1,125 @@
+import { assert } from "@std/assert";
+import { parse } from "@std/yaml";
+
+/**
+ * Guards the shard-artifact visibility invariant of
+ * `.github/workflows/coverage.yaml` (Issue #3550).
+ *
+ * `actions/upload-artifact` defaults to `include-hidden-files: false`, so a
+ * dot-prefixed path is silently dropped from the artifact. The shards used to
+ * write coverage into `.coverage-<shard>/`, which therefore never reached the
+ * merge job: the merge glob came back empty, coverage was skipped, and the run
+ * still went green. Coverage directories must be non-hidden, and the merge job
+ * must fail loud rather than skip when they are missing.
+ *
+ * These are "what" tests: they parse the committed workflow YAML and assert on
+ * the configuration the runner actually executes.
+ */
+
+interface Step {
+  id?: string;
+  name?: string;
+  run?: string;
+  uses?: string;
+  with?: Record<string, unknown>;
+}
+
+interface Job {
+  steps?: Step[];
+}
+
+interface Workflow {
+  jobs?: Record<string, Job>;
+}
+
+const COVERAGE_WORKFLOW = ".github/workflows/coverage.yaml";
+
+async function readWorkflow(): Promise<Workflow> {
+  return parse(await Deno.readTextFile(COVERAGE_WORKFLOW)) as Workflow;
+}
+
+function stepsOf(wf: Workflow, job: string): Step[] {
+  const steps = wf.jobs?.[job]?.steps;
+  assert(steps && steps.length > 0, `${job} job must declare steps`);
+  return steps;
+}
+
+/** Any dot-prefixed path segment is hidden and dropped by upload-artifact. */
+function hiddenPaths(paths: string[]): string[] {
+  return paths.filter((p) =>
+    p.split("/").some((segment) => segment.startsWith("."))
+  );
+}
+
+Deno.test("shard artifact upload lists no hidden paths", async () => {
+  const wf = await readWorkflow();
+  const upload = stepsOf(wf, "coverage").find((s) =>
+    typeof s.uses === "string" && s.uses.includes("upload-artifact")
+  );
+  assert(upload, "coverage job must upload a per-shard artifact");
+  const path = upload.with?.path;
+  assert(typeof path === "string", "upload step must declare a `path`");
+  const paths = path.split("\n").map((p) => p.trim()).filter((p) => p.length);
+  const hidden = hiddenPaths(paths);
+  assert(
+    hidden.length === 0,
+    `upload-artifact drops hidden paths by default; these would be silently lost: ${
+      hidden.join(", ")
+    }`,
+  );
+  assert(
+    paths.some((p) => /^coverage-\$\{\{\s*matrix\.shard\s*\}\}\/?$/.test(p)),
+    `shard artifact must include the non-hidden coverage dir, got: ${
+      paths.join(", ")
+    }`,
+  );
+});
+
+Deno.test("shard writes coverage into a non-hidden directory", async () => {
+  const wf = await readWorkflow();
+  const run = stepsOf(wf, "coverage").find((s) => s.id === "run_shard")?.run;
+  assert(typeof run === "string", "coverage job must declare a run_shard step");
+  const covDir = run.match(/COV_DIR="([^"]+)"/);
+  assert(covDir, "run_shard must set COV_DIR");
+  assert(
+    !covDir[1].startsWith("."),
+    `COV_DIR must not be hidden (upload-artifact drops it), got: ${covDir[1]}`,
+  );
+});
+
+Deno.test("merge job runs the coverage gate before merging", async () => {
+  const wf = await readWorkflow();
+  const merge = stepsOf(wf, "merge");
+  const covStep = merge.find((s) =>
+    typeof s.run === "string" && s.run.includes("deno coverage")
+  );
+  assert(covStep?.run, "merge job must create the merged coverage report");
+  assert(
+    covStep.run.includes("scripts/coverage_merge_gate.ts"),
+    "merge job must consult the unit-tested coverage merge gate (Issue #3550)",
+  );
+  assert(
+    !/coverage_merge_gate\.ts[^\n]*\|\|\s*true/.test(covStep.run),
+    "the gate's failure must not be swallowed with `|| true`",
+  );
+  assert(
+    covStep.run.includes("coverage-*/") &&
+      !covStep.run.includes(".coverage-*/"),
+    "merge glob must match the non-hidden coverage dirs",
+  );
+});
+
+Deno.test("merge job fails loud on an empty lcov report", async () => {
+  const wf = await readWorkflow();
+  const covStep = stepsOf(wf, "merge").find((s) =>
+    typeof s.run === "string" && s.run.includes("deno coverage")
+  );
+  assert(covStep?.run, "merge job must create the merged coverage report");
+  // Producing no (or an empty) lcov after a successful merge would silently
+  // skip the Codecov upload via its `hashFiles` guard — exactly the silent
+  // failure Issue #3550 removes.
+  assert(
+    /\[\s+!?\s*-s\s+\.coverage\.lcov\s+\]/.test(covStep.run),
+    "merge step must assert the lcov report is non-empty and exit non-zero otherwise",
+  );
+});


### PR DESCRIPTION
# Coverage merge silently skipped: shard dirs were hidden and never uploaded

## Summary

The sharded coverage workflow wrote each shard's partial coverage into
`.coverage-<shard>/`. `actions/upload-artifact` defaults to
`include-hidden-files: false`, so that dot-prefixed directory was dropped from
the artifact — the merge job's glob came back empty, printed
`No shard coverage directories found; skipping coverage report`, and exited 0.
Coverage was silently lost while the run stayed green.

This PR removes the footgun rather than working around it (option 1 in the
issue) and adds the loud-failure guard:

- Shards now write **non-hidden** `coverage-<shard>/` dirs and upload that path.
- New unit-tested gate
  [`scripts/coverage_merge_gate.ts`](../../../scripts/coverage_merge_gate.ts):
  if any shard uploaded a `shard-status-<n>.txt` marker it ran tests, so at
  least one `coverage-<shard>/` dir MUST exist — an empty glob exits **1**. Only
  when nothing at all was uploaded does it exit **2** (skip), because the
  existing shard-status gate already fails that build.
- The merge step also asserts `.coverage.lcov` is non-empty, so a merge that
  produced no report fails instead of silently skipping the Codecov upload
  (whose `hashFiles` guard hid the problem).
- `.gitignore` ignores `coverage-*/` so the now-visible local dirs are never
  committed.

Closes #3550.

## Evidence

Backend/CI change — no web interface to screenshot.

```mermaid
flowchart TD
    G["Merge job: coverage_merge_gate.ts"] --> D{"coverage-*/ dirs?"}
    D -->|"yes"| M["deno coverage → .coverage.lcov"]
    D -->|"no, but shard-status-*.txt present"| F["❌ exit 1 — coverage lost"]
    D -->|"no artifacts at all"| S["exit 2 — skip; shard-status gate fails build"]
    M --> L{".coverage.lcov non-empty?"}
    L -->|"yes"| U["Upload to Codecov"]
    L -->|"no"| F2["❌ exit 1 — empty report"]
```

CLI behaviour of the new gate, run against a scratch directory:

```text
$ echo passed > shard-status-0.txt && deno run --allow-read scripts/coverage_merge_gate.ts
❌ 1 shard(s) uploaded a shard-status marker but no coverage-<shard>/ directory
   reached the merge job. Coverage would be silently lost — ...
exit=1

$ mkdir coverage-0 && deno run --allow-read scripts/coverage_merge_gate.ts
Merging coverage from: coverage-0
exit=0

$ rm -r coverage-0 shard-status-0.txt && deno run --allow-read scripts/coverage_merge_gate.ts
No shard artifacts of any kind were uploaded; the shard-status gate reports this
failure. Skipping the coverage report.
exit=2
```

`actionlint .github/workflows/coverage.yaml` passes with no findings.

Docs: the shard/merge flow in
[`docs/troubleshooting/CI.md`](../../troubleshooting/CI.md) is updated with a new
"Coverage must never go missing silently" section explaining the hidden-file
footgun and both guards.

## Test Plan

New — `test/ci/CoverageMergeGate.ts` (calls the real gate functions):

- merges when shards reported status and coverage arrived
- **fails loud** when shards reported status but no coverage arrived (the
  regression: this is exactly the PR #3549 scenario, and it fails against the
  old skip-and-exit-0 behaviour)
- fails loud for a single status-without-coverage shard
- skips only when nothing at all was uploaded
- merges coverage that arrived without a status file
- reports the directories being merged
- `isCoverageShardDir` rejects hidden `.coverage-0` and non-shard names
- `isShardStatusFile` recognises `shard-status-<n>.txt` only
- scanning a real temp directory: a hidden `.coverage-0` is not counted (gate
  fails), a real `coverage-0` is (gate merges)

New — `test/ci/CoverageShardArtifactPaths.ts` (parses the committed workflow):

- shard artifact upload lists no hidden paths and includes
  {% raw %}`coverage-${{ matrix.shard }}/`{% endraw %}
- `COV_DIR` is not dot-prefixed
- merge job invokes the gate before `deno coverage`, does not swallow it with
  `|| true`, and globs `coverage-*/`
- merge job asserts a non-empty `.coverage.lcov`

Existing `test/ci/*` workflow tests (shard matrix parity, OOM retry, job
timeouts, actionlint) continue to pass; `./quality.sh` was run over the full
suite.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-ms7qktpk-06f782`<!-- vibe-worker-issue-3550 -->