### PR TITLE
chore: remove unused enableRepetitiveTraining flag (#3505 slice A) (Issue #3553)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "6.1.6",
+  "version": "6.1.7",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/OPTION_AUDIT_CONSOLIDATED.md
+++ b/docs/OPTION_AUDIT_CONSOLIDATED.md
@@ -42,7 +42,7 @@ grounds for removal.
 
 ```mermaid
 flowchart LR
-    H["#3518 harness<br/>enumerateOptionKeys()"] --> INV["275 rows<br/>115 top-level + 160 nested"]
+    H["#3518 harness<br/>enumerateOptionKeys()"] --> INV["274 rows<br/>114 top-level + 160 nested"]
     A["Slices A–F<br/>#3519–#3524"] --> TAB["Merged table<br/>optionAuditRollup.ts"]
     INV --> REC{"reconcile()"}
     TAB --> REC
@@ -62,7 +62,7 @@ run on every CI build by
 
 ```bash
 deno run --allow-read scripts/option-audit-rollup.ts
-# 🔎 275 enumerated rows (115 top-level, 160 nested) · 275 classified
+# 🔎 274 enumerated rows (114 top-level, 160 nested) · 274 classified
 # ✅ zero coverage gaps — every option key is classified
 ```
 
@@ -77,7 +77,7 @@ in #3518 and #3525. The original figure came from a grep that skipped
 `readonly mutation: readonly MutationInterface[]`; the parser-backed harness saw
 the real 119, and its CI test pins that number. Every slice brief was written
 from the 118-key list, so **no slice classified `mutation`**. (The pinned count
-is **115** today, as executed removals have taken keys back out. See
+is **114** today, as executed removals have taken keys back out. See
 [Executed removals](#executed-removals).)
 
 This roll-up classified it with the slice method — `git grep`, exit code
@@ -99,11 +99,12 @@ reported as an orphan (`reconcile()` lists keys the source no longer has) and
 fails `test/scripts/OptionAuditRollup.ts`. The counts in this document therefore
 shrink as the campaign proceeds.
 
-| Issue | Key                                | Slice | Landed                                                       |
-| ----- | ---------------------------------- | ----- | ------------------------------------------------------------ |
-| #3556 | `discoveryReplayDiagnostics`       | B     | Timing instrumentation and its `diagnostics` payload gone.   |
-| #3558 | `ensembleDiversity`                | C     | Parsed-but-never-read config and its 10 nested fields gone.  |
-| #3552 | `maxConns`, `maximumNumberOfNodes` | A     | Both `Mutator` growth guards gone; `maxSynapses` still caps. |
+| Issue | Key                                | Slice | Landed                                                              |
+| ----- | ---------------------------------- | ----- | ------------------------------------------------------------------- |
+| #3556 | `discoveryReplayDiagnostics`       | B     | Timing instrumentation and its `diagnostics` payload gone.          |
+| #3558 | `ensembleDiversity`                | C     | Parsed-but-never-read config and its 10 nested fields gone.         |
+| #3552 | `maxConns`, `maximumNumberOfNodes` | A     | Both `Mutator` growth guards gone; `maxSynapses` still caps.        |
+| #3553 | `enableRepetitiveTraining`         | A     | Repeat-training gate gone; the schedule guard is now unconditional. |
 
 ### `fitnessSampleRate` and `seed`
 
@@ -125,18 +126,18 @@ per-slice totals shift:
 
 | Slice     | Slice comment | Roll-up | Why                                                                                                                                               |
 | --------- | ------------: | ------: | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| A         |            46 |      44 | —                                                                                                                                                 |
+| A         |            46 |      43 | —                                                                                                                                                 |
 | B         |            36 |      42 | B classified its 3 nested configs at parent level; the harness enumerates `DiscoveryCacheConfig` (4) + `DiskSpaceConfig` (3) fields individually. |
 | C         |            59 |      45 | `adaptiveMutationThresholds` is declared inline in `NeatArguments`, so its 3 fields are not separate nested rows.                                 |
 | D         |            69 |      63 | Same for `plateauDetection`'s 6 inline fields.                                                                                                    |
 | E         |            33 |      37 | `RustScorerConfig` has no `NeatOptions` key (−1 parent row) but two interfaces, so `RequiredRustScorerConfig`'s 5 fields are enumerated too (+5). |
 | F         |            43 |      43 | —                                                                                                                                                 |
 | roll-up   |             — |       1 | `mutation`.                                                                                                                                       |
-| **Total** |       **286** | **275** |                                                                                                                                                   |
+| **Total** |       **286** | **274** |                                                                                                                                                   |
 
 No slice lost a key in the merge; the deltas are enumeration conventions plus
-the [executed removals](#executed-removals) — A is down 2 (#3552), B down 1
-(#3556) and C down 11 (#3558 and its 10 nested fields).
+the [executed removals](#executed-removals) — A is down 3 (#3552 and #3553), B
+down 1 (#3556) and C down 11 (#3558 and its 10 nested fields).
 
 ## Merged classification table
 
@@ -183,7 +184,6 @@ set independently. Generated by
 | `mutation`                                    | roll-up | `IN USE`    | —     | Gap found by this roll-up. GRQ `src/{exchange,fx,industry,location}/EvolveApp.ts` set it. |
 | `iterations`                                  | A       | `IN USE`    | —     |                                                                                           |
 | `verbose`                                     | A       | `IN USE`    | —     |                                                                                           |
-| `enableRepetitiveTraining`                    | A       | `QUALIFIES` | #3553 |                                                                                           |
 | `skipTrainingAfterConsecutiveRegressions`     | A       | `KEEP`      | —     |                                                                                           |
 | `subnetworkIndexSize`                         | A       | `KEEP`      | —     |                                                                                           |
 | `trainingBatchSize`                           | A       | `KEEP`      | —     |                                                                                           |

--- a/docs/archive/pr-summaries/pr-summary-3553.md
+++ b/docs/archive/pr-summaries/pr-summary-3553.md
@@ -1,0 +1,110 @@
+# chore: remove unused `enableRepetitiveTraining` flag (#3553)
+
+## Summary
+
+Removes the `enableRepetitiveTraining` option — slice A of the
+[#3505](https://github.com/stSoftwareAU/NEAT-AI/issues/3505) option audit
+(#3519), following the #3502 / #3552 pattern. Closes #3553.
+
+No consumer sets it (GRQ and NEAT-AI-Examples both return zero hits through
+`git grep` and `gh search code`, with `populationSize` as the positive control),
+and it defaulted to `false`. Its sole reader was the repeat-scheduling guard in
+`scheduleTraining()`:
+
+```ts
+if (neat.alreadyScheduledMap.has(uuid)) {
+  if (!neat.config.enableRepetitiveTraining) {
+    return;
+  }
+}
+```
+
+At the default the inner branch always returned, so collapsing it to an
+unconditional `return` preserves production behaviour exactly.
+
+Removed:
+
+- **Option surface** — `NeatArguments.enableRepetitiveTraining` and the
+  `createNeatConfig()` assignment. `NeatOptions` derives from
+  `Partial<NeatArguments>`, so it drops the key automatically; nothing in
+  `NeatOptions.ts` needed editing.
+- **Plumbing** — the nested guard in `src/NEAT/NeatScheduling.ts`, now a single
+  unconditional early return.
+- **Test option literals** — the three sites that set the flag `true`
+  (`test/NEAT/Ratios.ts`, `test/NEAT/Evolve.ts`, and the commented-out
+  `NARX Sequence` block in `test/creature/CreatureTrainEvolve.ts`).
+- **Audit book-keeping** — the `SLICE_A` roll-up entry (a retained entry would
+  be reported as an orphan by `reconcile()`), the pinned `NeatArguments`
+  top-level count (115 → 114), and the counts in
+  `docs/OPTION_AUDIT_CONSOLIDATED.md`.
+
+### Reviewer caveat resolved
+
+The issue flagged the three flag-setting tests as needing a rewrite because they
+"exercise the repeat-scheduling path". On inspection they do not: all three set
+the flag as one entry in a `NeatOptions` literal for a retry-looped evolution
+test and assert only on the final error rate — none asserts anything about
+re-scheduling. Deleting the line leaves their assertions intact (the full suite
+is green), and `test/NEAT/SchedulingRepeatGuard.ts` now covers the guard
+directly, which none of them did.
+
+### Scheduling path after removal
+
+```mermaid
+flowchart TD
+    A[scheduleTraining] --> B{training in flight?}
+    B -- yes --> R[return]
+    B -- no --> C{budget too small?}
+    C -- yes --> R
+    C -- no --> D{already scheduled<br/>this run?}
+    D -- yes --> R
+    D -- no --> E{regression streak?}
+    E -- yes --> R
+    E -- no --> F[dispatch to worker]
+```
+
+The `already scheduled` node was previously a two-level branch whose inner test
+read the flag; it is now a plain guard.
+
+## Evidence
+
+Backend/library change with no web interface, so there is no screenshot to
+capture. Evidence is the quality gate and the new tests:
+
+- `./quality.sh` — **8102 passed, 0 failed, 4 ignored** (2m32s); `deno fmt`
+  clean (2300 files), `deno lint` clean (1887 files), `deno check` clean.
+- `deno check` is the substantive signal here: deleting the key from
+  `NeatArguments` makes any consumer that still sets it a compile error rather
+  than a silent no-op. The downstream signal is the next `@stsoftware/neat-ai`
+  pin bump in GRQ and NEAT-AI-Examples.
+- `deno run --allow-read scripts/option-audit-rollup.ts` —
+  `274 enumerated rows (114 top-level, 160 nested) · 274 classified`, zero
+  coverage gaps.
+- Post-removal grep for `enableRepetitiveTraining` across `src/`, `test/`,
+  `scripts/` and `bench/` returns only the explanatory comments in
+  `NeatScheduling.ts` and the two regression-guard tests.
+
+## Test Plan
+
+Added `test/NEAT/SchedulingRepeatGuard.ts` — calls the real `scheduleTraining()`
+against a stub `Neat` with a counting stub worker:
+
+- `scheduleTraining dispatches a creature seen for the first time` — control;
+  asserts one dispatch and that the uuid is recorded in `alreadyScheduledMap`.
+- `scheduleTraining skips a creature already scheduled this run` — the behaviour
+  the removed flag used to gate; asserts zero dispatches when the uuid is
+  pre-seeded into `alreadyScheduledMap`.
+
+Added to `test/config/NeatOptions.ts`, alongside the equivalent #3558
+`ensembleDiversity` guard:
+
+- `NeatOptions - enableRepetitiveTraining is not a config key` — fails against
+  the unfixed code and passes after the removal; guards against reintroduction.
+
+Modified:
+
+- `test/scripts/AuditOptionUsage.ts` — pinned top-level key count 115 → 114,
+  with the reason appended to the existing comment chain.
+- `test/NEAT/Ratios.ts`, `test/NEAT/Evolve.ts`,
+  `test/creature/CreatureTrainEvolve.ts` — dropped the now-invalid option key;
+  all assertions unchanged.

--- a/scripts/lib/optionAuditRollup.ts
+++ b/scripts/lib/optionAuditRollup.ts
@@ -69,14 +69,14 @@ const qualifies = (
 /**
  * Slice A (#3519) — 46 non-`discovery*` top-level options.
  *
- * Two of slice A's `QUALIFIES` verdicts, `maxConns` and
- * `maximumNumberOfNodes`, were carried out by #3552: the keys no longer exist
- * in `NeatArguments`, so the harness no longer enumerates them and their
- * entries are gone from this table. A retained entry would be an orphan
- * (`reconcile()` reports keys the source no longer has).
+ * Three of slice A's `QUALIFIES` verdicts have been carried out: `maxConns`
+ * and `maximumNumberOfNodes` by #3552, and `enableRepetitiveTraining` by
+ * #3553. Those keys no longer exist in `NeatArguments`, so the harness no
+ * longer enumerates them and their entries are gone from this table. A
+ * retained entry would be an orphan (`reconcile()` reports keys the source no
+ * longer has).
  */
 const SLICE_A: RollupEntry[] = [
-  qualifies("enableRepetitiveTraining", "A", 3553),
   qualifies("dnaSharingMode", "A", 3554, {
     note:
       "Slice F confirmed `DnaSharingPreset.ts` is covered here and filed nothing.",

--- a/src/NEAT/NeatScheduling.ts
+++ b/src/NEAT/NeatScheduling.ts
@@ -293,11 +293,10 @@ export function scheduleTraining(
     return;
   }
 
-  if (neat.alreadyScheduledMap.has(uuid)) {
-    if (!neat.config.enableRepetitiveTraining) {
-      return;
-    }
-  }
+  // Issue #3553: a creature is trained at most once per run. This guard was
+  // previously gated on the unused `enableRepetitiveTraining` flag, which
+  // defaulted to `false` and was never set by any consumer.
+  if (neat.alreadyScheduledMap.has(uuid)) return;
 
   // Issue #2382: bypass training for creatures whose last N attempts all
   // produced a higher error and no usable fine-tune variant. The heavy

--- a/src/config/NeatArguments.ts
+++ b/src/config/NeatArguments.ts
@@ -195,8 +195,6 @@ export interface NeatArguments {
   /** Enable verbose logging. Default is false. */
   verbose: boolean;
 
-  enableRepetitiveTraining: boolean;
-
   /**
    * Issue #2382: Skip scheduling training for a creature whose last N training
    * attempts all produced a higher error and no usable fine-tune variant. A

--- a/src/config/NeatConfig.ts
+++ b/src/config/NeatConfig.ts
@@ -401,8 +401,6 @@ export function createNeatConfig(options: NeatOptionsInput): NeatConfig {
     }),
     verbose: options.verbose ? true : false,
 
-    enableRepetitiveTraining: options.enableRepetitiveTraining || false,
-
     // Issue #2382: skip training for a creature whose last N attempts all
     // produced a higher error and no usable fine-tune variant. Default of 2
     // means a creature must regress twice in a row before it is bypassed.

--- a/test/NEAT/Evolve.ts
+++ b/test/NEAT/Evolve.ts
@@ -189,7 +189,6 @@ Deno.test("XNOR - evolve", async () => {
         const results = await creature.evolveDataSet(trainingSet, {
           targetError: 0.05,
           iterations: 20_000,
-          enableRepetitiveTraining: true,
           threads: 1,
         });
 

--- a/test/NEAT/Ratios.ts
+++ b/test/NEAT/Ratios.ts
@@ -26,7 +26,6 @@ Deno.test("hypotenuse", async () => {
     targetError: 0.002,
     log: 50,
     elitism: 3,
-    enableRepetitiveTraining: true,
     threads: 1, // Avoid worker init in test; multi-threaded evolution is tested elsewhere.
   };
 

--- a/test/NEAT/SchedulingRepeatGuard.ts
+++ b/test/NEAT/SchedulingRepeatGuard.ts
@@ -1,0 +1,84 @@
+/**
+ * Issue #3553: `scheduleTraining()` never re-dispatches a creature that has
+ * already been scheduled this run.
+ *
+ * The guard used to be conditional on the unused `enableRepetitiveTraining`
+ * flag, which defaulted to `false` — so in every production run the branch
+ * returned unconditionally. These tests lock that behaviour in now the flag
+ * is gone.
+ */
+import { assert, assertEquals } from "@std/assert";
+import { CreatureUtil } from "@architecture/CreatureUtils.ts";
+import { createNeatConfig } from "@config/NeatConfig.ts";
+import { Creature } from "@creature";
+import type { Neat } from "@neat/Neat.ts";
+import { scheduleTraining } from "@neat/NeatScheduling.ts";
+import { TrainingRegressionTracker } from "@neat/TrainingRegressionTracker.ts";
+import { initWasmForTests } from "../_initWasm.ts";
+
+/** Records how many times a training task was dispatched to a worker. */
+class StubWorker {
+  trainCalls = 0;
+
+  train(): Promise<never> {
+    this.trainCalls++;
+    // Never settles: the test only cares about dispatch, not the outcome.
+    // A pending promise leaks no ops or resources.
+    return new Promise<never>(() => {});
+  }
+}
+
+function createStubNeat(worker: StubWorker): Neat {
+  const pool = {
+    selectWorker: () => worker,
+    getIdleWorkers: () => [],
+  };
+  return {
+    config: createNeatConfig({}),
+    hardDeadlineTS: 0,
+    abandonEpoch: 0,
+    trainingInProgress: new Map(),
+    trainingDeadlines: new Map(),
+    alreadyScheduledMap: new Map<string, number>(),
+    trainingRegressionTracker: new TrainingRegressionTracker(),
+    heavyWorkerPool: pool,
+    fastWorkerPool: pool,
+    isRunAbandonedSince: () => false,
+    recordTrainingComplete: () => {},
+  } as unknown as Neat;
+}
+
+Deno.test("scheduleTraining dispatches a creature seen for the first time", async () => {
+  await initWasmForTests();
+  const worker = new StubWorker();
+  const neat = createStubNeat(worker);
+  const creature = new Creature(2, 1);
+  const uuid = CreatureUtil.makeUUID(creature);
+
+  scheduleTraining(neat, creature, 5);
+
+  assertEquals(worker.trainCalls, 1, "First schedule should dispatch");
+  assert(
+    neat.alreadyScheduledMap.has(uuid),
+    "Dispatch should record the creature as scheduled",
+  );
+});
+
+Deno.test("scheduleTraining skips a creature already scheduled this run", async () => {
+  await initWasmForTests();
+  const worker = new StubWorker();
+  const neat = createStubNeat(worker);
+  const creature = new Creature(2, 1);
+  const uuid = CreatureUtil.makeUUID(creature);
+
+  // Previously scheduled, but no longer in flight (the run completed it).
+  neat.alreadyScheduledMap.set(uuid, Date.now());
+
+  scheduleTraining(neat, creature, 5);
+
+  assertEquals(
+    worker.trainCalls,
+    0,
+    "An already-scheduled creature must never be re-dispatched",
+  );
+});

--- a/test/config/NeatOptions.ts
+++ b/test/config/NeatOptions.ts
@@ -96,6 +96,13 @@ Deno.test("NeatOptions - ensembleDiversity is not a config key", () => {
   assertEquals(Object.hasOwn(config, "ensembleDiversity"), false);
 });
 
+// Issue #3553: enableRepetitiveTraining was removed as an unused option — the
+// parsed config must no longer carry it (regression guard against reintroduction).
+Deno.test("NeatOptions - enableRepetitiveTraining is not a config key", () => {
+  const config = createNeatConfig({}) as unknown as Record<string, unknown>;
+  assertEquals(Object.hasOwn(config, "enableRepetitiveTraining"), false);
+});
+
 Deno.test("NeatOptions - seed option produces deterministic RNG", () => {
   const config1 = createNeatConfig({ seed: 42 });
   const config2 = createNeatConfig({ seed: 42 });

--- a/test/creature/CreatureTrainEvolve.ts
+++ b/test/creature/CreatureTrainEvolve.ts
@@ -434,7 +434,6 @@ Deno.test("NARX Sequence", async () => {
       iterations: 500,
       targetError:targetError,
       feedbackLoop: true,
-      enableRepetitiveTraining: true,
     });
 
     if (result.error <= targetError){

--- a/test/scripts/AuditOptionUsage.ts
+++ b/test/scripts/AuditOptionUsage.ts
@@ -148,10 +148,11 @@ Deno.test("enumerateOptionKeys - pins the real NeatArguments top-level surface",
   // which came from a grep that skipped `readonly mutation` — the parser saw
   // the real 119. #3558 then removed `ensembleDiversity`, leaving 118; #3556
   // then removed `discoveryReplayDiagnostics`, leaving 117; #3552 then removed
-  // `maxConns` and `maximumNumberOfNodes`, leaving 115.
+  // `maxConns` and `maximumNumberOfNodes`, leaving 115; #3553 then removed
+  // `enableRepetitiveTraining`, leaving 114.
   assertEquals(
     topLevel.length,
-    115,
+    114,
     "NeatArguments top-level key count changed",
   );
   assert(


### PR DESCRIPTION
# chore: remove unused `enableRepetitiveTraining` flag (#3553)

## Summary

Removes the `enableRepetitiveTraining` option — slice A of the
[#3505](https://github.com/stSoftwareAU/NEAT-AI/issues/3505) option audit
(#3519), following the #3502 / #3552 pattern. Closes #3553.

No consumer sets it (GRQ and NEAT-AI-Examples both return zero hits through
`git grep` and `gh search code`, with `populationSize` as the positive control),
and it defaulted to `false`. Its sole reader was the repeat-scheduling guard in
`scheduleTraining()`:

```ts
if (neat.alreadyScheduledMap.has(uuid)) {
  if (!neat.config.enableRepetitiveTraining) {
    return;
  }
}
```

At the default the inner branch always returned, so collapsing it to an
unconditional `return` preserves production behaviour exactly.

Removed:

- **Option surface** — `NeatArguments.enableRepetitiveTraining` and the
  `createNeatConfig()` assignment. `NeatOptions` derives from
  `Partial<NeatArguments>`, so it drops the key automatically; nothing in
  `NeatOptions.ts` needed editing.
- **Plumbing** — the nested guard in `src/NEAT/NeatScheduling.ts`, now a single
  unconditional early return.
- **Test option literals** — the three sites that set the flag `true`
  (`test/NEAT/Ratios.ts`, `test/NEAT/Evolve.ts`, and the commented-out
  `NARX Sequence` block in `test/creature/CreatureTrainEvolve.ts`).
- **Audit book-keeping** — the `SLICE_A` roll-up entry (a retained entry would
  be reported as an orphan by `reconcile()`), the pinned `NeatArguments`
  top-level count (115 → 114), and the counts in
  `docs/OPTION_AUDIT_CONSOLIDATED.md`.

### Reviewer caveat resolved

The issue flagged the three flag-setting tests as needing a rewrite because they
"exercise the repeat-scheduling path". On inspection they do not: all three set
the flag as one entry in a `NeatOptions` literal for a retry-looped evolution
test and assert only on the final error rate — none asserts anything about
re-scheduling. Deleting the line leaves their assertions intact (the full suite
is green), and `test/NEAT/SchedulingRepeatGuard.ts` now covers the guard
directly, which none of them did.

### Scheduling path after removal

```mermaid
flowchart TD
    A[scheduleTraining] --> B{training in flight?}
    B -- yes --> R[return]
    B -- no --> C{budget too small?}
    C -- yes --> R
    C -- no --> D{already scheduled<br/>this run?}
    D -- yes --> R
    D -- no --> E{regression streak?}
    E -- yes --> R
    E -- no --> F[dispatch to worker]
```

The `already scheduled` node was previously a two-level branch whose inner test
read the flag; it is now a plain guard.

## Evidence

Backend/library change with no web interface, so there is no screenshot to
capture. Evidence is the quality gate and the new tests:

- `./quality.sh` — **8102 passed, 0 failed, 4 ignored** (2m32s); `deno fmt`
  clean (2300 files), `deno lint` clean (1887 files), `deno check` clean.
- `deno check` is the substantive signal here: deleting the key from
  `NeatArguments` makes any consumer that still sets it a compile error rather
  than a silent no-op. The downstream signal is the next `@stsoftware/neat-ai`
  pin bump in GRQ and NEAT-AI-Examples.
- `deno run --allow-read scripts/option-audit-rollup.ts` —
  `274 enumerated rows (114 top-level, 160 nested) · 274 classified`, zero
  coverage gaps.
- Post-removal grep for `enableRepetitiveTraining` across `src/`, `test/`,
  `scripts/` and `bench/` returns only the explanatory comments in
  `NeatScheduling.ts` and the two regression-guard tests.

## Test Plan

Added `test/NEAT/SchedulingRepeatGuard.ts` — calls the real `scheduleTraining()`
against a stub `Neat` with a counting stub worker:

- `scheduleTraining dispatches a creature seen for the first time` — control;
  asserts one dispatch and that the uuid is recorded in `alreadyScheduledMap`.
- `scheduleTraining skips a creature already scheduled this run` — the behaviour
  the removed flag used to gate; asserts zero dispatches when the uuid is
  pre-seeded into `alreadyScheduledMap`.

Added to `test/config/NeatOptions.ts`, alongside the equivalent #3558
`ensembleDiversity` guard:

- `NeatOptions - enableRepetitiveTraining is not a config key` — fails against
  the unfixed code and passes after the removal; guards against reintroduction.

Modified:

- `test/scripts/AuditOptionUsage.ts` — pinned top-level key count 115 → 114,
  with the reason appended to the existing comment chain.
- `test/NEAT/Ratios.ts`, `test/NEAT/Evolve.ts`,
  `test/creature/CreatureTrainEvolve.ts` — dropped the now-invalid option key;
  all assertions unchanged.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-ms8ch0h6-b310eb`<!-- vibe-worker-issue-3553 -->