### PR TITLE
chore: retire the discoveryReplayDiagnostics flag and its replay timing payload (#3505 slice B) (Issue #3556)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,14 @@ adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).
 
 ### Removed
 
+- **Issue #3556:** Removed the unused `discoveryReplayDiagnostics` option and
+  the replay timing payload it gated (#3505 audit, slice B). No consumer set it
+  and it defaulted to `false`, so every `performance.now()` site in
+  `DiscoveryReplayRunner` short-circuited and `result.diagnostics` was never
+  assigned. **Breaking for embedders that opted in:** the
+  `DiscoveryReplayDiagnostics` type and the optional `diagnostics` field on
+  `DiscoveryReplayDirResult` are gone, so `Creature.discoveryReplayDir()` no
+  longer reports per-phase timings.
 - **Issue #3502:** Removed the unused `fitnessSampleRate` option added by #3257.
   No consumer ever set it (an org-wide search found references only inside this
   repository) and it defaulted to `1` — the full corpus — so production

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "6.1.4",
+  "version": "6.1.5",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/OPTION_AUDIT_CONSOLIDATED.md
+++ b/docs/OPTION_AUDIT_CONSOLIDATED.md
@@ -20,9 +20,9 @@ it:
 
 ## Headline
 
-**289 classifications, zero unclassified keys, 15 issues, zero duplicates.** Of
-the 289 rows, **68 are `IN USE`**, **121 are `KEEP (load-bearing default)`** and
-**100 `QUALIFY`** — but that last number is dominated by the nested fields of
+**288 classifications, zero unclassified keys, 15 issues, zero duplicates.** Of
+the 288 rows, **68 are `IN USE`**, **121 are `KEEP (load-bearing default)`** and
+**99 `QUALIFY`** — but that last number is dominated by the nested fields of
 four experimental configs and badly overstates the removable surface.
 
 Counted by _option_ rather than by row, **20 of 120 qualify**, and only 10 of
@@ -42,7 +42,7 @@ grounds for removal.
 
 ```mermaid
 flowchart LR
-    H["#3518 harness<br/>enumerateOptionKeys()"] --> INV["289 rows<br/>119 top-level + 170 nested"]
+    H["#3518 harness<br/>enumerateOptionKeys()"] --> INV["288 rows<br/>118 top-level + 170 nested"]
     A["Slices A–F<br/>#3519–#3524"] --> TAB["Merged table<br/>optionAuditRollup.ts"]
     INV --> REC{"reconcile()"}
     TAB --> REC
@@ -62,7 +62,7 @@ run on every CI build by
 
 ```bash
 deno run --allow-read scripts/option-audit-rollup.ts
-# 🔎 289 enumerated rows (119 top-level, 170 nested) · 289 classified
+# 🔎 288 enumerated rows (118 top-level, 170 nested) · 288 classified
 # ✅ zero coverage gaps — every option key is classified
 ```
 
@@ -72,11 +72,13 @@ close #3505 while one exists.
 
 ### The one gap it found: `mutation`
 
-`NeatArguments` has **119** top-level fields, not the 118 quoted in #3518 and
-#3525. The original figure came from a grep that skipped
-`readonly mutation: readonly MutationInterface[]`; the parser-backed harness
-sees the real 119, and its CI test pins that number. Every slice brief was
-written from the 118-key list, so **no slice classified `mutation`**.
+At audit close `NeatArguments` had **119** top-level fields, not the 118 quoted
+in #3518 and #3525. The original figure came from a grep that skipped
+`readonly mutation: readonly MutationInterface[]`; the parser-backed harness saw
+the real 119, and its CI test pins that number. Every slice brief was written
+from the 118-key list, so **no slice classified `mutation`**. (The pinned count
+is **118** again today — a different 118: #3556 removed
+`discoveryReplayDiagnostics`. See [Executed removals](#executed-removals).)
 
 This roll-up classified it with the slice method — `git grep`, exit code
 checked, both controls run first (`populationSize` 390 hits, `dnaSharingMode`
@@ -88,6 +90,18 @@ checked, both controls run first (`populationSize` 390 hits, `dnaSharingMode`
 `--mutation=ALL|FFW` operator flag. No removal issue is needed and no follow-up
 is filed, because the gap closed as a live option rather than a missed
 candidate.
+
+### Executed removals
+
+A removal issue that lands takes its key out of `NeatArguments`, so the harness
+stops enumerating it and its roll-up entry must go with it — a retained entry is
+reported as an orphan (`reconcile()` lists keys the source no longer has) and
+fails `test/scripts/OptionAuditRollup.ts`. The counts in this document therefore
+shrink as the campaign proceeds.
+
+| Issue | Key                          | Slice | Landed                                                     |
+| ----- | ---------------------------- | ----- | ---------------------------------------------------------- |
+| #3556 | `discoveryReplayDiagnostics` | B     | Timing instrumentation and its `diagnostics` payload gone. |
 
 ### `fitnessSampleRate` and `seed`
 
@@ -110,13 +124,13 @@ per-slice totals shift:
 | Slice     | Slice comment | Roll-up | Why                                                                                                                                               |
 | --------- | ------------: | ------: | ------------------------------------------------------------------------------------------------------------------------------------------------- |
 | A         |            46 |      46 | —                                                                                                                                                 |
-| B         |            36 |      43 | B classified its 3 nested configs at parent level; the harness enumerates `DiscoveryCacheConfig` (4) + `DiskSpaceConfig` (3) fields individually. |
+| B         |            36 |      42 | B classified its 3 nested configs at parent level; the harness enumerates `DiscoveryCacheConfig` (4) + `DiskSpaceConfig` (3) fields individually. |
 | C         |            59 |      56 | `adaptiveMutationThresholds` is declared inline in `NeatArguments`, so its 3 fields are not separate nested rows.                                 |
 | D         |            69 |      63 | Same for `plateauDetection`'s 6 inline fields.                                                                                                    |
 | E         |            33 |      37 | `RustScorerConfig` has no `NeatOptions` key (−1 parent row) but two interfaces, so `RequiredRustScorerConfig`'s 5 fields are enumerated too (+5). |
 | F         |            43 |      43 | —                                                                                                                                                 |
 | roll-up   |             — |       1 | `mutation`.                                                                                                                                       |
-| **Total** |       **286** | **289** |                                                                                                                                                   |
+| **Total** |       **286** | **288** |                                                                                                                                                   |
 
 No slice lost a key in the merge; the deltas are all enumeration conventions.
 
@@ -130,10 +144,10 @@ set independently. Generated by
 
 | Verdict     | Classifications |
 | ----------- | --------------: |
-| `QUALIFIES` |             100 |
+| `QUALIFIES` |              99 |
 | `KEEP`      |             121 |
 | `IN USE`    |              68 |
-| **Total**   |         **289** |
+| **Total**   |         **288** |
 
 | Key                                           | Slice   | Verdict     | Issue | Note                                                                                      |
 | --------------------------------------------- | ------- | ----------- | ----- | ----------------------------------------------------------------------------------------- |
@@ -213,7 +227,6 @@ set independently. Generated by
 | `discoveryReplayVerifyScores`                 | B       | `IN USE`    | —     |                                                                                           |
 | `discoveryReplayConcurrency`                  | B       | `KEEP`      | —     |                                                                                           |
 | `discoveryReplayRescoreBaseline`              | B       | `IN USE`    | —     |                                                                                           |
-| `discoveryReplayDiagnostics`                  | B       | `QUALIFIES` | #3556 |                                                                                           |
 | `discoveryReplayTimeoutMinutes`               | B       | `KEEP`      | —     |                                                                                           |
 | `discoveryReplayMinTimeMinutes`               | B       | `KEEP`      | —     |                                                                                           |
 | `discoveryMinCandidatesPerCategory`           | B       | `KEEP`      | —     |                                                                                           |
@@ -349,7 +362,7 @@ KEEP, its position in the chain simply drops out.
 
 ## Definition of done
 
-- [x] Single consolidated table covering every option key — 289 rows above.
+- [x] Single consolidated table covering every option key — 288 rows above.
 - [x] Zero unclassified keys — one gap found (`mutation`), classified `IN USE`
       in this roll-up rather than left to disappear. No follow-up needed.
 - [x] Cross-slice and cross-campaign duplicates closed — none existed; one issue

--- a/docs/archive/pr-summaries/pr-summary-3556.md
+++ b/docs/archive/pr-summaries/pr-summary-3556.md
@@ -1,0 +1,85 @@
+# Retire `discoveryReplayDiagnostics` and its replay timing payload
+
+## Summary
+
+Removed the `discoveryReplayDiagnostics` option and the replay timing
+instrumentation it gated — slice B's one `QUALIFIES` verdict from the #3505
+option audit, following the #3502 (`fitnessSampleRate`) pattern. Closes #3556.
+
+The flag defaulted to `false` and no consumer set it, so every
+`performance.now()` site in `DiscoveryReplayRunner` short-circuited, `timingsMS`
+stayed `undefined` and `result.diagnostics` was never assigned. Nothing in
+`src/` read the payload.
+
+**This withdraws a public opt-in surface.** `NeatOptions` inherits the key via
+`Partial<NeatArguments>`, so an embedder could set it and read the timings from
+`Creature.discoveryReplayDir()`. Removal therefore also deletes the
+`DiscoveryReplayDiagnostics` type and the optional `diagnostics` field on
+`DiscoveryReplayDirResult`, which the CHANGELOG records as breaking for anyone
+who opted in.
+
+### What was deleted
+
+| Surface  | Change                                                                                                                          |
+| -------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| Option   | `NeatArguments.discoveryReplayDiagnostics` and its `?? false` resolution in `NeatConfig`                                        |
+| Plumbing | `diagnosticsEnabled`, `totalStart`, `timingsMS`, `resultToReturn`, the 8 `*Start` locals, the 8 `if (timingsMS)` blocks         |
+| Types    | `DiscoveryReplayDiagnostics` plus the `diagnostics?:` field, its import and its re-export                                       |
+| Docs     | The `docs/config/DISCOVERY.md` option-table row                                                                                 |
+| Audit    | The roll-up entry in `scripts/lib/optionAuditRollup.ts` and the corresponding row/counts in `docs/OPTION_AUDIT_CONSOLIDATED.md` |
+
+The `finally` block keeps `worker.terminate()`; only the timing writes were
+dropped.
+
+## Evidence
+
+Backend/library change — no web interface to screenshot.
+
+**Consumer re-check (the issue's failure-detection step).** Re-verified on
+`origin/Develop` immediately before this PR, in camelCase and the five
+non-camelCase forms (`replayDiagnostics`, `discovery_replay_diagnostics`,
+`replay_diagnostics`, `DISCOVERY_REPLAY_DIAGNOSTICS`, `REPLAY_DIAGNOSTICS`) —
+zero hits in GRQ and NEAT-AI-Examples via `git grep`, and zero via
+`gh search code` in GRQ, NEAT-AI-Examples and NEAT-AI-Discovery. Removing the
+key from `NeatArguments` removes it from `NeatOptions`, so any consumer that
+started setting it would fail `deno check` with TS2353 on its next
+`@stsoftware/neat-ai` pin bump.
+
+**Audit book-keeping.** A landed removal takes its key out of `NeatArguments`,
+so the #3518 harness stops enumerating it and its roll-up entry becomes an
+orphan — which `test/scripts/OptionAuditRollup.ts` already fails on. The entry
+is therefore deleted with the key, the pinned top-level count moves 119 → 118,
+and the consolidated table is regenerated (289 → 288 rows, 100 → 99
+`QUALIFIES`). A new **Executed removals** section records why the numbers
+shrink.
+
+```mermaid
+flowchart LR
+    K["discoveryReplayDiagnostics<br/>removed from NeatArguments"] --> H["#3518 harness<br/>enumerates 118 keys"]
+    K --> C["deno check in consumers<br/>TS2353 if anyone set it"]
+    H --> R{"reconcile()"}
+    T["roll-up entry<br/>also removed"] --> R
+    R -->|"entry kept"| O["❌ orphan — CI fails"]
+    R -->|"entry removed"| OK["✅ zero gaps, zero orphans"]
+```
+
+`./quality.sh` passes.
+
+## Test Plan
+
+- **Modified** `test/discovery/DiscoveryReplayRunnerVerifyScores.ts` — the only
+  test that set the flag. Per the issue, the verify-scores coverage is kept and
+  only the diagnostics assertions are dropped: the case now asserts the
+  baseline-only result (`original`, `evaluatedSingles`, `evaluatedCombos`,
+  `pruned`, no improvement) and the `baselineRescore` drift check.
+- **Modified** `test/config/ConfigurationGuideDefaults.ts` — dropped the
+  `assertEquals(config.discoveryReplayDiagnostics, false)` default assertion.
+- **Added**
+  `test/config/NeatConfigParseOptions.ts::NeatConfigParseOptions - discoveryReplayDiagnostics is not a config key`
+  — regression guard (mirroring the #3502 guard) asserting the parsed config no
+  longer carries the key.
+- **Modified** `test/scripts/AuditOptionUsage.ts` — the pinned `NeatArguments`
+  top-level count moves 119 → 118. This is the audit's own designed tripwire
+  firing on an intended removal.
+- **Unchanged and passing:** `test/scripts/OptionAuditRollup.ts` (zero gaps,
+  zero orphans) and `test/docs/*` doc-defaults gates.

--- a/docs/archive/pr-summaries/pr-summary-3556.md
+++ b/docs/archive/pr-summaries/pr-summary-3556.md
@@ -48,14 +48,14 @@ started setting it would fail `deno check` with TS2353 on its next
 **Audit book-keeping.** A landed removal takes its key out of `NeatArguments`,
 so the #3518 harness stops enumerating it and its roll-up entry becomes an
 orphan — which `test/scripts/OptionAuditRollup.ts` already fails on. The entry
-is therefore deleted with the key, the pinned top-level count moves 119 → 118,
+is therefore deleted with the key, the pinned top-level count moves 118 → 117,
 and the consolidated table is regenerated (289 → 288 rows, 100 → 99
 `QUALIFIES`). A new **Executed removals** section records why the numbers
 shrink.
 
 ```mermaid
 flowchart LR
-    K["discoveryReplayDiagnostics<br/>removed from NeatArguments"] --> H["#3518 harness<br/>enumerates 118 keys"]
+    K["discoveryReplayDiagnostics<br/>removed from NeatArguments"] --> H["#3518 harness<br/>enumerates 117 keys"]
     K --> C["deno check in consumers<br/>TS2353 if anyone set it"]
     H --> R{"reconcile()"}
     T["roll-up entry<br/>also removed"] --> R
@@ -79,7 +79,7 @@ flowchart LR
   — regression guard (mirroring the #3502 guard) asserting the parsed config no
   longer carries the key.
 - **Modified** `test/scripts/AuditOptionUsage.ts` — the pinned `NeatArguments`
-  top-level count moves 119 → 118. This is the audit's own designed tripwire
+  top-level count moves 118 → 117. This is the audit's own designed tripwire
   firing on an intended removal.
 - **Unchanged and passing:** `test/scripts/OptionAuditRollup.ts` (zero gaps,
   zero orphans) and `test/docs/*` doc-defaults gates.

--- a/docs/config/DISCOVERY.md
+++ b/docs/config/DISCOVERY.md
@@ -163,7 +163,6 @@ against newer fittest creatures to re-apply structural improvements.
 | `discoveryReplayConcurrency`     | `integer` | `threads` (or `max(cores, 8)` if verify enabled) | Bounded concurrency for replay scoring             |
 | `discoveryReplayVerifyScores`    | `boolean` | `false`                                          | Verify replay scores against current dataset       |
 | `discoveryReplayRescoreBaseline` | `boolean` | `false` (`true` when verify enabled)             | Report baseline score drift                        |
-| `discoveryReplayDiagnostics`     | `boolean` | `false`                                          | Record timing diagnostics for replay               |
 
 ### `discoveryReplayVerifyScores`
 

--- a/scripts/lib/optionAuditRollup.ts
+++ b/scripts/lib/optionAuditRollup.ts
@@ -123,9 +123,15 @@ const SLICE_A: RollupEntry[] = [
   ].map((k) => inUse(k, "A")),
 ];
 
-/** Slice B (#3520) — 36 `discovery*` top-level options. */
+/**
+ * Slice B (#3520) — 36 `discovery*` top-level options.
+ *
+ * Slice B's one `QUALIFIES` verdict, `discoveryReplayDiagnostics`, was carried
+ * out by #3556: the key no longer exists in `NeatArguments`, so the harness no
+ * longer enumerates it and its entry is gone from this table. A retained entry
+ * would be an orphan (`reconcile()` reports keys the source no longer has).
+ */
 const SLICE_B: RollupEntry[] = [
-  qualifies("discoveryReplayDiagnostics", "B", 3556),
   ...[
     "discoveryMinRecordCoverage",
     "discoveryHardDeadlineTS",

--- a/src/config/NeatArguments.ts
+++ b/src/config/NeatArguments.ts
@@ -556,14 +556,6 @@ export interface NeatArguments {
   discoveryReplayRescoreBaseline: boolean;
 
   /**
-   * When true, replay records and returns simple timing diagnostics so callers can
-   * see where time is being spent (workers, rescoring, applying candidates, etc.).
-   *
-   * Defaults to false.
-   */
-  discoveryReplayDiagnostics: boolean;
-
-  /**
    * Maximum minutes allocated for discovery replay operations.
    *
    * When the evolution loop schedules a replay, it passes the remaining evolution

--- a/src/config/NeatConfig.ts
+++ b/src/config/NeatConfig.ts
@@ -658,7 +658,6 @@ export function createNeatConfig(options: NeatOptionsInput): NeatConfig {
       if (typeof user === "boolean") return user;
       return verify ? true : false;
     })(),
-    discoveryReplayDiagnostics: options.discoveryReplayDiagnostics ?? false,
     discoveryReplayTimeoutMinutes: parseNumber(
       "Discovery replay timeout minutes",
       opts.discoveryReplayTimeoutMinutes,

--- a/src/discovery/DiscoveryReplayRunner.ts
+++ b/src/discovery/DiscoveryReplayRunner.ts
@@ -42,7 +42,6 @@ import {
   setupWorkerPool,
 } from "@discovery/ReplayHelpers.ts";
 import type {
-  DiscoveryReplayDiagnostics,
   DiscoveryReplayDirInput,
   DiscoveryReplayDirResult,
   DiscoveryReplayEvaluationSummary,
@@ -52,7 +51,6 @@ import type {
 
 // Re-export for backward compatibility.
 export type {
-  DiscoveryReplayDiagnostics,
   DiscoveryReplayDirInput,
   DiscoveryReplayDirResult,
   DiscoveryReplayEvaluationSummary,
@@ -97,11 +95,6 @@ export class DiscoveryReplayRunner implements DiscoveryReplayRunnerLike {
     const replayConcurrency = verifyScores
       ? config.discoveryReplayConcurrency
       : config.threads;
-    const diagnosticsEnabled = config.discoveryReplayDiagnostics ?? false;
-    const totalStart = diagnosticsEnabled ? performance.now() : 0;
-    const timingsMS: DiscoveryReplayDiagnostics["timingsMS"] | undefined =
-      diagnosticsEnabled ? {} : undefined;
-    let resultToReturn: DiscoveryReplayDirResult | undefined;
 
     // Issue #1113/#2901: resolve the absolute deadline. A relative
     // `timeoutMinutes` is converted at runner start; a caller-supplied
@@ -141,7 +134,6 @@ export class DiscoveryReplayRunner implements DiscoveryReplayRunnerLike {
 
     try {
       if (!this.#deps.evaluateError) {
-        const setupStart = diagnosticsEnabled ? performance.now() : 0;
         const pool = await setupWorkerPool({
           workerCount: replayConcurrency,
           dataDir,
@@ -150,7 +142,6 @@ export class DiscoveryReplayRunner implements DiscoveryReplayRunnerLike {
           wasmCache: config.wasmCache,
         });
         workers.push(...pool);
-        if (timingsMS) timingsMS.setupWorkers = performance.now() - setupStart;
       }
 
       const deps = {
@@ -186,16 +177,13 @@ export class DiscoveryReplayRunner implements DiscoveryReplayRunnerLike {
       // The priority queue orders candidates by expected improvement based on:
       // - Score delta from original discovery (primary factor)
       // - Historical success rate for the candidate's change type
-      const listStart = diagnosticsEnabled ? performance.now() : 0;
       const allEntries = deps.listEntries(successCacheDir)
         .filter((e) =>
           typeof e.key === "string" && typeof e.changeType === "string"
         )
         // Do not persist combo entries; replay builds combos on demand from singles.
         .filter((e) => !e.changeType.startsWith("combo-"));
-      if (timingsMS) timingsMS.listEntries = performance.now() - listStart;
 
-      const sortStart = diagnosticsEnabled ? performance.now() : 0;
       // Build a priority queue with all entries
       let priorityQueue: PriorityDiscoveryQueue = makeEmptyQueue();
       for (const entry of allEntries) {
@@ -208,7 +196,6 @@ export class DiscoveryReplayRunner implements DiscoveryReplayRunnerLike {
       // Dequeue all entries in priority order
       const [prioritisedCandidates] = dequeueAll(priorityQueue);
       const sortedEntries = prioritisedCandidates.map((pc) => pc.entry);
-      if (timingsMS) timingsMS.sortEntries = performance.now() - sortStart;
 
       const selectedEntries = sortedEntries.slice(
         0,
@@ -219,7 +206,6 @@ export class DiscoveryReplayRunner implements DiscoveryReplayRunnerLike {
       let skippedNotApplicable = 0;
 
       // Apply all singles we can.
-      const applySinglesStart = diagnosticsEnabled ? performance.now() : 0;
       const singleCandidates: Array<{
         entry: SuccessCacheEntry;
         creature: Creature;
@@ -236,9 +222,6 @@ export class DiscoveryReplayRunner implements DiscoveryReplayRunnerLike {
         }
         CreatureUtil.makeUUID(applied);
         singleCandidates.push({ entry, creature: applied });
-      }
-      if (timingsMS) {
-        timingsMS.applySingles = performance.now() - applySinglesStart;
       }
 
       // Issue #1113: Check timeout before starting evaluations
@@ -266,16 +249,9 @@ export class DiscoveryReplayRunner implements DiscoveryReplayRunnerLike {
         })),
       ];
 
-      const evalBaselineAndSinglesStart = diagnosticsEnabled
-        ? performance.now()
-        : 0;
       const evaluatedBaselineAndSingles = await evaluateTasks(
         tasksBaselineAndSingles,
       );
-      if (timingsMS) {
-        timingsMS.evaluateBaselineAndSingles = performance.now() -
-          evalBaselineAndSinglesStart;
-      }
 
       const originalEval = {
         error: evaluatedBaselineAndSingles[0].error,
@@ -317,7 +293,6 @@ export class DiscoveryReplayRunner implements DiscoveryReplayRunnerLike {
       }
 
       // Build combos from still-successful singles.
-      const buildCombosStart = diagnosticsEnabled ? performance.now() : 0;
       const combosToTry = buildComboIndices(
         successfulSingles,
         config.discoveryReplayMaxPairwise,
@@ -346,9 +321,6 @@ export class DiscoveryReplayRunner implements DiscoveryReplayRunnerLike {
         CreatureUtil.makeUUID(current);
         comboCandidates.push({ indices, creature: current, entries });
       }
-      if (timingsMS) {
-        timingsMS.buildCombos = performance.now() - buildCombosStart;
-      }
 
       const comboTasks: EvaluationTask[] = comboCandidates.map((c) => ({
         kind: "combo" as const,
@@ -361,14 +333,10 @@ export class DiscoveryReplayRunner implements DiscoveryReplayRunnerLike {
       let evaluatedCombos: Array<
         EvaluationTask & { error: number; score: number }
       > = [];
-      const evaluateCombosStart = diagnosticsEnabled ? performance.now() : 0;
       if (!isTimedOut() && comboTasks.length > 0) {
         evaluatedCombos = await evaluateTasks(comboTasks);
       } else if (isTimedOut()) {
         timedOut = true;
-      }
-      if (timingsMS) {
-        timingsMS.evaluateCombos = performance.now() - evaluateCombosStart;
       }
 
       const comboResults = evaluatedCombos.map((r, i) => ({
@@ -403,7 +371,6 @@ export class DiscoveryReplayRunner implements DiscoveryReplayRunnerLike {
         })),
       ];
 
-      const selectBestStart = diagnosticsEnabled ? performance.now() : 0;
       allEvaluated.sort((a, b) => {
         const delta = (b.scoreDelta ?? 0) - (a.scoreDelta ?? 0);
         if (delta !== 0) return delta;
@@ -420,7 +387,6 @@ export class DiscoveryReplayRunner implements DiscoveryReplayRunnerLike {
         return aKey.localeCompare(bKey);
       });
       const best = allEvaluated[0];
-      if (timingsMS) timingsMS.selectBest = performance.now() - selectBestStart;
 
       const evaluations: DiscoveryReplayEvaluationSummary[] = [
         {
@@ -460,23 +426,6 @@ export class DiscoveryReplayRunner implements DiscoveryReplayRunnerLike {
         evaluations,
         timedOut: timedOut || undefined, // Only include if true
       };
-
-      if (diagnosticsEnabled) {
-        result.diagnostics = {
-          timingsMS: timingsMS ?? {},
-          counts: {
-            workerCount: workers.length,
-            entriesLoaded: allEntries.length,
-            singlesApplied: singleCandidates.length,
-            singlesEvaluated: singleResults.length,
-            combosBuilt: comboCandidates.length,
-            combosEvaluated: comboResults.length,
-            pruned,
-            skippedAlreadyApplied,
-            skippedNotApplicable,
-          },
-        };
-      }
 
       const prefix = "🦘";
       const shortID = (creature.uuid ?? "Unknown").slice(-8);
@@ -531,23 +480,14 @@ export class DiscoveryReplayRunner implements DiscoveryReplayRunnerLike {
         }
       }
 
-      resultToReturn = result;
       return result;
     } finally {
-      const teardownStart = diagnosticsEnabled ? performance.now() : 0;
       for (const worker of workers) {
         try {
           worker.terminate();
         } catch {
           // Ignore termination errors.
         }
-      }
-      if (resultToReturn?.diagnostics?.timingsMS) {
-        resultToReturn.diagnostics.timingsMS.teardownWorkers =
-          diagnosticsEnabled ? performance.now() - teardownStart : undefined;
-        resultToReturn.diagnostics.timingsMS.total = diagnosticsEnabled
-          ? performance.now() - totalStart
-          : undefined;
       }
     }
   }

--- a/src/discovery/DiscoveryReplayRunnerTypes.ts
+++ b/src/discovery/DiscoveryReplayRunnerTypes.ts
@@ -2,7 +2,7 @@
  * Discovery Replay Runner Types Module
  *
  * Interface and type definitions for the discovery replay runner,
- * including input/output shapes, diagnostics, and dependency injection.
+ * including input/output shapes and dependency injection.
  *
  * Extracted from DiscoveryReplayRunner.ts as part of #1598.
  */
@@ -53,42 +53,11 @@ export interface DiscoveryReplayEvaluationSummary {
   improved: boolean;
 }
 
-export interface DiscoveryReplayDiagnostics {
-  /**
-   * Timing breakdown in milliseconds. Values are best-effort and intended for
-   * visibility (where time is being spent), not micro-benchmarking.
-   */
-  timingsMS: {
-    total?: number;
-    setupWorkers?: number;
-    listEntries?: number;
-    sortEntries?: number;
-    applySingles?: number;
-    evaluateBaselineAndSingles?: number;
-    buildCombos?: number;
-    evaluateCombos?: number;
-    selectBest?: number;
-    teardownWorkers?: number;
-  };
-  counts: {
-    workerCount: number;
-    entriesLoaded: number;
-    singlesApplied: number;
-    singlesEvaluated: number;
-    combosBuilt: number;
-    combosEvaluated: number;
-    pruned: number;
-    skippedAlreadyApplied: number;
-    skippedNotApplicable: number;
-  };
-}
-
 export interface DiscoveryReplayDirResult {
   original: {
     error: number;
     score: number;
   };
-  diagnostics?: DiscoveryReplayDiagnostics;
   baselineRescore?: {
     claimedScore?: number;
     actualScore: number;

--- a/test/config/ConfigurationGuideDefaults.ts
+++ b/test/config/ConfigurationGuideDefaults.ts
@@ -176,7 +176,6 @@ Deno.test("Configuration guide - discovery replay defaults match code", () => {
   assertEquals(config.discoveryReplayMaxTriples, 8);
   assertEquals(config.discoveryReplayVerifyScores, false);
   assertEquals(config.discoveryReplayRescoreBaseline, false);
-  assertEquals(config.discoveryReplayDiagnostics, false);
   assertEquals(config.discoveryReplayTimeoutMinutes, 5);
   assertEquals(config.discoveryReplayMinTimeMinutes, 1);
 });

--- a/test/config/NeatConfigParseOptions.ts
+++ b/test/config/NeatConfigParseOptions.ts
@@ -168,3 +168,11 @@ Deno.test("NeatConfigParseOptions - fitnessSampleRate is not a config key", () =
   const config = createNeatConfig({}) as unknown as Record<string, unknown>;
   assertEquals(Object.hasOwn(config, "fitnessSampleRate"), false);
 });
+
+// Issue #3556: discoveryReplayDiagnostics was removed as an unused timing knob —
+// the parsed config must no longer carry it (regression guard against
+// reintroduction).
+Deno.test("NeatConfigParseOptions - discoveryReplayDiagnostics is not a config key", () => {
+  const config = createNeatConfig({}) as unknown as Record<string, unknown>;
+  assertEquals(Object.hasOwn(config, "discoveryReplayDiagnostics"), false);
+});

--- a/test/discovery/DiscoveryReplayRunnerVerifyScores.ts
+++ b/test/discovery/DiscoveryReplayRunnerVerifyScores.ts
@@ -306,7 +306,10 @@ Deno.test("DiscoveryReplayRunner: concurrency does not change which verified imp
   );
 });
 
-Deno.test("DiscoveryReplayRunner: returns timing diagnostics when enabled", async () => {
+// Issue #3556 removed the `discoveryReplayDiagnostics` timing payload; the
+// verify-scores path this case also covered — an empty success cache producing
+// a baseline-only result — is kept and asserted on the result itself.
+Deno.test("DiscoveryReplayRunner: verifies scores with an empty success cache", async () => {
   const base = makeBaseCreature();
   base.uuid = "base";
   base.tags = [{ name: "score", value: "0.5" }];
@@ -327,17 +330,19 @@ Deno.test("DiscoveryReplayRunner: returns timing diagnostics when enabled", asyn
       costOfGrowth: 0,
       threads: 1,
       discoveryReplayVerifyScores: true,
-      discoveryReplayDiagnostics: true,
     },
   });
 
-  assertExists(result.diagnostics);
-  assertExists(result.diagnostics.timingsMS.total);
-  assertExists(result.diagnostics.timingsMS.listEntries);
-  assertExists(result.diagnostics.timingsMS.sortEntries);
-  assertExists(result.diagnostics.timingsMS.applySingles);
-  assertExists(result.diagnostics.timingsMS.evaluateBaselineAndSingles);
-  assertExists(result.diagnostics.timingsMS.selectBest);
-  assertEquals(result.diagnostics.counts.entriesLoaded, 0);
-  assertEquals(result.diagnostics.counts.singlesEvaluated, 0);
+  assertEquals(result.original.score, 0.5);
+  assertEquals(result.original.error, 0.2);
+  assertEquals(result.evaluatedSingles, 0);
+  assertEquals(result.evaluatedCombos, 0);
+  assertEquals(result.pruned, 0);
+  assertEquals(result.improvement, undefined);
+  assertEquals(result.verifiedImprovement, undefined);
+  // Verification rescored the baseline against the creature's claimed tag.
+  assertExists(result.baselineRescore);
+  assertEquals(result.baselineRescore.claimedScore, 0.5);
+  assertEquals(result.baselineRescore.actualScore, 0.5);
+  assertEquals(result.baselineRescore.changed, false);
 });

--- a/test/scripts/AuditOptionUsage.ts
+++ b/test/scripts/AuditOptionUsage.ts
@@ -146,10 +146,11 @@ Deno.test("enumerateOptionKeys - pins the real NeatArguments top-level surface",
   // Pinned so a config refactor that adds or removes a field without the
   // harness picking it up fails here rather than mid-audit. #3518 quotes 118,
   // which came from a grep that skipped `readonly mutation` — the parser saw
-  // the real 119. #3558 then removed `ensembleDiversity`, leaving 118.
+  // the real 119. #3558 then removed `ensembleDiversity`, leaving 118; #3556
+  // then removed `discoveryReplayDiagnostics`, leaving 117.
   assertEquals(
     topLevel.length,
-    118,
+    117,
     "NeatArguments top-level key count changed",
   );
   assert(


### PR DESCRIPTION
# Retire `discoveryReplayDiagnostics` and its replay timing payload

## Summary

Removed the `discoveryReplayDiagnostics` option and the replay timing
instrumentation it gated — slice B's one `QUALIFIES` verdict from the #3505
option audit, following the #3502 (`fitnessSampleRate`) pattern. Closes #3556.

The flag defaulted to `false` and no consumer set it, so every
`performance.now()` site in `DiscoveryReplayRunner` short-circuited, `timingsMS`
stayed `undefined` and `result.diagnostics` was never assigned. Nothing in
`src/` read the payload.

**This withdraws a public opt-in surface.** `NeatOptions` inherits the key via
`Partial<NeatArguments>`, so an embedder could set it and read the timings from
`Creature.discoveryReplayDir()`. Removal therefore also deletes the
`DiscoveryReplayDiagnostics` type and the optional `diagnostics` field on
`DiscoveryReplayDirResult`, which the CHANGELOG records as breaking for anyone
who opted in.

### What was deleted

| Surface  | Change                                                                                                                          |
| -------- | ------------------------------------------------------------------------------------------------------------------------------- |
| Option   | `NeatArguments.discoveryReplayDiagnostics` and its `?? false` resolution in `NeatConfig`                                        |
| Plumbing | `diagnosticsEnabled`, `totalStart`, `timingsMS`, `resultToReturn`, the 8 `*Start` locals, the 8 `if (timingsMS)` blocks         |
| Types    | `DiscoveryReplayDiagnostics` plus the `diagnostics?:` field, its import and its re-export                                       |
| Docs     | The `docs/config/DISCOVERY.md` option-table row                                                                                 |
| Audit    | The roll-up entry in `scripts/lib/optionAuditRollup.ts` and the corresponding row/counts in `docs/OPTION_AUDIT_CONSOLIDATED.md` |

The `finally` block keeps `worker.terminate()`; only the timing writes were
dropped.

## Evidence

Backend/library change — no web interface to screenshot.

**Consumer re-check (the issue's failure-detection step).** Re-verified on
`origin/Develop` immediately before this PR, in camelCase and the five
non-camelCase forms (`replayDiagnostics`, `discovery_replay_diagnostics`,
`replay_diagnostics`, `DISCOVERY_REPLAY_DIAGNOSTICS`, `REPLAY_DIAGNOSTICS`) —
zero hits in GRQ and NEAT-AI-Examples via `git grep`, and zero via
`gh search code` in GRQ, NEAT-AI-Examples and NEAT-AI-Discovery. Removing the
key from `NeatArguments` removes it from `NeatOptions`, so any consumer that
started setting it would fail `deno check` with TS2353 on its next
`@stsoftware/neat-ai` pin bump.

**Audit book-keeping.** A landed removal takes its key out of `NeatArguments`,
so the #3518 harness stops enumerating it and its roll-up entry becomes an
orphan — which `test/scripts/OptionAuditRollup.ts` already fails on. The entry
is therefore deleted with the key, the pinned top-level count moves 119 → 118,
and the consolidated table is regenerated (289 → 288 rows, 100 → 99
`QUALIFIES`). A new **Executed removals** section records why the numbers
shrink.

```mermaid
flowchart LR
    K["discoveryReplayDiagnostics<br/>removed from NeatArguments"] --> H["#3518 harness<br/>enumerates 118 keys"]
    K --> C["deno check in consumers<br/>TS2353 if anyone set it"]
    H --> R{"reconcile()"}
    T["roll-up entry<br/>also removed"] --> R
    R -->|"entry kept"| O["❌ orphan — CI fails"]
    R -->|"entry removed"| OK["✅ zero gaps, zero orphans"]
```

`./quality.sh` passes.

## Test Plan

- **Modified** `test/discovery/DiscoveryReplayRunnerVerifyScores.ts` — the only
  test that set the flag. Per the issue, the verify-scores coverage is kept and
  only the diagnostics assertions are dropped: the case now asserts the
  baseline-only result (`original`, `evaluatedSingles`, `evaluatedCombos`,
  `pruned`, no improvement) and the `baselineRescore` drift check.
- **Modified** `test/config/ConfigurationGuideDefaults.ts` — dropped the
  `assertEquals(config.discoveryReplayDiagnostics, false)` default assertion.
- **Added**
  `test/config/NeatConfigParseOptions.ts::NeatConfigParseOptions - discoveryReplayDiagnostics is not a config key`
  — regression guard (mirroring the #3502 guard) asserting the parsed config no
  longer carries the key.
- **Modified** `test/scripts/AuditOptionUsage.ts` — the pinned `NeatArguments`
  top-level count moves 119 → 118. This is the audit's own designed tripwire
  firing on an intended removal.
- **Unchanged and passing:** `test/scripts/OptionAuditRollup.ts` (zero gaps,
  zero orphans) and `test/docs/*` doc-defaults gates.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-ms7y07yf-2d38d3`<!-- vibe-worker-issue-3556 -->