### PR TITLE
chore: remove unused maxConns / maximumNumberOfNodes growth-cap options (#3505 slice A) (Issue #3552)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,15 @@ adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).
 
 ### Removed
 
+- **Issue #3552:** Removed the unused `maxConns` and `maximumNumberOfNodes`
+  growth-cap options (#3505 audit, slice A). No consumer set either key and both
+  defaulted to `Number.MAX_SAFE_INTEGER`, so the two `Mutator`
+  mutation-candidate guards they fed were inert in every production run — the
+  `ADD_CONN` guard could never fire and the `ADD_NODE` guard was always true.
+  **Breaking for embedders that set them:** setting either key is now a
+  `deno check` error, and there is no config cap on neuron or synapse count.
+  `ADD_CONN` is still bounded by the structural `maxSynapses` ceiling, and
+  `costOfGrowth` remains the lever for discouraging topology growth.
 - **Issue #3556:** Removed the unused `discoveryReplayDiagnostics` option and
   the replay timing payload it gated (#3505 audit, slice B). No consumer set it
   and it defaulted to `false`, so every `performance.now()` site in

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "6.1.5",
+  "version": "6.1.6",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/OPTION_AUDIT_CONSOLIDATED.md
+++ b/docs/OPTION_AUDIT_CONSOLIDATED.md
@@ -20,9 +20,9 @@ it:
 
 ## Headline
 
-**288 classifications, zero unclassified keys, 15 issues, zero duplicates.** Of
-the 288 rows, **68 are `IN USE`**, **121 are `KEEP (load-bearing default)`** and
-**99 `QUALIFY`** — but that last number is dominated by the nested fields of
+**275 classifications, zero unclassified keys, 15 issues, zero duplicates.** Of
+the 275 rows, **68 are `IN USE`**, **121 are `KEEP (load-bearing default)`** and
+**86 `QUALIFY`** — but that last number is dominated by the nested fields of
 four experimental configs and badly overstates the removable surface.
 
 Counted by _option_ rather than by row, **20 of 120 qualify**, and only 10 of
@@ -42,7 +42,7 @@ grounds for removal.
 
 ```mermaid
 flowchart LR
-    H["#3518 harness<br/>enumerateOptionKeys()"] --> INV["288 rows<br/>118 top-level + 170 nested"]
+    H["#3518 harness<br/>enumerateOptionKeys()"] --> INV["275 rows<br/>115 top-level + 160 nested"]
     A["Slices A–F<br/>#3519–#3524"] --> TAB["Merged table<br/>optionAuditRollup.ts"]
     INV --> REC{"reconcile()"}
     TAB --> REC
@@ -62,7 +62,7 @@ run on every CI build by
 
 ```bash
 deno run --allow-read scripts/option-audit-rollup.ts
-# 🔎 288 enumerated rows (118 top-level, 170 nested) · 288 classified
+# 🔎 275 enumerated rows (115 top-level, 160 nested) · 275 classified
 # ✅ zero coverage gaps — every option key is classified
 ```
 
@@ -77,8 +77,8 @@ in #3518 and #3525. The original figure came from a grep that skipped
 `readonly mutation: readonly MutationInterface[]`; the parser-backed harness saw
 the real 119, and its CI test pins that number. Every slice brief was written
 from the 118-key list, so **no slice classified `mutation`**. (The pinned count
-is **118** again today — a different 118: #3556 removed
-`discoveryReplayDiagnostics`. See [Executed removals](#executed-removals).)
+is **115** today, as executed removals have taken keys back out. See
+[Executed removals](#executed-removals).)
 
 This roll-up classified it with the slice method — `git grep`, exit code
 checked, both controls run first (`populationSize` 390 hits, `dnaSharingMode`
@@ -99,9 +99,11 @@ reported as an orphan (`reconcile()` lists keys the source no longer has) and
 fails `test/scripts/OptionAuditRollup.ts`. The counts in this document therefore
 shrink as the campaign proceeds.
 
-| Issue | Key                          | Slice | Landed                                                     |
-| ----- | ---------------------------- | ----- | ---------------------------------------------------------- |
-| #3556 | `discoveryReplayDiagnostics` | B     | Timing instrumentation and its `diagnostics` payload gone. |
+| Issue | Key                                | Slice | Landed                                                       |
+| ----- | ---------------------------------- | ----- | ------------------------------------------------------------ |
+| #3556 | `discoveryReplayDiagnostics`       | B     | Timing instrumentation and its `diagnostics` payload gone.   |
+| #3558 | `ensembleDiversity`                | C     | Parsed-but-never-read config and its 10 nested fields gone.  |
+| #3552 | `maxConns`, `maximumNumberOfNodes` | A     | Both `Mutator` growth guards gone; `maxSynapses` still caps. |
 
 ### `fitnessSampleRate` and `seed`
 
@@ -123,16 +125,18 @@ per-slice totals shift:
 
 | Slice     | Slice comment | Roll-up | Why                                                                                                                                               |
 | --------- | ------------: | ------: | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| A         |            46 |      46 | —                                                                                                                                                 |
+| A         |            46 |      44 | —                                                                                                                                                 |
 | B         |            36 |      42 | B classified its 3 nested configs at parent level; the harness enumerates `DiscoveryCacheConfig` (4) + `DiskSpaceConfig` (3) fields individually. |
-| C         |            59 |      56 | `adaptiveMutationThresholds` is declared inline in `NeatArguments`, so its 3 fields are not separate nested rows.                                 |
+| C         |            59 |      45 | `adaptiveMutationThresholds` is declared inline in `NeatArguments`, so its 3 fields are not separate nested rows.                                 |
 | D         |            69 |      63 | Same for `plateauDetection`'s 6 inline fields.                                                                                                    |
 | E         |            33 |      37 | `RustScorerConfig` has no `NeatOptions` key (−1 parent row) but two interfaces, so `RequiredRustScorerConfig`'s 5 fields are enumerated too (+5). |
 | F         |            43 |      43 | —                                                                                                                                                 |
 | roll-up   |             — |       1 | `mutation`.                                                                                                                                       |
-| **Total** |       **286** | **288** |                                                                                                                                                   |
+| **Total** |       **286** | **275** |                                                                                                                                                   |
 
-No slice lost a key in the merge; the deltas are all enumeration conventions.
+No slice lost a key in the merge; the deltas are enumeration conventions plus
+the [executed removals](#executed-removals) — A is down 2 (#3552), B down 1
+(#3556) and C down 11 (#3558 and its 10 nested fields).
 
 ## Merged classification table
 
@@ -144,10 +148,10 @@ set independently. Generated by
 
 | Verdict     | Classifications |
 | ----------- | --------------: |
-| `QUALIFIES` |              99 |
+| `QUALIFIES` |              86 |
 | `KEEP`      |             121 |
 | `IN USE`    |              68 |
-| **Total**   |         **288** |
+| **Total**   |         **275** |
 
 | Key                                           | Slice   | Verdict     | Issue | Note                                                                                      |
 | --------------------------------------------- | ------- | ----------- | ----- | ----------------------------------------------------------------------------------------- |
@@ -170,8 +174,6 @@ set independently. Generated by
 | `timeoutMinutes`                              | A       | `IN USE`    | —     |                                                                                           |
 | `trainPerGen`                                 | A       | `IN USE`    | —     |                                                                                           |
 | `trainingTaskTimeoutMinutes`                  | A       | `KEEP`      | —     |                                                                                           |
-| `maxConns`                                    | A       | `QUALIFIES` | #3552 |                                                                                           |
-| `maximumNumberOfNodes`                        | A       | `QUALIFIES` | #3552 |                                                                                           |
 | `mutationAmount`                              | A       | `IN USE`    | —     |                                                                                           |
 | `mutationRate`                                | A       | `IN USE`    | —     |                                                                                           |
 | `populationSize`                              | A       | `IN USE`    | —     |                                                                                           |
@@ -235,7 +237,6 @@ set independently. Generated by
 | `stabilityAdaptation`                         | D       | `QUALIFIES` | #3562 | No implementation exists — parsed, never read.                                            |
 | `weightRegularisation`                        | D       | `KEEP`      | —     |                                                                                           |
 | `biasRegularisation`                          | D       | `KEEP`      | —     |                                                                                           |
-| `ensembleDiversity`                           | C       | `QUALIFIES` | #3558 | No implementation exists — parsed, never read.                                            |
 | `quantumStep`                                 | D       | `KEEP`      | —     |                                                                                           |
 | `fineTunePopulation`                          | C       | `KEEP`      | —     |                                                                                           |
 | `predictiveCoding`                            | D       | `IN USE`    | —     | GRQ sets only `.enabled`; the other four defaults then drive inference.                   |
@@ -362,7 +363,7 @@ KEEP, its position in the chain simply drops out.
 
 ## Definition of done
 
-- [x] Single consolidated table covering every option key — 288 rows above.
+- [x] Single consolidated table covering every option key — 275 rows above.
 - [x] Zero unclassified keys — one gap found (`mutation`), classified `IN USE`
       in this roll-up rather than left to disappear. No follow-up needed.
 - [x] Cross-slice and cross-campaign duplicates closed — none existed; one issue

--- a/docs/api/CONFIGURATION.md
+++ b/docs/api/CONFIGURATION.md
@@ -84,12 +84,10 @@ import type { NeatOptions, NeatOptionsInput } from "@stsoftware/neat-ai";
 
 ### 🔒 Network constraints
 
-| Field                  | Type      | Default            | Description                                                                  |
-| ---------------------- | --------- | ------------------ | ---------------------------------------------------------------------------- |
-| `feedbackLoop`         | `boolean` | `false`            | Enable recurrent connections                                                 |
-| `maxConns`             | `number`  | `MAX_SAFE_INTEGER` | Maximum synapses allowed (see [Core evolution](../config/CORE_EVOLUTION.md)) |
-| `maximumNumberOfNodes` | `number`  | `MAX_SAFE_INTEGER` | Maximum neurons allowed (see [Core evolution](../config/CORE_EVOLUTION.md))  |
-| `costOfGrowth`         | `number`  | `0.000_000_1`      | Complexity penalty per synapse/neuron                                        |
+| Field          | Type      | Default       | Description                           |
+| -------------- | --------- | ------------- | ------------------------------------- |
+| `feedbackLoop` | `boolean` | `false`       | Enable recurrent connections          |
+| `costOfGrowth` | `number`  | `0.000_000_1` | Complexity penalty per synapse/neuron |
 
 ### 🔬 Discovery fields
 

--- a/docs/archive/pr-summaries/pr-summary-3552.md
+++ b/docs/archive/pr-summaries/pr-summary-3552.md
@@ -3,9 +3,10 @@
 ## Summary
 
 Removes the `maxConns` and `maximumNumberOfNodes` options — slice A's two
-`QUALIFIES` verdicts from the [#3505](https://github.com/stSoftwareAU/NEAT-AI/issues/3505)
-option audit ([slice A brief](../../OPTION_AUDIT_SLICE_A.md), #3519). Follows the
-#3502 / #3556 removal pattern. Closes #3552.
+`QUALIFIES` verdicts from the
+[#3505](https://github.com/stSoftwareAU/NEAT-AI/issues/3505) option audit
+([slice A brief](../../OPTION_AUDIT_SLICE_A.md), #3519). Follows the #3502 /
+#3556 removal pattern. Closes #3552.
 
 Both keys are filed together because they share one code path — the `Mutator`
 mutation-candidate filter — and both defaulted to `Number.MAX_SAFE_INTEGER`, the
@@ -44,13 +45,13 @@ flowchart LR
 
 ### What was deleted
 
-| Area      | Change                                                                                                        |
-| --------- | ------------------------------------------------------------------------------------------------------------- |
-| Options   | `src/config/NeatArguments.ts` (both fields), `src/config/NeatOptions.ts` (both `NumericOptionKeys` entries)     |
-| Parsing   | `src/config/NeatConfig.ts` — both `parseNumber` blocks                                                          |
-| Plumbing  | `src/NEAT/Mutator.ts` — the `ADD_NODE` case and the `maxConns` half of the `ADD_CONN` case                       |
-| Docs      | `docs/api/CONFIGURATION.md`, `docs/config/CORE_EVOLUTION.md`, `docs/config/RECIPES.md`, `docs/troubleshooting/MEMORY.md` |
-| Audit     | `scripts/lib/optionAuditRollup.ts` entries, `docs/OPTION_AUDIT_CONSOLIDATED.md` counts, pinned key count       |
+| Area     | Change                                                                                                                   |
+| -------- | ------------------------------------------------------------------------------------------------------------------------ |
+| Options  | `src/config/NeatArguments.ts` (both fields), `src/config/NeatOptions.ts` (both `NumericOptionKeys` entries)              |
+| Parsing  | `src/config/NeatConfig.ts` — both `parseNumber` blocks                                                                   |
+| Plumbing | `src/NEAT/Mutator.ts` — the `ADD_NODE` case and the `maxConns` half of the `ADD_CONN` case                               |
+| Docs     | `docs/api/CONFIGURATION.md`, `docs/config/CORE_EVOLUTION.md`, `docs/config/RECIPES.md`, `docs/troubleshooting/MEMORY.md` |
+| Audit    | `scripts/lib/optionAuditRollup.ts` entries, `docs/OPTION_AUDIT_CONSOLIDATED.md` counts, pinned key count                 |
 
 `bench/` referenced neither key.
 
@@ -96,11 +97,12 @@ $ deno run --allow-read scripts/option-audit-rollup.ts
 **Added**
 
 - `test/config/NeatConfigParseOptions.ts::NeatConfigParseOptions - growth-cap
-  options are not config keys` — asserts the parsed config carries neither key,
-  guarding against reintroduction (mirrors the #3502 and #3556 guards).
+  options are not config keys`
+  — asserts the parsed config carries neither key, guarding against
+  reintroduction (mirrors the #3502 and #3556 guards).
 - `test/docs/ApiConfigurationDefaults.ts::CONFIGURATION.md - removed growth-cap
-  options are not documented` — asserts the doc table no longer has a row for
-  either key.
+  options are not documented`
+  — asserts the doc table no longer has a row for either key.
 
 **Modified**
 
@@ -108,10 +110,11 @@ $ deno run --allow-read scripts/option-audit-rollup.ts
   117 → 115.
 - `test/NEAT/MutatorComputeMutationCandidates.ts` — **one test removed**:
   `filters ADD_NODE when at maximum nodes` asserted a cap that no longer exists,
-  so it could not be rewritten to pass. Its sibling `allows ADD_NODE when below
-  maximum` is retained, renamed `allows ADD_NODE regardless of neuron count`,
-  and now covers the new behaviour: ADD_NODE stays a candidate at any creature
-  size.
+  so it could not be rewritten to pass. Its sibling
+  `allows ADD_NODE when below
+  maximum` is retained, renamed
+  `allows ADD_NODE regardless of neuron count`, and now covers the new
+  behaviour: ADD_NODE stays a candidate at any creature size.
 - `test/NEAT/MutatorCacheValidMutations.ts` — dropped the two removed keys from
   two configs. Neither test asserted on the caps; the per-creature cache test
   still exercises distinct cache keys via differing neuron counts.

--- a/docs/archive/pr-summaries/pr-summary-3552.md
+++ b/docs/archive/pr-summaries/pr-summary-3552.md
@@ -1,0 +1,128 @@
+# Remove the unused `maxConns` / `maximumNumberOfNodes` growth-cap options
+
+## Summary
+
+Removes the `maxConns` and `maximumNumberOfNodes` options — slice A's two
+`QUALIFIES` verdicts from the [#3505](https://github.com/stSoftwareAU/NEAT-AI/issues/3505)
+option audit ([slice A brief](../../OPTION_AUDIT_SLICE_A.md), #3519). Follows the
+#3502 / #3556 removal pattern. Closes #3552.
+
+Both keys are filed together because they share one code path — the `Mutator`
+mutation-candidate filter — and both defaulted to `Number.MAX_SAFE_INTEGER`, the
+no-cap sentinel:
+
+- `ADD_CONN` guard `creature.synapses.length >= config.maxConns` could never be
+  true at the default. The adjacent `maxSynapses` bound is what actually caps
+  connection growth, and it stays.
+- `ADD_NODE` guard `creature.neurons.length < config.maximumNumberOfNodes` was
+  always true at the default, so the case fell through to `return true`.
+
+Neither key is set by any consumer (verified per-repo across GRQ and
+NEAT-AI-Examples in the issue, with `populationSize` as the positive control).
+
+**Breaking for embedders that set them.** Both keys are gone from
+`NeatArguments` / `NeatOptions`, so setting either is now a `deno check` error
+rather than a silent no-op — the failure is loud, exactly as the audit intended.
+There is no config cap on neuron or synapse count any more; `costOfGrowth`
+remains the lever for discouraging topology growth.
+
+```mermaid
+flowchart LR
+    subgraph Before
+        B1["ADD_NODE"] --> B2{"neurons &lt; maximumNumberOfNodes"}
+        B2 -->|"always true<br/>at MAX_SAFE_INTEGER"| B3["candidate"]
+        B4["ADD_CONN"] --> B5{"synapses &gt;= maxConns"}
+        B5 -->|"never true<br/>at MAX_SAFE_INTEGER"| B6{"synapses &gt;= maxSynapses"}
+        B6 --> B7["candidate"]
+    end
+    subgraph After
+        A1["ADD_NODE"] --> A3["candidate"]
+        A4["ADD_CONN"] --> A6{"synapses &lt; maxSynapses"}
+        A6 --> A7["candidate"]
+    end
+```
+
+### What was deleted
+
+| Area      | Change                                                                                                        |
+| --------- | ------------------------------------------------------------------------------------------------------------- |
+| Options   | `src/config/NeatArguments.ts` (both fields), `src/config/NeatOptions.ts` (both `NumericOptionKeys` entries)     |
+| Parsing   | `src/config/NeatConfig.ts` — both `parseNumber` blocks                                                          |
+| Plumbing  | `src/NEAT/Mutator.ts` — the `ADD_NODE` case and the `maxConns` half of the `ADD_CONN` case                       |
+| Docs      | `docs/api/CONFIGURATION.md`, `docs/config/CORE_EVOLUTION.md`, `docs/config/RECIPES.md`, `docs/troubleshooting/MEMORY.md` |
+| Audit     | `scripts/lib/optionAuditRollup.ts` entries, `docs/OPTION_AUDIT_CONSOLIDATED.md` counts, pinned key count       |
+
+`bench/` referenced neither key.
+
+`docs/troubleshooting/MEMORY.md` documented the pair as a memory-safety lever.
+Since the caps are gone, that step now points at `costOfGrowth` — a real,
+`IN USE` lever — rather than at two knobs that no longer exist.
+
+### Audit book-keeping
+
+A landed removal takes its key out of `NeatArguments`, so the harness stops
+enumerating it and its roll-up entry must go too — a retained entry is an orphan
+and fails `test/scripts/OptionAuditRollup.ts`. The pinned top-level count moves
+117 → **115**.
+
+Regenerating `docs/OPTION_AUDIT_CONSOLIDATED.md` also picked up pre-existing
+drift: #3558 (`ensembleDiversity` + its 10 nested fields) had removed its
+roll-up entries without updating the document, so the headline still read 288
+rows. The document now matches the script's actual output — **275 rows (115
+top-level, 160 nested)** — and the "Executed removals" table lists #3556, #3558
+and #3552.
+
+## Evidence
+
+Backend/CLI change with no web interface, so there is no screenshot. Evidence is
+the quality gate:
+
+```
+$ ./quality.sh < /dev/null
+ok | 8099 passed (5 steps) | 0 failed | 4 ignored (8m54s)
+```
+
+The removal is verified by the new regression guards plus the reconciliation
+script, which exits non-zero on an orphaned entry:
+
+```
+$ deno run --allow-read scripts/option-audit-rollup.ts
+🔎 275 enumerated rows (115 top-level, 160 nested) · 275 classified
+✅ zero coverage gaps — every option key is classified
+```
+
+## Test Plan
+
+**Added**
+
+- `test/config/NeatConfigParseOptions.ts::NeatConfigParseOptions - growth-cap
+  options are not config keys` — asserts the parsed config carries neither key,
+  guarding against reintroduction (mirrors the #3502 and #3556 guards).
+- `test/docs/ApiConfigurationDefaults.ts::CONFIGURATION.md - removed growth-cap
+  options are not documented` — asserts the doc table no longer has a row for
+  either key.
+
+**Modified**
+
+- `test/scripts/AuditOptionUsage.ts` — pinned `NeatArguments` top-level count
+  117 → 115.
+- `test/NEAT/MutatorComputeMutationCandidates.ts` — **one test removed**:
+  `filters ADD_NODE when at maximum nodes` asserted a cap that no longer exists,
+  so it could not be rewritten to pass. Its sibling `allows ADD_NODE when below
+  maximum` is retained, renamed `allows ADD_NODE regardless of neuron count`,
+  and now covers the new behaviour: ADD_NODE stays a candidate at any creature
+  size.
+- `test/NEAT/MutatorCacheValidMutations.ts` — dropped the two removed keys from
+  two configs. Neither test asserted on the caps; the per-creature cache test
+  still exercises distinct cache keys via differing neuron counts.
+- `test/NEAT/FocusCachePreservation.ts` — dropped the two removed keys from an
+  otherwise unrelated config.
+- `test/docs/ApiConfigurationDefaults.ts` — removed the two doc-table tests and
+  the two default assertions for the deleted keys.
+
+## Security self-check
+
+No new input surface, dependencies, endpoints, or external calls — this PR only
+deletes configuration. Removing the keys narrows the accepted input surface, and
+a consumer that still sets one now fails `deno check` rather than being silently
+ignored.

--- a/docs/config/CORE_EVOLUTION.md
+++ b/docs/config/CORE_EVOLUTION.md
@@ -30,8 +30,6 @@ const config = createNeatConfig({
 | `mutationAmount`                  | `integer`  | `1`                | Number of changes per gene during mutation (min: 1)                                                       |
 | `elitism`                         | `integer`  | `1`                | Top-performing individuals retained each generation (min: 1)                                              |
 | `costOfGrowth`                    | `number`   | `0.0000001`        | Penalty per structural addition (min: 0)                                                                  |
-| `maxConns`                        | `integer`  | `MAX_SAFE_INTEGER` | Maximum connections (min: 1)                                                                              |
-| `maximumNumberOfNodes`            | `integer`  | `MAX_SAFE_INTEGER` | Maximum neurons (min: 1)                                                                                  |
 | `timeoutMinutes`                  | `integer`  | `0`                | Maximum training time in minutes (0 = unlimited)                                                          |
 | `feedbackLoop`                    | `boolean`  | `false`            | Enable recurrent connections                                                                              |
 | `debug`                           | `boolean`  | `false`            | Enable debug mode (slower)                                                                                |
@@ -188,18 +186,6 @@ Set to `0` to disable the growth penalty entirely.
 
 The cost (fitness) function used to evaluate creatures. Common options include
 `"MSE"` (Mean Squared Error) and others defined in `src/costs/`.
-
-### `maxConns`
-
-**Default: MAX_SAFE_INTEGER** | Type: integer | Min: 1
-
-Hard cap on the number of synapses any creature may have.
-
-### `maximumNumberOfNodes`
-
-**Default: MAX_SAFE_INTEGER** | Type: integer | Min: 1
-
-Hard cap on the number of neurons any creature may have.
 
 ## 🔁 Topology mode
 

--- a/docs/config/RECIPES.md
+++ b/docs/config/RECIPES.md
@@ -88,8 +88,6 @@ Favour simpler networks with aggressive growth penalties:
 ```ts
 const config = createNeatConfig({
   costOfGrowth: 0.001,
-  maxConns: 50,
-  maximumNumberOfNodes: 20,
   populationSize: 50,
   targetError: 0.05,
 });

--- a/docs/troubleshooting/MEMORY.md
+++ b/docs/troubleshooting/MEMORY.md
@@ -131,11 +131,12 @@ WASM compilation. Reduce `populationSize` if memory is tight:
 populationSize: 30, // Reduce from default 50
 ```
 
-Also consider limiting network complexity:
+Also consider discouraging network complexity. There is no hard neuron or
+synapse cap — raise the growth penalty so larger topologies have to earn their
+size:
 
 ```typescript
-maxConns: 100,            // Limit connections
-maximumNumberOfNodes: 30, // Limit neurons
+costOfGrowth: 0.001, // Raise from the default 0.0000001
 ```
 
 **Step 5 — Check V8 heap allocation:**

--- a/scripts/lib/optionAuditRollup.ts
+++ b/scripts/lib/optionAuditRollup.ts
@@ -66,10 +66,16 @@ const qualifies = (
   rest: Partial<RollupEntry> = {},
 ): RollupEntry => ({ key, slice, verdict: "QUALIFIES", issue, ...rest });
 
-/** Slice A (#3519) — 46 non-`discovery*` top-level options. */
+/**
+ * Slice A (#3519) — 46 non-`discovery*` top-level options.
+ *
+ * Two of slice A's `QUALIFIES` verdicts, `maxConns` and
+ * `maximumNumberOfNodes`, were carried out by #3552: the keys no longer exist
+ * in `NeatArguments`, so the harness no longer enumerates them and their
+ * entries are gone from this table. A retained entry would be an orphan
+ * (`reconcile()` reports keys the source no longer has).
+ */
 const SLICE_A: RollupEntry[] = [
-  qualifies("maxConns", "A", 3552),
-  qualifies("maximumNumberOfNodes", "A", 3552),
   qualifies("enableRepetitiveTraining", "A", 3553),
   qualifies("dnaSharingMode", "A", 3554, {
     note:

--- a/src/NEAT/Mutator.ts
+++ b/src/NEAT/Mutator.ts
@@ -645,13 +645,8 @@ export class Mutator {
     // the current constraints.
     const candidates = mutationMethods.filter((method) => {
       switch (method.name) {
-        case Mutation.ADD_NODE.name:
-          return creature.neurons.length < this.config.maximumNumberOfNodes;
         case Mutation.ADD_CONN.name:
-          return !(
-            creature.synapses.length >= this.config.maxConns ||
-            creature.synapses.length >= maxSynapses
-          );
+          return creature.synapses.length < maxSynapses;
         case Mutation.SUB_NODE.name:
           return creature.neurons.length > creature.input + creature.output;
         case Mutation.SWAP_NODES.name:

--- a/src/config/NeatArguments.ts
+++ b/src/config/NeatArguments.ts
@@ -151,12 +151,6 @@ export interface NeatArguments {
    */
   trainingTaskTimeoutMinutes: number;
 
-  /** Maximum number of connections allowed in the neural network. */
-  maxConns: number;
-
-  /** Maximum number of nodes allowed in the neural network. */
-  maximumNumberOfNodes: number;
-
   /** Number of changes to apply per gene during mutation. */
   mutationAmount: number;
 

--- a/src/config/NeatConfig.ts
+++ b/src/config/NeatConfig.ts
@@ -358,18 +358,6 @@ export function createNeatConfig(options: NeatOptionsInput): NeatConfig {
       min: 1,
     }),
 
-    maxConns: parseNumber(
-      "Max Connections",
-      opts.maxConns,
-      Number.MAX_SAFE_INTEGER,
-      { integer: true, min: 1 },
-    ),
-    maximumNumberOfNodes: parseNumber(
-      "Maximum Number of Nodes",
-      opts.maximumNumberOfNodes,
-      Number.MAX_SAFE_INTEGER,
-      { integer: true, min: 1 },
-    ),
     mutationRate: parseNumber("Mutation Rate", opts.mutationRate, 0.3, {
       minExclusive: 0.001,
       max: 1,

--- a/src/config/NeatOptions.ts
+++ b/src/config/NeatOptions.ts
@@ -52,8 +52,6 @@ type NumericOptionKeys =
   | "iterations"
   | "populationSize"
   | "elitism"
-  | "maxConns"
-  | "maximumNumberOfNodes"
   | "mutationRate"
   | "mutationAmount"
   | "timeoutMinutes"

--- a/test/NEAT/FocusCachePreservation.ts
+++ b/test/NEAT/FocusCachePreservation.ts
@@ -194,8 +194,6 @@ Deno.test("Mutator should clear focus cache only when focus list changes", () =>
     mutationAmount: 3,
     focusRate: 1.0, // Always use focus list
     focusList: [1, 2],
-    maxConns: 100,
-    maximumNumberOfNodes: 50,
     feedbackLoop: false,
     mutation: [Mutation.MOD_WEIGHT, Mutation.MOD_BIAS],
   });

--- a/test/NEAT/MutatorCacheValidMutations.ts
+++ b/test/NEAT/MutatorCacheValidMutations.ts
@@ -105,11 +105,10 @@ Deno.test(
   () => {
     const config = createNeatConfig({
       mutation: Mutation.FFW,
-      maximumNumberOfNodes: 10,
     });
     const mutator = new Mutator(config);
 
-    // Create creature at max nodes - ADD_NODE should be filtered out
+    // Larger creature — a different cache key to the small one below.
     const maxCreature = new Creature(3, 2, {
       layers: [{ count: 5 }],
     }); // 3 + 5 + 2 = 10 neurons
@@ -120,7 +119,7 @@ Deno.test(
       "maxCreature should have exactly 10 neurons",
     );
 
-    // Create normal creature - ADD_NODE should be allowed
+    // Smaller creature — must not pick up the larger creature's cache entry.
     const normalCreature = new Creature(3, 2, { layers: [{ count: 1 }] });
     assertEquals(
       normalCreature.neurons.length,
@@ -194,7 +193,6 @@ Deno.test(
   () => {
     const config = createNeatConfig({
       mutation: Mutation.FFW,
-      maxConns: 1000,
     });
     const mutator = new Mutator(config);
 

--- a/test/NEAT/MutatorComputeMutationCandidates.ts
+++ b/test/NEAT/MutatorComputeMutationCandidates.ts
@@ -9,7 +9,7 @@ import { Mutator } from "@neat/Mutator.ts";
  *
  * Issue #1397: Verify that selectMutationMethod correctly filters
  * mutations based on creature state and config, including forward-only
- * constraints, maximum node/connection limits, and adaptive behaviour.
+ * constraints, the structural synapse ceiling, and adaptive behaviour.
  */
 
 function createConfig(overrides: Record<string, unknown> = {}) {
@@ -117,27 +117,10 @@ Deno.test("ComputeMutationCandidates: filters SWAP_NODES when insufficient hidde
   );
 });
 
-Deno.test("ComputeMutationCandidates: filters ADD_NODE when at maximum nodes", () => {
-  const config = createConfig({ maximumNumberOfNodes: 6 });
-  const mutator = new Mutator(config);
-
-  // Creature with 3 input + 2 output + 1 hidden = 6 neurons (at max)
-  const creature = new Creature(3, 2, { layers: [{ count: 1 }] });
-
-  const selectedNames = new Set<string>();
-  for (let i = 0; i < 500; i++) {
-    const method = mutator.selectMutationMethod(creature);
-    selectedNames.add(method.name);
-  }
-
-  assert(
-    !selectedNames.has("ADD_NODE"),
-    "ADD_NODE should not be selected when at maximum nodes",
-  );
-});
-
-Deno.test("ComputeMutationCandidates: allows ADD_NODE when below maximum", () => {
-  const config = createConfig({ maximumNumberOfNodes: 100 });
+// Issue #3552: `maximumNumberOfNodes` was removed, so neuron growth is no
+// longer capped by config — ADD_NODE stays a candidate at any creature size.
+Deno.test("ComputeMutationCandidates: allows ADD_NODE regardless of neuron count", () => {
+  const config = createConfig();
   const mutator = new Mutator(config);
 
   const creature = new Creature(3, 2, { layers: [{ count: 5 }] });
@@ -150,7 +133,7 @@ Deno.test("ComputeMutationCandidates: allows ADD_NODE when below maximum", () =>
 
   assert(
     selectedNames.has("ADD_NODE"),
-    "ADD_NODE should be available when below maximum nodes",
+    "ADD_NODE should always be an available candidate",
   );
 });
 

--- a/test/config/NeatConfigParseOptions.ts
+++ b/test/config/NeatConfigParseOptions.ts
@@ -176,3 +176,12 @@ Deno.test("NeatConfigParseOptions - discoveryReplayDiagnostics is not a config k
   const config = createNeatConfig({}) as unknown as Record<string, unknown>;
   assertEquals(Object.hasOwn(config, "discoveryReplayDiagnostics"), false);
 });
+
+// Issue #3552: maxConns and maximumNumberOfNodes were removed as unused
+// growth-cap knobs — the parsed config must no longer carry them (regression
+// guard against reintroduction).
+Deno.test("NeatConfigParseOptions - growth-cap options are not config keys", () => {
+  const config = createNeatConfig({}) as unknown as Record<string, unknown>;
+  assertEquals(Object.hasOwn(config, "maxConns"), false);
+  assertEquals(Object.hasOwn(config, "maximumNumberOfNodes"), false);
+});

--- a/test/docs/ApiConfigurationDefaults.ts
+++ b/test/docs/ApiConfigurationDefaults.ts
@@ -8,10 +8,9 @@
  * with the code. They fail if the doc drifts from the source again.
  */
 
-import { assert } from "@std/assert";
+import { assert, assertRejects } from "@std/assert";
 import { fromFileUrl, resolve } from "@std/path";
 import { DEFAULT_HEAVY_TASK_WORKER_COUNT } from "@config/NeatConfig.ts";
-import { createNeatConfig } from "@config/NeatConfig.ts";
 
 const REPO_ROOT = resolve(fromFileUrl(import.meta.url), "..", "..", "..");
 const CONFIG_DOC = `${REPO_ROOT}/docs/api/CONFIGURATION.md`;
@@ -36,28 +35,6 @@ Deno.test("CONFIGURATION.md - threads default reflects hardwareConcurrency + hea
   assert(
     def.includes(`+ ${DEFAULT_HEAVY_TASK_WORKER_COUNT}`),
     `threads default must document "+ ${DEFAULT_HEAVY_TASK_WORKER_COUNT}", got: ${def}`,
-  );
-});
-
-Deno.test("CONFIGURATION.md - maxConns default is MAX_SAFE_INTEGER not Infinity", async () => {
-  const [, , def] = await tableRow("maxConns");
-  assert(def.includes("MAX_SAFE_INTEGER"), `maxConns default wrong: ${def}`);
-  assert(!def.includes("Infinity"), `maxConns must not say Infinity: ${def}`);
-});
-
-Deno.test("CONFIGURATION.md - maximumNumberOfNodes default and semantics", async () => {
-  const row = await tableRow("maximumNumberOfNodes");
-  const def = row[2];
-  const desc = row[3];
-  assert(
-    def.includes("MAX_SAFE_INTEGER"),
-    `maximumNumberOfNodes default wrong: ${def}`,
-  );
-  assert(!def.includes("Infinity"), `must not say Infinity: ${def}`);
-  // Caps all neurons, not only hidden neurons.
-  assert(
-    !/hidden/i.test(desc),
-    `maximumNumberOfNodes must not be labelled "hidden": ${desc}`,
   );
 });
 
@@ -87,8 +64,20 @@ Deno.test("CONFIGURATION.md - verbose is not conflated with debug", async () => 
 
 Deno.test("CONFIGURATION.md - documented defaults still match code", () => {
   // Guards the numeric source-of-truth the doc now cites.
-  const config = createNeatConfig({});
-  assert(config.maxConns === Number.MAX_SAFE_INTEGER);
-  assert(config.maximumNumberOfNodes === Number.MAX_SAFE_INTEGER);
   assert(DEFAULT_HEAVY_TASK_WORKER_COUNT === 2);
+});
+
+// Issue #3552: the two growth-cap knobs were removed, so the doc table must no
+// longer advertise them.
+Deno.test("CONFIGURATION.md - removed growth-cap options are not documented", async () => {
+  await Promise.all(
+    ["maxConns", "maximumNumberOfNodes"].map((field) =>
+      assertRejects(
+        () => tableRow(field),
+        Error,
+        "No table row found",
+        `${field} was removed by #3552 and must not be documented`,
+      )
+    ),
+  );
 });

--- a/test/scripts/AuditOptionUsage.ts
+++ b/test/scripts/AuditOptionUsage.ts
@@ -147,10 +147,11 @@ Deno.test("enumerateOptionKeys - pins the real NeatArguments top-level surface",
   // harness picking it up fails here rather than mid-audit. #3518 quotes 118,
   // which came from a grep that skipped `readonly mutation` — the parser saw
   // the real 119. #3558 then removed `ensembleDiversity`, leaving 118; #3556
-  // then removed `discoveryReplayDiagnostics`, leaving 117.
+  // then removed `discoveryReplayDiagnostics`, leaving 117; #3552 then removed
+  // `maxConns` and `maximumNumberOfNodes`, leaving 115.
   assertEquals(
     topLevel.length,
-    117,
+    115,
     "NeatArguments top-level key count changed",
   );
   assert(


### PR DESCRIPTION
# Remove the unused `maxConns` / `maximumNumberOfNodes` growth-cap options

## Summary

Removes the `maxConns` and `maximumNumberOfNodes` options — slice A's two
`QUALIFIES` verdicts from the
[#3505](https://github.com/stSoftwareAU/NEAT-AI/issues/3505) option audit
([slice A brief](../../OPTION_AUDIT_SLICE_A.md), #3519). Follows the #3502 /
#3556 removal pattern. Closes #3552.

Both keys are filed together because they share one code path — the `Mutator`
mutation-candidate filter — and both defaulted to `Number.MAX_SAFE_INTEGER`, the
no-cap sentinel:

- `ADD_CONN` guard `creature.synapses.length >= config.maxConns` could never be
  true at the default. The adjacent `maxSynapses` bound is what actually caps
  connection growth, and it stays.
- `ADD_NODE` guard `creature.neurons.length < config.maximumNumberOfNodes` was
  always true at the default, so the case fell through to `return true`.

Neither key is set by any consumer (verified per-repo across GRQ and
NEAT-AI-Examples in the issue, with `populationSize` as the positive control).

**Breaking for embedders that set them.** Both keys are gone from
`NeatArguments` / `NeatOptions`, so setting either is now a `deno check` error
rather than a silent no-op — the failure is loud, exactly as the audit intended.
There is no config cap on neuron or synapse count any more; `costOfGrowth`
remains the lever for discouraging topology growth.

```mermaid
flowchart LR
    subgraph Before
        B1["ADD_NODE"] --> B2{"neurons &lt; maximumNumberOfNodes"}
        B2 -->|"always true<br/>at MAX_SAFE_INTEGER"| B3["candidate"]
        B4["ADD_CONN"] --> B5{"synapses &gt;= maxConns"}
        B5 -->|"never true<br/>at MAX_SAFE_INTEGER"| B6{"synapses &gt;= maxSynapses"}
        B6 --> B7["candidate"]
    end
    subgraph After
        A1["ADD_NODE"] --> A3["candidate"]
        A4["ADD_CONN"] --> A6{"synapses &lt; maxSynapses"}
        A6 --> A7["candidate"]
    end
```

### What was deleted

| Area     | Change                                                                                                                   |
| -------- | ------------------------------------------------------------------------------------------------------------------------ |
| Options  | `src/config/NeatArguments.ts` (both fields), `src/config/NeatOptions.ts` (both `NumericOptionKeys` entries)              |
| Parsing  | `src/config/NeatConfig.ts` — both `parseNumber` blocks                                                                   |
| Plumbing | `src/NEAT/Mutator.ts` — the `ADD_NODE` case and the `maxConns` half of the `ADD_CONN` case                               |
| Docs     | `docs/api/CONFIGURATION.md`, `docs/config/CORE_EVOLUTION.md`, `docs/config/RECIPES.md`, `docs/troubleshooting/MEMORY.md` |
| Audit    | `scripts/lib/optionAuditRollup.ts` entries, `docs/OPTION_AUDIT_CONSOLIDATED.md` counts, pinned key count                 |

`bench/` referenced neither key.

`docs/troubleshooting/MEMORY.md` documented the pair as a memory-safety lever.
Since the caps are gone, that step now points at `costOfGrowth` — a real,
`IN USE` lever — rather than at two knobs that no longer exist.

### Audit book-keeping

A landed removal takes its key out of `NeatArguments`, so the harness stops
enumerating it and its roll-up entry must go too — a retained entry is an orphan
and fails `test/scripts/OptionAuditRollup.ts`. The pinned top-level count moves
117 → **115**.

Regenerating `docs/OPTION_AUDIT_CONSOLIDATED.md` also picked up pre-existing
drift: #3558 (`ensembleDiversity` + its 10 nested fields) had removed its
roll-up entries without updating the document, so the headline still read 288
rows. The document now matches the script's actual output — **275 rows (115
top-level, 160 nested)** — and the "Executed removals" table lists #3556, #3558
and #3552.

## Evidence

Backend/CLI change with no web interface, so there is no screenshot. Evidence is
the quality gate:

```
$ ./quality.sh < /dev/null
ok | 8099 passed (5 steps) | 0 failed | 4 ignored (8m54s)
```

The removal is verified by the new regression guards plus the reconciliation
script, which exits non-zero on an orphaned entry:

```
$ deno run --allow-read scripts/option-audit-rollup.ts
🔎 275 enumerated rows (115 top-level, 160 nested) · 275 classified
✅ zero coverage gaps — every option key is classified
```

## Test Plan

**Added**

- `test/config/NeatConfigParseOptions.ts::NeatConfigParseOptions - growth-cap
  options are not config keys`
  — asserts the parsed config carries neither key, guarding against
  reintroduction (mirrors the #3502 and #3556 guards).
- `test/docs/ApiConfigurationDefaults.ts::CONFIGURATION.md - removed growth-cap
  options are not documented`
  — asserts the doc table no longer has a row for either key.

**Modified**

- `test/scripts/AuditOptionUsage.ts` — pinned `NeatArguments` top-level count
  117 → 115.
- `test/NEAT/MutatorComputeMutationCandidates.ts` — **one test removed**:
  `filters ADD_NODE when at maximum nodes` asserted a cap that no longer exists,
  so it could not be rewritten to pass. Its sibling
  `allows ADD_NODE when below
  maximum` is retained, renamed
  `allows ADD_NODE regardless of neuron count`, and now covers the new
  behaviour: ADD_NODE stays a candidate at any creature size.
- `test/NEAT/MutatorCacheValidMutations.ts` — dropped the two removed keys from
  two configs. Neither test asserted on the caps; the per-creature cache test
  still exercises distinct cache keys via differing neuron counts.
- `test/NEAT/FocusCachePreservation.ts` — dropped the two removed keys from an
  otherwise unrelated config.
- `test/docs/ApiConfigurationDefaults.ts` — removed the two doc-table tests and
  the two default assertions for the deleted keys.

## Security self-check

No new input surface, dependencies, endpoints, or external calls — this PR only
deletes configuration. Removing the keys narrows the accepted input surface, and
a consumer that still sets one now fails `deno check` rather than being silently
ignored.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-ms8a28z3-959621`<!-- vibe-worker-issue-3552 -->