### PR TITLE
Worker start heartbeat: distinguish "never started" from "started and stalled" (stSoftwareAU/GRQ#3771)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "6.1.3",
+  "version": "6.1.4",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-worker-start-heartbeat.md
+++ b/docs/archive/pr-summaries/pr-summary-worker-start-heartbeat.md
@@ -29,7 +29,7 @@ No behaviour change: the direct-execution fallback, the timeout value, and the
 existing greppable field names are all untouched — the timeout message gains one
 field and one closing sentence.
 
-Raised for `stSoftwareAU/GRQ#3771`.
+Raised for the orchestration repo's worker-init timeout tracking issue.
 
 ### Design notes
 

--- a/docs/archive/pr-summaries/pr-summary-worker-start-heartbeat.md
+++ b/docs/archive/pr-summaries/pr-summary-worker-start-heartbeat.md
@@ -1,0 +1,90 @@
+# Worker start heartbeat — tell "never started" apart from "started and stalled"
+
+## Summary
+
+The #3494 worker-init timeout diagnostic names three candidates but cannot tell
+them apart:
+
+```text
+Child WASM phase timings unknown — the worker never answered the init handshake
+(may be stuck loading WASM, CPU-starved, or OOM).
+```
+
+A `stSoftwareAU/GRQ` `team` run lost five worker slots to that 60-second
+handshake with `cache=hit`, `bundleLoadMs=2`, `instantiateMs=1`,
+`wasmTotalMs=20` and `workerError=none` — the parent loaded and instantiated the
+bundle in 20 ms, so "stuck loading WASM" was already ruled out, yet nothing in
+the log said whether the child isolate had ever started.
+
+This adds a **start heartbeat**: the child posts one message as soon as its
+module has evaluated and its message loop is installed, _before_ any init work.
+The parent records receipt and the timeout error now reports it:
+
+- `heartbeat=received heartbeatMs=N` — the isolate started, then stalled;
+  suspect CPU starvation or a stuck init.
+- `heartbeat=none` — the isolate never reached its entry point; suspect spawn
+  starvation or OOM.
+
+No behaviour change: the direct-execution fallback, the timeout value, and the
+existing greppable field names are all untouched — the timeout message gains one
+field and one closing sentence.
+
+Raised for `stSoftwareAU/GRQ#3771`.
+
+### Design notes
+
+`WorkerHandlerBase`'s task-callback map asserts a callback exists for every
+message it routes, so an unsolicited task-shaped message would throw
+`No callback` and kill init. The heartbeat therefore carries a single
+unmistakable field (`neatAiWorkerHeartbeat`) and the parent's listener takes it
+off the wire before task routing sees it.
+
+`setupWorkerMessageLoop` is the single entry point both the multithreading and
+intelligentDesign workers reach, and `createInitSequence` is the single choke
+point every pooled worker reaches via `waitUntilReady()` — so both halves are
+one-site changes that cover every worker pool.
+
+## Evidence
+
+Library change with no web interface, so no screenshot. Evidence is the test
+suite plus the lint/type gates:
+
+```mermaid
+sequenceDiagram
+    participant P as Parent (WorkerHandlerBase)
+    participant C as Child (workerEntryPoint)
+    P->>C: new Worker(...)
+    C-->>P: heartbeat {phase: loaded}
+    Note over P: heartbeatAtMs recorded
+    P->>C: initialize
+    alt child answers
+        C-->>P: initialize OK
+    else child stalls
+        Note over P: timeout → heartbeat=received (started, then stalled)
+    end
+    Note over P: no heartbeat at all → heartbeat=none (never started)
+```
+
+```text
+deno test test/workers/ test/multithreading/ test/intelligentDesign/Worker*.ts
+  ... ok | 186 passed | 0 failed
+./quality.sh --lint-only   ... ✅
+./quality.sh --check-only  ... ✅
+```
+
+## Test Plan
+
+- **`test/workers/WorkerStartHeartbeat.ts`** (new):
+  - a stalled child that sent no heartbeat → timeout error carries
+    `heartbeat=none` and the "did not reach its entry point" verdict;
+  - a stalled child that sent one → `heartbeat=received heartbeatMs=…` and the
+    "then stalled before answering" verdict;
+  - the two messages differ (the point of the change);
+  - a heartbeat is never routed as a task response (would throw `No callback`);
+  - `setupWorkerMessageLoop` posts exactly one heartbeat on start, before any
+    init work;
+  - `isWorkerHeartbeatMessage` rejects task responses, `null`, strings, and
+    malformed payloads.
+- Existing `test/workers/WorkerInitDiagnostics.ts` and
+  `test/wasm/WasmInitDiagnostics.ts` remain green — the pre-existing fields of
+  the timeout contract are unchanged.

--- a/src/wasm/WasmInitDiagnostics.ts
+++ b/src/wasm/WasmInitDiagnostics.ts
@@ -31,9 +31,14 @@
  *
  *    ```text
  *    [WasmWorkerInit] Worker init: no response after 60s (worker=worker-3). \
- *      Parent-observed: handshakeMs=60001 workerError=none wasm[cache=hit …]. \
- *      Child WASM phase timings unknown — the worker never answered …
+ *      Parent-observed: handshakeMs=60001 workerError=none heartbeat=none \
+ *      wasm[cache=hit …]. Child WASM phase timings unknown — the worker never \
+ *      answered … The child never sent its start heartbeat …
  *    ```
+ *
+ *    `heartbeat=received heartbeatMs=N` / `heartbeat=none` (Issue #3771) is
+ *    the field that separates a child which started and then stalled from one
+ *    that never started at all.
  *
  * The phrases "no response after Ns" and "stuck loading WASM" are preserved so
  * existing operator greps keep matching.
@@ -184,28 +189,64 @@ export interface WorkerInitTimeoutInput {
   wasm: WasmActivationInitDiagnostics | null;
   /** Any worker `error`/`messageerror` captured during init. */
   workerError?: Error;
+  /**
+   * Milliseconds into the handshake at which the child's start heartbeat
+   * arrived, or `undefined` when it never did (Issue #3771).
+   */
+  heartbeatMs?: number;
+}
+
+/**
+ * The `heartbeat=…` field and the sentence that reads it (Issue #3771).
+ *
+ * A received heartbeat proves the child isolate started and evaluated its
+ * entry point, so a subsequent stall is inside the worker (CPU starvation or a
+ * stuck init) rather than a spawn that never happened. No heartbeat means the
+ * isolate never got that far — spawn starvation or OOM.
+ */
+function heartbeatFields(
+  heartbeatMs: number | undefined,
+): { field: string; verdict: string } {
+  if (heartbeatMs === undefined) {
+    return {
+      field: "heartbeat=none",
+      verdict: "The child never sent its start heartbeat, so it did not " +
+        "reach its entry point — suspect spawn starvation or OOM, not WASM " +
+        "loading.",
+    };
+  }
+  return {
+    field: `heartbeat=received heartbeatMs=${ms(heartbeatMs)}`,
+    verdict: "The child sent its start heartbeat and then stalled before " +
+      "answering — suspect CPU starvation or a stuck init, not a failed spawn.",
+  };
 }
 
 /**
  * Build the timeout error message. The breakdown is embedded here (not merely
  * logged) so it survives into the caller's `Error:`-suffixed fallback log line
- * and GRQ's `firstError=` field. Child-side phase timings are explicitly
- * flagged unknown, since a worker that never answered cannot report them.
+ * and GRQ's `firstError=` field. Child-side phase timings are still unknown —
+ * a worker that never answered cannot report them — but the start heartbeat
+ * (Issue #3771) says whether the child ever ran, which is what separates the
+ * "never started" and "started and stalled" cases the phase timings cannot.
  */
 export function formatWorkerInitTimeout(
   input: WorkerInitTimeoutInput,
 ): string {
-  const { workerLabel, timeoutMs, elapsedMs, wasm, workerError } = input;
+  const { workerLabel, timeoutMs, elapsedMs, wasm, workerError, heartbeatMs } =
+    input;
   const seconds = Math.round(timeoutMs / 1000);
   const parentWasm = wasm
     ? `wasm[${bundleFields(wasm)}]`
     : "wasm[not-measured]";
+  const heartbeat = heartbeatFields(heartbeatMs);
   return `${WASM_WORKER_INIT_LOG_PREFIX} Worker init: no response after ` +
     `${seconds}s (worker=${workerLabel}). Parent-observed: ` +
     `handshakeMs=${ms(elapsedMs)} workerError=${
       workerErrorField(workerError)
     } ` +
+    `${heartbeat.field} ` +
     `${parentWasm}. Child WASM phase timings unknown — the worker never ` +
     `answered the init handshake (may be stuck loading WASM, CPU-starved, ` +
-    `or OOM).`;
+    `or OOM). ${heartbeat.verdict}`;
 }

--- a/src/workers/WorkerHandlerBase.ts
+++ b/src/workers/WorkerHandlerBase.ts
@@ -18,6 +18,7 @@ import type {
   WorkerInterface,
 } from "@workers/WorkerInterface.ts";
 import { getLogger, type Logger } from "@utils/Logger.ts";
+import { isWorkerHeartbeatMessage } from "@workers/WorkerHeartbeat.ts";
 import {
   formatWorkerInitDiagnostics,
   formatWorkerInitTimeout,
@@ -221,6 +222,12 @@ export abstract class WorkerHandlerBase<
   protected ready: Promise<TResponse>;
   /** Captured worker error during initialisation (if any). */
   protected initWorkerError?: Error;
+  /**
+   * `performance.now()` at which the child's start heartbeat arrived, or
+   * `undefined` when it never did (Issue #3771). This is what separates a
+   * child that never started from one that started and then stalled.
+   */
+  private heartbeatAtMs?: number;
 
   /**
    * Creates a new WorkerHandlerBase.
@@ -236,6 +243,13 @@ export abstract class WorkerHandlerBase<
 
     this.worker.addEventListener("message", (message) => {
       const me = message as MessageEvent;
+      // Issue #3771: the child's start heartbeat is not a task response —
+      // take it off the wire before task routing, which asserts a callback
+      // exists for every message it sees.
+      if (isWorkerHeartbeatMessage(me.data)) {
+        this.heartbeatAtMs = performance.now();
+        return;
+      }
       this.handleCallback(me.data as TResponse);
     });
 
@@ -343,6 +357,11 @@ export abstract class WorkerHandlerBase<
                   elapsedMs: performance.now() - startMs,
                   wasm: getLastWasmActivationInitDiagnostics(),
                   workerError: this.initWorkerError,
+                  // Clamped: a heartbeat that beat the init request to the
+                  // parent is 0 ms into the handshake, never negative.
+                  heartbeatMs: this.heartbeatAtMs === undefined
+                    ? undefined
+                    : Math.max(0, this.heartbeatAtMs - startMs),
                 }),
               ),
             ),

--- a/src/workers/WorkerHeartbeat.ts
+++ b/src/workers/WorkerHeartbeat.ts
@@ -1,0 +1,63 @@
+/**
+ * Worker start heartbeat (Issue #3771).
+ *
+ * When a pooled worker misses its init handshake the parent can only report
+ * what it can see, and the timeout diagnostic (Issue #3494) says so:
+ *
+ * ```text
+ * Child WASM phase timings unknown — the worker never answered the init
+ * handshake (may be stuck loading WASM, CPU-starved, or OOM).
+ * ```
+ *
+ * That leaves the two most likely causes indistinguishable. A GRQ-23 `team`
+ * run lost five slots with `cache=hit`, `wasmTotalMs=20` and
+ * `workerError=none` — the parent's own WASM work took 20 ms, so "stuck
+ * loading WASM" was already ruled out, yet nothing in the log said whether the
+ * worker isolate had even started.
+ *
+ * The heartbeat closes that gap with one message: the child posts it as soon
+ * as its module has evaluated and its message loop is installed — *before* any
+ * init work. The parent records receipt, so the timeout error can report
+ * `heartbeat=received` (the isolate started, then stalled — CPU starvation or
+ * a stuck init) or `heartbeat=none` (the isolate never got far enough to run
+ * its own entry point — spawn starvation or OOM).
+ *
+ * The message deliberately carries a single, unmistakable field rather than a
+ * `taskID`: the parent's callback map is keyed by task and asserts a callback
+ * exists for every response, so an unsolicited task-shaped message would
+ * throw. {@link isWorkerHeartbeatMessage} lets the parent's listener take the
+ * heartbeat off the wire before task routing sees it.
+ *
+ * @module
+ */
+
+/** Field name identifying a heartbeat message. Part of the wire contract. */
+export const WORKER_HEARTBEAT_FIELD = "neatAiWorkerHeartbeat";
+
+/** Lifecycle point a heartbeat was emitted from. */
+export type WorkerHeartbeatPhase = "loaded";
+
+/** The message a child posts to announce it is alive. */
+export interface WorkerHeartbeatMessage {
+  [WORKER_HEARTBEAT_FIELD]: { phase: WorkerHeartbeatPhase };
+}
+
+/** Build the heartbeat message for `phase`. */
+export function buildWorkerHeartbeatMessage(
+  phase: WorkerHeartbeatPhase = "loaded",
+): WorkerHeartbeatMessage {
+  return { [WORKER_HEARTBEAT_FIELD]: { phase } };
+}
+
+/**
+ * True when `data` is a heartbeat rather than a task response. Callers must
+ * check this before routing a message to the task-callback map.
+ */
+export function isWorkerHeartbeatMessage(
+  data: unknown,
+): data is WorkerHeartbeatMessage {
+  if (typeof data !== "object" || data === null) return false;
+  const beat = (data as Record<string, unknown>)[WORKER_HEARTBEAT_FIELD];
+  if (typeof beat !== "object" || beat === null) return false;
+  return typeof (beat as { phase?: unknown }).phase === "string";
+}

--- a/src/workers/workerEntryPoint.ts
+++ b/src/workers/workerEntryPoint.ts
@@ -15,6 +15,7 @@ import type {
   BaseResponseData,
 } from "@workers/WorkerInterface.ts";
 import { getInitTimeoutMs } from "@workers/WorkerHandlerBase.ts";
+import { buildWorkerHeartbeatMessage } from "@workers/WorkerHeartbeat.ts";
 import {
   currentHeapLimitMb,
   planWorkerHeapBudget,
@@ -100,6 +101,15 @@ export function setupWorkerMessageLoop<
 ): void {
   const INIT_TIMEOUT_MS = getInitTimeoutMs();
   const workerSelf = self as unknown as WorkerSelf<TRequest, TResponse>;
+
+  // Announce the isolate is alive BEFORE any init work (Issue #3771). The
+  // parent records receipt so a missed handshake can report whether the child
+  // ever started — `heartbeat=none` (never started: spawn starvation or OOM)
+  // versus `heartbeat=received` (started, then stalled). Emitting it here, at
+  // the end of module evaluation, is the earliest point the child controls.
+  workerSelf.postMessage(
+    buildWorkerHeartbeatMessage("loaded") as unknown as TResponse,
+  );
 
   workerSelf.onmessage = async function (message: { data: TRequest }) {
     const start = Date.now();

--- a/test/workers/WorkerStartHeartbeat.ts
+++ b/test/workers/WorkerStartHeartbeat.ts
@@ -129,7 +129,8 @@ Deno.test("#3771: the two stall cases produce different diagnostics", async () =
 
 Deno.test("#3771: a heartbeat is not routed as a task response", async () => {
   // The task-callback map asserts a callback exists for every message it
-  // sees, so an unrouted heartbeat would throw "No callback" and kill init.
+  // sees, so a heartbeat reaching that map would throw "No callback" and kill
+  // init.
   resetWasmActivationInitDiagnostics();
   const worker = new StalledWorker(true);
   const handler = new Handler(

--- a/test/workers/WorkerStartHeartbeat.ts
+++ b/test/workers/WorkerStartHeartbeat.ts
@@ -1,0 +1,187 @@
+/**
+ * Issue #3771 — a child that misses its init handshake must still say whether
+ * it ever started.
+ *
+ * The #3494 timeout diagnostic names three candidates ("stuck loading WASM,
+ * CPU-starved, or OOM") but cannot tell them apart, so a GRQ-23 `team` run
+ * with `cache=hit wasmTotalMs=20 workerError=none` and five 60-second stalls
+ * left the actual cause unknown. The child now posts a start heartbeat before
+ * any init work, and the timeout error reports it:
+ *
+ *   - `heartbeat=received` — the isolate started, then stalled;
+ *   - `heartbeat=none`     — the isolate never reached its entry point.
+ *
+ * These tests drive the real `createInitSequence` choke point and the real
+ * entry-point message loop, asserting on the error text an operator greps.
+ */
+
+import {
+  assert,
+  assertEquals,
+  assertRejects,
+  assertStringIncludes,
+} from "@std/assert";
+import type {
+  BaseRequestData,
+  BaseResponseData,
+  WorkerInterface,
+} from "@workers/WorkerInterface.ts";
+import { WorkerHandlerBase } from "@workers/WorkerHandlerBase.ts";
+import {
+  buildWorkerHeartbeatMessage,
+  isWorkerHeartbeatMessage,
+  WORKER_HEARTBEAT_FIELD,
+} from "@workers/WorkerHeartbeat.ts";
+import { setupWorkerMessageLoop } from "@workers/workerEntryPoint.ts";
+import { resetWasmActivationInitDiagnostics } from "@wasm/WasmInitDiagnostics.ts";
+
+interface TestRequest extends BaseRequestData {
+  initialize?: { payload: string };
+}
+interface TestResponse extends BaseResponseData {
+  initialize?: { status: string };
+}
+
+/**
+ * A worker that never answers the init handshake, optionally emitting the
+ * start heartbeat first — the two cases the diagnostic must distinguish.
+ */
+class StalledWorker implements WorkerInterface<TestRequest> {
+  private callBack: EventListener | null = null;
+  constructor(private readonly sendHeartbeat: boolean) {}
+
+  addEventListener(
+    _type: string,
+    listener: EventListenerOrEventListenerObject,
+  ): void {
+    this.callBack = listener as EventListener;
+    if (this.sendHeartbeat) this.emit(buildWorkerHeartbeatMessage("loaded"));
+  }
+
+  postMessage(_data: TestRequest): void {
+    // Stalled: the init request is never answered.
+  }
+
+  terminate(): void {
+    this.callBack = null;
+  }
+
+  private emit(data: unknown): void {
+    type MockEvent = Event & { data: unknown };
+    const event = new Event("message") as MockEvent;
+    event.data = data;
+    this.callBack?.(event);
+  }
+}
+
+class Handler extends WorkerHandlerBase<TestRequest, TestResponse> {
+  runInit(timeoutMs: number, label: string): Promise<TestResponse> {
+    return this.createInitSequence(
+      { taskID: 1, initialize: { payload: "x" } },
+      new Promise<never>(() => {}),
+      timeoutMs,
+      label,
+    );
+  }
+}
+
+async function timeoutMessage(sendHeartbeat: boolean): Promise<string> {
+  resetWasmActivationInitDiagnostics();
+  const worker = new StalledWorker(sendHeartbeat);
+  const handler = new Handler(
+    worker,
+    Promise.resolve({ taskID: 0, duration: 0, initialize: { status: "OK" } }),
+  );
+  const error = await assertRejects(
+    () => handler.runInit(50, "worker-26"),
+    Error,
+    "no response after",
+  );
+  handler.terminate();
+  return error.message;
+}
+
+Deno.test("#3771: a child that never started reports heartbeat=none", async () => {
+  const message = await timeoutMessage(false);
+  assertStringIncludes(message, "heartbeat=none");
+  assertStringIncludes(message, "did not reach its entry point");
+  assert(
+    !message.includes("heartbeat=received"),
+    "a missing heartbeat must never read as received",
+  );
+});
+
+Deno.test("#3771: a child that started then stalled reports heartbeat=received", async () => {
+  const message = await timeoutMessage(true);
+  assertStringIncludes(message, "heartbeat=received");
+  assertStringIncludes(message, "heartbeatMs=");
+  assertStringIncludes(message, "then stalled before answering");
+});
+
+Deno.test("#3771: the two stall cases produce different diagnostics", async () => {
+  const never = await timeoutMessage(false);
+  const stalled = await timeoutMessage(true);
+  assert(
+    never !== stalled,
+    "the whole point is that the operator can tell the two apart",
+  );
+});
+
+Deno.test("#3771: a heartbeat is not routed as a task response", async () => {
+  // The task-callback map asserts a callback exists for every message it
+  // sees, so an unrouted heartbeat would throw "No callback" and kill init.
+  resetWasmActivationInitDiagnostics();
+  const worker = new StalledWorker(true);
+  const handler = new Handler(
+    worker,
+    Promise.resolve({ taskID: 0, duration: 0, initialize: { status: "OK" } }),
+  );
+  const error = await assertRejects(
+    () => handler.runInit(50, "worker-1"),
+    Error,
+  );
+  assertStringIncludes(error.message, "no response after");
+  handler.terminate();
+});
+
+Deno.test("#3771: the entry point announces itself before any init work", () => {
+  const posted: unknown[] = [];
+  const scope = self as unknown as {
+    onmessage: unknown;
+    postMessage: (data: unknown) => void;
+  };
+  const originalOnMessage = scope.onmessage;
+  const originalPost = scope.postMessage;
+  scope.postMessage = (data: unknown) => posted.push(data);
+  try {
+    setupWorkerMessageLoop<TestRequest, TestResponse>(
+      {
+        process: () =>
+          Promise.resolve({ taskID: 1, duration: 0 } as TestResponse),
+      },
+      (data) => ({ taskID: data.taskID, duration: 0 }),
+    );
+  } finally {
+    scope.postMessage = originalPost;
+    scope.onmessage = originalOnMessage;
+  }
+
+  assertEquals(posted.length, 1, "exactly one heartbeat on start");
+  assert(
+    isWorkerHeartbeatMessage(posted[0]),
+    `first message must be the start heartbeat, got ${
+      JSON.stringify(
+        posted[0],
+      )
+    }`,
+  );
+});
+
+Deno.test("#3771: only well-formed heartbeats are recognised", () => {
+  assert(isWorkerHeartbeatMessage(buildWorkerHeartbeatMessage("loaded")));
+  assert(!isWorkerHeartbeatMessage({ taskID: 1, duration: 0 }));
+  assert(!isWorkerHeartbeatMessage(null));
+  assert(!isWorkerHeartbeatMessage("loaded"));
+  assert(!isWorkerHeartbeatMessage({ [WORKER_HEARTBEAT_FIELD]: "loaded" }));
+  assert(!isWorkerHeartbeatMessage({ [WORKER_HEARTBEAT_FIELD]: {} }));
+});


### PR DESCRIPTION
# Worker start heartbeat — tell "never started" apart from "started and stalled"

## Summary

The #3494 worker-init timeout diagnostic names three candidates but cannot tell
them apart:

```text
Child WASM phase timings unknown — the worker never answered the init handshake
(may be stuck loading WASM, CPU-starved, or OOM).
```

A `stSoftwareAU/GRQ` `team` run lost five worker slots to that 60-second
handshake with `cache=hit`, `bundleLoadMs=2`, `instantiateMs=1`,
`wasmTotalMs=20` and `workerError=none` — the parent loaded and instantiated the
bundle in 20 ms, so "stuck loading WASM" was already ruled out, yet nothing in
the log said whether the child isolate had ever started.

This adds a **start heartbeat**: the child posts one message as soon as its
module has evaluated and its message loop is installed, _before_ any init work.
The parent records receipt and the timeout error now reports it:

- `heartbeat=received heartbeatMs=N` — the isolate started, then stalled;
  suspect CPU starvation or a stuck init.
- `heartbeat=none` — the isolate never reached its entry point; suspect spawn
  starvation or OOM.

No behaviour change: the direct-execution fallback, the timeout value, and the
existing greppable field names are all untouched — the timeout message gains one
field and one closing sentence.

Raised for `stSoftwareAU/GRQ#3771`.

### Design notes

`WorkerHandlerBase`'s task-callback map asserts a callback exists for every
message it routes, so an unsolicited task-shaped message would throw
`No callback` and kill init. The heartbeat therefore carries a single
unmistakable field (`neatAiWorkerHeartbeat`) and the parent's listener takes it
off the wire before task routing sees it.

`setupWorkerMessageLoop` is the single entry point both the multithreading and
intelligentDesign workers reach, and `createInitSequence` is the single choke
point every pooled worker reaches via `waitUntilReady()` — so both halves are
one-site changes that cover every worker pool.

## Evidence

Library change with no web interface, so no screenshot. Evidence is the test
suite plus the lint/type gates:

```mermaid
sequenceDiagram
    participant P as Parent (WorkerHandlerBase)
    participant C as Child (workerEntryPoint)
    P->>C: new Worker(...)
    C-->>P: heartbeat {phase: loaded}
    Note over P: heartbeatAtMs recorded
    P->>C: initialize
    alt child answers
        C-->>P: initialize OK
    else child stalls
        Note over P: timeout → heartbeat=received (started, then stalled)
    end
    Note over P: no heartbeat at all → heartbeat=none (never started)
```

```text
deno test test/workers/ test/multithreading/ test/intelligentDesign/Worker*.ts
  ... ok | 186 passed | 0 failed
./quality.sh --lint-only   ... ✅
./quality.sh --check-only  ... ✅
```

## Test Plan

- **`test/workers/WorkerStartHeartbeat.ts`** (new):
  - a stalled child that sent no heartbeat → timeout error carries
    `heartbeat=none` and the "did not reach its entry point" verdict;
  - a stalled child that sent one → `heartbeat=received heartbeatMs=…` and the
    "then stalled before answering" verdict;
  - the two messages differ (the point of the change);
  - a heartbeat is never routed as a task response (would throw `No callback`);
  - `setupWorkerMessageLoop` posts exactly one heartbeat on start, before any
    init work;
  - `isWorkerHeartbeatMessage` rejects task responses, `null`, strings, and
    malformed payloads.
- Existing `test/workers/WorkerInitDiagnostics.ts` and
  `test/wasm/WasmInitDiagnostics.ts` remain green — the pre-existing fields of
  the timeout contract are unchanged.
