### PR TITLE
Isolate the ACTIONS_PUSH PAT from PR-controlled code in quality.yml (Issue #3607)

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -25,80 +25,40 @@ permissions:
   contents: read
 
 jobs:
+  # Everything in this job runs code from the pull request head — `build.sh`,
+  # `deno check`/`fmt`/`lint`, and the repo's own scripts. It therefore holds
+  # NO credential beyond the default read-scoped `GITHUB_TOKEN` (Issue #3607).
+  # Any fmt/lint fixes leave as a patch artefact for the `push-fixes` job,
+  # which is the only place `secrets.ACTIONS_PUSH` appears.
   quality:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
       NEAT_RUST_DISCOVERY_OPTIONAL: "true"
+    outputs:
+      has_changes: ${{ steps.check_changes.outputs.has_changes }}
 
     steps:
       # Checkout the code.
       #
+      # The fetch uses the default `GITHUB_TOKEN` (scoped `contents: read`
+      # above) — read access is all this job needs, and keeping the
+      # privileged PAT out of the job that executes PR-controlled code is
+      # the point of the split (Issue #3607).
+      #
       # `persist-credentials: false` (Issue #2727) — the default `true`
       # writes the fetch token into `.git/config`
       # (`http.https://github.com/.extraheader = AUTHORIZATION: basic …`)
-      # for the rest of the job. Because a later step runs PR-controlled
-      # code (`./build.sh --verify-only`) and the fetch token here is the
-      # privileged `secrets.ACTIONS_PUSH` PAT, persisting it would let a
-      # malicious PR read `.git/config` and exfiltrate the PAT. The PAT is
-      # re-introduced only at push time via a per-command auth header so
-      # it never lives on disk.
+      # for the rest of the job, where PR-controlled code could read it.
       - name: Checkout Code
         # actions/checkout@v6.0.2
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
-          token: ${{ secrets.ACTIONS_PUSH }} # Use the GitHub Actions token for write access
           persist-credentials: false
-          # For pull_request events, explicitly checkout the PR head branch to enable pushing
+          # For pull_request events, explicitly checkout the PR head branch so
+          # the checks see exactly what the contributor pushed.
           ref: ${{ github.event.pull_request.head.ref || github.ref }}
           fetch-depth: 0
-
-      # Ensure we're on the correct branch and prevent pushing to protected branches
-      # Untrusted GitHub-context strings (the PR source branch name is attacker-
-      # controllable) are passed via env: rather than interpolated into the
-      # script body, so shell metacharacters in branch names cannot break out
-      # of quoting (Issue #2709).
-      - name: Setup Branch
-        id: branch_setup
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
-          GITHUB_REF_NAME: ${{ github.ref_name }}
-        run: |
-          set -Eeuo pipefail
-          # Determine the branch name
-          if [[ "$EVENT_NAME" == "pull_request" ]]; then
-            BRANCH_NAME="$PR_HEAD_REF"
-          else
-            BRANCH_NAME="$GITHUB_REF_NAME"
-          fi
-
-          # Defence in depth: reject branch names that contain shell
-          # metacharacters or that could be parsed as a git option. Even
-          # though the value reaches git as a single argv element, a name
-          # beginning with `-` would still be interpreted as a flag.
-          if [[ ! "$BRANCH_NAME" =~ ^[A-Za-z0-9._/-]+$ ]] || [[ "$BRANCH_NAME" == -* ]]; then
-            echo "❌ Refusing to act on suspicious branch name: $BRANCH_NAME" >&2
-            exit 1
-          fi
-
-          # Protect default branch - never push to Develop
-          PROTECTED_BRANCHES="Develop main master"
-          for protected in $PROTECTED_BRANCHES; do
-            if [[ "$BRANCH_NAME" == "$protected" ]]; then
-              echo "❌ Cannot push to protected branch: $BRANCH_NAME" >&2
-              echo "Protected branches can only be updated via PR." >&2
-              exit 1
-            fi
-          done
-
-          # Ensure we're on the branch (checkout@v4 with ref: may leave us in
-          # detached HEAD). `--` after the branch name ends option parsing
-          # before any pathspecs (none here), preserving git's
-          # branch-switch semantics.
-          git checkout "$BRANCH_NAME" -- 2>/dev/null || git checkout -b "$BRANCH_NAME" --
-
-          echo "branch_name=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
 
       - name: Check Bash Script Syntax
         run: |
@@ -251,20 +211,140 @@ jobs:
       - name: Make executable
         run: find . -type f -name "*.sh" -exec chmod u+x {} +
 
-      # Check for Changes
+      # Check for Changes — capture the fmt/lint fixes as a patch so the
+      # privileged `push-fixes` job can apply them as data without ever
+      # executing anything from the PR tree (Issue #3607). `--binary` keeps
+      # any `wasm_activation/pkg` deltas applicable.
       - name: Check for Changes
         id: check_changes # Define step ID to use outputs
+        env:
+          PATCH_FILE: ${{ runner.temp }}/quality-fixes.patch
         run: |
+          set -Eeuo pipefail
           if git diff --quiet; then
             echo "has_changes=false" >> "$GITHUB_OUTPUT"
           else
+            git diff --binary > "$PATCH_FILE"
             echo "has_changes=true" >> "$GITHUB_OUTPUT"
           fi
 
-      # Commit Changes
-      - name: Commit Changes
-        if: steps.check_changes.outputs.has_changes == 'true' # Use step output
+      - name: Upload Fix Patch
+        if: steps.check_changes.outputs.has_changes == 'true'
+        # actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: quality-fix-patch
+          path: ${{ runner.temp }}/quality-fixes.patch
+          retention-days: 1
+          if-no-files-found: error
+
+      # Note: Tests are run in coverage.yaml workflow
+      # - coverage.yaml runs all tests with full permissions (including FFI) for coverage reporting
+      # - Discovery tests gracefully skip when Rust library is unavailable via ignore: !isRustDiscoveryEnabled()
+      # - No need to run tests here as they're already covered in the coverage workflow
+
+  # The only job that sees `secrets.ACTIONS_PUSH` (Issue #3607). It executes
+  # nothing from the checked-out tree: it applies the fmt/lint patch produced
+  # by `quality` as pure data, commits it, and pushes. Because a fresh
+  # checkout runs here, no `$GITHUB_PATH` entry, `$GITHUB_ENV` variable or
+  # repo-local git config planted by PR-controlled code in `quality` can reach
+  # the push.
+  push-fixes:
+    needs: quality
+    if: needs.quality.outputs.has_changes == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout Code
+        # actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          fetch-depth: 0
+
+      # Ensure we're on the correct branch and prevent pushing to protected
+      # branches. The branch name is derived from the GitHub context and
+      # re-validated here — never taken from the `quality` job's outputs,
+      # which PR-controlled code can write to freely.
+      #
+      # Untrusted GitHub-context strings (the PR source branch name is
+      # attacker-controllable) are passed via env: rather than interpolated
+      # into the script body, so shell metacharacters in branch names cannot
+      # break out of quoting (Issue #2709).
+      - name: Setup Branch
+        id: branch_setup
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          GITHUB_REF_NAME: ${{ github.ref_name }}
         run: |
+          set -Eeuo pipefail
+          # Determine the branch name
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            BRANCH_NAME="$PR_HEAD_REF"
+          else
+            BRANCH_NAME="$GITHUB_REF_NAME"
+          fi
+
+          # Defence in depth: reject branch names that contain shell
+          # metacharacters or that could be parsed as a git option. Even
+          # though the value reaches git as a single argv element, a name
+          # beginning with `-` would still be interpreted as a flag.
+          if [[ ! "$BRANCH_NAME" =~ ^[A-Za-z0-9._/-]+$ ]] || [[ "$BRANCH_NAME" == -* ]]; then
+            echo "❌ Refusing to act on suspicious branch name: $BRANCH_NAME" >&2
+            exit 1
+          fi
+
+          # Protect default branch - never push to Develop
+          PROTECTED_BRANCHES="Develop main master"
+          for protected in $PROTECTED_BRANCHES; do
+            if [[ "$BRANCH_NAME" == "$protected" ]]; then
+              echo "❌ Cannot push to protected branch: $BRANCH_NAME" >&2
+              echo "Protected branches can only be updated via PR." >&2
+              exit 1
+            fi
+          done
+
+          # Ensure we're on the branch (checkout@v4 with ref: may leave us in
+          # detached HEAD). `--` after the branch name ends option parsing
+          # before any pathspecs (none here), preserving git's
+          # branch-switch semantics.
+          git checkout "$BRANCH_NAME" -- 2>/dev/null || git checkout -b "$BRANCH_NAME" --
+
+          echo "branch_name=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
+
+      - name: Download Fix Patch
+        # actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: quality-fix-patch
+          path: ${{ runner.temp }}/fix-patch
+
+      - name: Apply Fix Patch
+        env:
+          PATCH_FILE: ${{ runner.temp }}/fix-patch/quality-fixes.patch
+        run: |
+          set -Eeuo pipefail
+          if [[ ! -s "$PATCH_FILE" ]]; then
+            echo "❌ Expected a non-empty fmt/lint patch at $PATCH_FILE" >&2
+            exit 1
+          fi
+
+          # Defence in depth: the patch was produced by the PR-controlled
+          # `quality` job, so refuse anything addressing the git directory.
+          # `git apply` rejects these too — fail loud before it gets there.
+          if grep -qE '^(diff --git |--- |\+\+\+ )[^\n]*\.git/' "$PATCH_FILE"; then
+            echo "❌ Patch addresses paths under .git/ — refusing to apply" >&2
+            exit 1
+          fi
+
+          git apply --binary --whitespace=nowarn "$PATCH_FILE"
+
+      - name: Commit Changes
+        run: |
+          set -Eeuo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git commit -am "chore: apply deno fmt and lint fixes"
@@ -274,12 +354,11 @@ jobs:
       #
       # The PAT is re-introduced here via a per-command
       # `http.https://github.com/.extraheader` so it never lives in
-      # `.git/config` for any PR-controlled step to read (Issue #2727).
-      # `GH_PAT` is passed through the step env: map rather than
-      # interpolated into the script body to avoid leaking the secret
-      # into shell expansion or `ps`/job-log echo paths.
+      # `.git/config` (Issue #2727). `GH_PAT` is passed through the step env:
+      # map rather than interpolated into the script body to avoid leaking the
+      # secret into shell expansion or `ps`/job-log echo paths.
       - name: Push Changes
-        if: steps.check_changes.outputs.has_changes == 'true' && steps.branch_setup.outputs.branch_name != ''
+        if: steps.branch_setup.outputs.branch_name != ''
         env:
           BRANCH_NAME: ${{ steps.branch_setup.outputs.branch_name }}
           GH_PAT: ${{ secrets.ACTIONS_PUSH }}
@@ -288,8 +367,3 @@ jobs:
           AUTH_HEADER="AUTHORIZATION: basic $(printf 'x-access-token:%s' "$GH_PAT" | base64 -w0)"
           git -c http.https://github.com/.extraheader="$AUTH_HEADER" \
             push origin "$BRANCH_NAME"
-
-      # Note: Tests are run in coverage.yaml workflow
-      # - coverage.yaml runs all tests with full permissions (including FFI) for coverage reporting
-      # - Discovery tests gracefully skip when Rust library is unavailable via ignore: !isRustDiscoveryEnabled()
-      # - No need to run tests here as they're already covered in the coverage workflow

--- a/docs/REPO_GOVERNANCE.md
+++ b/docs/REPO_GOVERNANCE.md
@@ -14,9 +14,16 @@ run with secrets beyond the default `GITHUB_TOKEN`:
 | `.github/workflows/publish.yml`                | `id-token: write` — OIDC tokenless publish of `@stsoftware/neat-ai` to JSR |
 | `.github/workflows/pages.yml`                  | `id-token: write` + `pages: write` — GitHub Pages deploy                   |
 | `.github/workflows/update-package-version.yml` | `secrets.ACTIONS_PUSH` — write-scoped push PAT                             |
-| `.github/workflows/quality.yml`                | `secrets.ACTIONS_PUSH`, `secrets.GITLEAKS_LICENSE`                         |
+| `.github/workflows/quality.yml`                | `secrets.ACTIONS_PUSH` (`push-fixes` job only), `secrets.GITLEAKS_LICENSE` |
 | `.github/workflows/semgrep.yml`                | `secrets.SEMGREP_APP_TOKEN`                                                |
 | `.github/workflows/coverage.yaml`              | `secrets.CODECOV_TOKEN`                                                    |
+
+`quality.yml` splits its privileged capability out of the job that runs
+PR-controlled code (Issue #3607): the `quality` job executes `build.sh` and the
+Deno checks with only the read-scoped default `GITHUB_TOKEN` and hands its
+fmt/lint fixes on as a patch artefact, while the separate `push-fixes` job
+checks out fresh, applies that patch as data, and is the only place
+`secrets.ACTIONS_PUSH` is in scope.
 
 Without a code-owner rule covering `.github/workflows/`, a single careless or
 compromised account could open a pull request that quietly edits one of these

--- a/docs/archive/pr-summaries/pr-summary-3607.md
+++ b/docs/archive/pr-summaries/pr-summary-3607.md
@@ -1,0 +1,86 @@
+# Isolate the ACTIONS_PUSH PAT from PR-controlled code in quality.yml
+
+## Summary
+
+`.github/workflows/quality.yml` ran PR-controlled code (`build.sh`, plus
+`deno check`/`fmt`/`lint`) in the same job that held the org-level
+`ACTIONS_PUSH` PAT. `persist-credentials: false` (Issue #2727) kept the PAT out
+of `.git/config`, but steps in one job share the workspace, `$GITHUB_ENV` and
+`$GITHUB_PATH` — so a same-repo PR editing `build.sh` could plant a `git` shim
+on `$GITHUB_PATH`, or write a repo-local git config/hook, and the later
+`Push Changes` step would execute it with `GH_PAT` in scope.
+
+Both fixes from the issue are applied:
+
+1. **The checkout no longer fetches with the PAT.** The fetch only needs read
+   access, which the default `GITHUB_TOKEN` (already `contents: read`) provides;
+   the push supplies the PAT via the existing per-command
+   `http.<url>.extraheader`.
+2. **The job is split.** The `quality` job runs every PR-controlled step with no
+   credential beyond the default token and uploads the fmt/lint diff as a patch
+   artefact. A new `push-fixes` job checks out fresh, applies that patch as pure
+   data, commits and pushes — and is the only place `secrets.ACTIONS_PUSH`
+   appears.
+
+`push-fixes` derives the target branch from the GitHub context and re-runs the
+protected-branch guard locally; it never trusts the `quality` job's step
+outputs, which PR-controlled code can write to freely. It also refuses a patch
+whose file headers address paths under `.git/` before handing it to `git apply`
+(defence in depth — `git apply` rejects these too).
+
+Closes #3607.
+
+## Evidence
+
+Backend/CI change — no web interface to screenshot. The evidence is the workflow
+topology and the tests below.
+
+```mermaid
+flowchart TD
+    subgraph before["Before — one job"]
+        B1[Checkout with ACTIONS_PUSH PAT] --> B2["build.sh / deno check / fmt / lint<br/>(PR-controlled code)"]
+        B2 -->|"shared $GITHUB_PATH, $GITHUB_ENV, workspace"| B3[Push Changes with GH_PAT]
+        B3 --> B4([PAT reachable by PR-controlled code])
+    end
+
+    subgraph after["After — split jobs"]
+        A1["job: quality<br/>checkout with default GITHUB_TOKEN"] --> A2["build.sh / deno check / fmt / lint<br/>(PR-controlled code)"]
+        A2 --> A3[Upload fmt/lint patch artefact]
+        A3 -.->|artefact only| A4["job: push-fixes<br/>fresh checkout, no PR code executed"]
+        A4 --> A5[Apply patch as data → commit → push with GH_PAT]
+        A5 --> A6([PAT never shares a job with PR-controlled code])
+    end
+```
+
+## Test Plan
+
+New quality gate `test/ci/QualityWorkflowPatIsolation.ts` — four "what" tests
+that parse the committed workflow YAML and assert on the resulting
+job/credential topology:
+
+- `no job both runs PR-controlled code and holds the ACTIONS_PUSH PAT` — the
+  regression test for this issue; fails against the pre-fix workflow, naming the
+  four offending steps.
+- `no checkout fetches with the ACTIONS_PUSH PAT` — pins fix 1.
+- `the PAT-holding job executes no checked-out repository code` — the PAT job
+  may only use `actions/checkout` / `actions/download-artifact` and must run no
+  command that executes the PR tree.
+- `the PAT-holding job derives its push branch from the github context, not
+  from the PR-code job`
+  — no `needs.*` value reaches the push, and the protected-branch guard is
+  re-run.
+
+Existing workflow gates still pass unchanged, including
+`WorkflowPersistCredentialsFalse.ts` (#2727),
+`QualityWorkflowScriptInjection.ts` (#2709),
+`QualityWorkflowDepBumpQuarantine.ts` (#2697), `WorkflowJobTimeoutMinutes.ts`
+(#2841) and `WorkflowActionPinning.ts` (#2696).
+
+Full gate: `./quality.sh` — 8031 passed, 0 failed, 4 ignored. `actionlint`
+reports no findings on the edited workflow.
+
+## Documentation
+
+`docs/REPO_GOVERNANCE.md` — the privileged-workflow table now scopes
+`secrets.ACTIONS_PUSH` to the `push-fixes` job, with a short note on why the
+split exists.

--- a/test/ci/QualityWorkflowPatIsolation.ts
+++ b/test/ci/QualityWorkflowPatIsolation.ts
@@ -1,0 +1,207 @@
+/**
+ * Issue #3607 — `.github/workflows/quality.yml` must not run PR-controlled
+ * code in the same job that holds the org-level `ACTIONS_PUSH` PAT.
+ *
+ * `persist-credentials: false` (Issue #2727) keeps the PAT out of
+ * `.git/config`, but steps within one job share the workspace, `$GITHUB_ENV`
+ * and `$GITHUB_PATH`. A same-repo PR that edits `build.sh` can therefore
+ * prepend a directory to `$GITHUB_PATH` and plant a `git` shim, or write a
+ * repo-local git config/hook, and the later push step then executes it with
+ * the PAT in its environment.
+ *
+ * The fix splits the workflow: a first job runs the PR-controlled checks with
+ * only the default `GITHUB_TOKEN` and uploads the fmt/lint diff as an
+ * artefact; a second job checks out fresh, applies that patch as data, and is
+ * the only place `secrets.ACTIONS_PUSH` appears.
+ *
+ * These are "what" tests: they parse the committed workflow YAML and assert on
+ * the resulting job/credential topology.
+ */
+
+import { assert } from "@std/assert";
+import { fromFileUrl, join } from "@std/path";
+import { parse } from "@std/yaml";
+
+const REPO_ROOT = fromFileUrl(new URL("../../", import.meta.url));
+const WORKFLOW_PATH = ".github/workflows/quality.yml";
+
+interface Step {
+  name?: string;
+  uses?: string;
+  run?: string;
+  with?: Record<string, unknown>;
+  env?: Record<string, string>;
+}
+
+interface Job {
+  env?: Record<string, string>;
+  steps?: Step[];
+}
+
+interface Workflow {
+  jobs?: Record<string, Job>;
+}
+
+async function readWorkflow(): Promise<Workflow> {
+  const text = await Deno.readTextFile(join(REPO_ROOT, WORKFLOW_PATH));
+  return parse(text) as Workflow;
+}
+
+/**
+ * Command forms that execute code checked out from the pull request. Each is
+ * anchored at a statement boundary so a command *name* quoted inside an
+ * argument (e.g. a commit message mentioning `deno fmt`) is not mistaken for
+ * an invocation.
+ */
+const REPO_CODE_PATTERNS: RegExp[] = [
+  // `./build.sh`, `scripts/foo.sh`, … — a script from the PR tree.
+  /(?:^|[;&|(!])\s*\.{0,2}\/[\w./-]*\.(sh|bash)\b/m,
+  // `bash script.sh` — but not `bash -n file` (parse only, no execution).
+  /(?:^|[;&|(!])\s*(bash|sh|zsh)\s+\S*\.(sh|bash)\b/m,
+  // Deno runs PR-controlled config (deno.json tasks, lint plugins, imports).
+  /(?:^|[;&|(!])\s*deno\s/m,
+  /(?:^|[;&|(!])\s*(npm|npx|node|pnpm|yarn|make)\s/m,
+];
+
+function stepRunsRepoCode(step: Step): boolean {
+  if (typeof step.run !== "string") return false;
+  return REPO_CODE_PATTERNS.some((re) => re.test(step.run as string));
+}
+
+function jobRunsRepoCode(job: Job): boolean {
+  return (job.steps ?? []).some(stepRunsRepoCode);
+}
+
+/** True when `secrets.ACTIONS_PUSH` is reachable anywhere in the job. */
+function jobExposesPat(job: Job): boolean {
+  return /secrets\.ACTIONS_PUSH/.test(JSON.stringify(job));
+}
+
+function jobEntries(wf: Workflow): [string, Job][] {
+  return Object.entries(wf.jobs ?? {});
+}
+
+Deno.test(
+  "quality.yml: no job both runs PR-controlled code and holds the ACTIONS_PUSH PAT (Issue #3607)",
+  async () => {
+    const wf = await readWorkflow();
+    const offenders = jobEntries(wf)
+      .filter(([, job]) => jobExposesPat(job) && jobRunsRepoCode(job))
+      .map(([id, job]) => {
+        const steps = (job.steps ?? [])
+          .filter(stepRunsRepoCode)
+          .map((s) => `      - ${s.name ?? s.run?.trim().split("\n")[0]}`)
+          .join("\n");
+        return `  job "${id}" runs:\n${steps}`;
+      });
+
+    assert(
+      offenders.length === 0,
+      `${WORKFLOW_PATH} runs PR-controlled code in a job that holds ` +
+        "secrets.ACTIONS_PUSH. Steps in one job share $GITHUB_PATH, " +
+        "$GITHUB_ENV and the workspace, so PR-controlled code can plant a " +
+        "shim the later push step executes with the PAT in scope. Split the " +
+        "PR-controlled steps into a job that carries no PAT.\n" +
+        offenders.join("\n"),
+    );
+  },
+);
+
+Deno.test(
+  "quality.yml: no checkout fetches with the ACTIONS_PUSH PAT (Issue #3607)",
+  async () => {
+    const wf = await readWorkflow();
+    const checkouts = jobEntries(wf).flatMap(([id, job]) =>
+      (job.steps ?? [])
+        .filter((s) =>
+          typeof s.uses === "string" &&
+          s.uses.startsWith("actions/checkout@")
+        )
+        .map((s) => ({ id, step: s }))
+    );
+
+    assert(
+      checkouts.length > 0,
+      `${WORKFLOW_PATH} expected at least one actions/checkout step`,
+    );
+
+    for (const { id, step } of checkouts) {
+      const token = String(step.with?.token ?? "");
+      assert(
+        !/secrets\.ACTIONS_PUSH/.test(token),
+        `${WORKFLOW_PATH} job "${id}" step "${step.name ?? "<unnamed>"}" ` +
+          "fetches with secrets.ACTIONS_PUSH. The fetch only needs read " +
+          "access, which the default GITHUB_TOKEN already provides; the push " +
+          "supplies the PAT via a per-command auth header instead.",
+      );
+    }
+  },
+);
+
+Deno.test(
+  "quality.yml: the PAT-holding job executes no checked-out repository code (Issue #3607)",
+  async () => {
+    const wf = await readWorkflow();
+    const patJobs = jobEntries(wf).filter(([, job]) => jobExposesPat(job));
+    assert(
+      patJobs.length === 1,
+      `${WORKFLOW_PATH} must expose secrets.ACTIONS_PUSH in exactly one job; ` +
+        `found ${patJobs.length}`,
+    );
+
+    // The PAT job may only check out and collect the patch artefact. Any other
+    // action runs third-party code beside the PAT.
+    const ALLOWED_ACTIONS = [
+      "actions/checkout@",
+      "actions/download-artifact@",
+    ];
+
+    const [id, job] = patJobs[0];
+    for (const step of job.steps ?? []) {
+      if (typeof step.uses === "string") {
+        assert(
+          ALLOWED_ACTIONS.some((a) => step.uses!.startsWith(a)),
+          `${WORKFLOW_PATH} job "${id}" uses "${step.uses}" beside the PAT. ` +
+            `Only ${ALLOWED_ACTIONS.join(", ")} are permitted in this job.`,
+        );
+      }
+      assert(
+        !stepRunsRepoCode(step),
+        `${WORKFLOW_PATH} job "${id}" step "${step.name ?? "<unnamed>"}" ` +
+          "executes code from the checked-out PR tree while holding the PAT.",
+      );
+    }
+  },
+);
+
+Deno.test(
+  "quality.yml: the PAT-holding job derives its push branch from the github context, not from the PR-code job (Issue #3607)",
+  async () => {
+    const wf = await readWorkflow();
+    const [id, job] = jobEntries(wf).filter(([, j]) => jobExposesPat(j))[0];
+
+    // The upstream job runs PR-controlled code and can write arbitrary values
+    // to `$GITHUB_OUTPUT`. Anything the push job feeds to git must therefore
+    // come from the github context and be re-validated locally.
+    for (const step of job.steps ?? []) {
+      for (const [key, value] of Object.entries(step.env ?? {})) {
+        assert(
+          !/needs\./.test(String(value)),
+          `${WORKFLOW_PATH} job "${id}" step "${step.name ?? "<unnamed>"}" ` +
+            `env "${key}" is taken from another job's outputs. That job runs ` +
+            "PR-controlled code and can write arbitrary values to " +
+            "$GITHUB_OUTPUT — derive the value from the github context and " +
+            "re-validate it here instead.",
+        );
+      }
+    }
+
+    // …and it must still re-run the protected-branch guard before pushing.
+    const body = (job.steps ?? []).map((s) => s.run ?? "").join("\n");
+    assert(
+      /PROTECTED_BRANCHES/.test(body),
+      `${WORKFLOW_PATH} job "${id}" must re-run the protected-branch guard ` +
+        "so a push can never target Develop/main/master.",
+    );
+  },
+);


### PR DESCRIPTION
# Isolate the ACTIONS_PUSH PAT from PR-controlled code in quality.yml

## Summary

`.github/workflows/quality.yml` ran PR-controlled code (`build.sh`, plus
`deno check`/`fmt`/`lint`) in the same job that held the org-level
`ACTIONS_PUSH` PAT. `persist-credentials: false` (Issue #2727) kept the PAT out
of `.git/config`, but steps in one job share the workspace, `$GITHUB_ENV` and
`$GITHUB_PATH` — so a same-repo PR editing `build.sh` could plant a `git` shim
on `$GITHUB_PATH`, or write a repo-local git config/hook, and the later
`Push Changes` step would execute it with `GH_PAT` in scope.

Both fixes from the issue are applied:

1. **The checkout no longer fetches with the PAT.** The fetch only needs read
   access, which the default `GITHUB_TOKEN` (already `contents: read`) provides;
   the push supplies the PAT via the existing per-command
   `http.<url>.extraheader`.
2. **The job is split.** The `quality` job runs every PR-controlled step with no
   credential beyond the default token and uploads the fmt/lint diff as a patch
   artefact. A new `push-fixes` job checks out fresh, applies that patch as pure
   data, commits and pushes — and is the only place `secrets.ACTIONS_PUSH`
   appears.

`push-fixes` derives the target branch from the GitHub context and re-runs the
protected-branch guard locally; it never trusts the `quality` job's step
outputs, which PR-controlled code can write to freely. It also refuses a patch
whose file headers address paths under `.git/` before handing it to `git apply`
(defence in depth — `git apply` rejects these too).

Closes #3607.

## Evidence

Backend/CI change — no web interface to screenshot. The evidence is the workflow
topology and the tests below.

```mermaid
flowchart TD
    subgraph before["Before — one job"]
        B1[Checkout with ACTIONS_PUSH PAT] --> B2["build.sh / deno check / fmt / lint<br/>(PR-controlled code)"]
        B2 -->|"shared $GITHUB_PATH, $GITHUB_ENV, workspace"| B3[Push Changes with GH_PAT]
        B3 --> B4([PAT reachable by PR-controlled code])
    end

    subgraph after["After — split jobs"]
        A1["job: quality<br/>checkout with default GITHUB_TOKEN"] --> A2["build.sh / deno check / fmt / lint<br/>(PR-controlled code)"]
        A2 --> A3[Upload fmt/lint patch artefact]
        A3 -.->|artefact only| A4["job: push-fixes<br/>fresh checkout, no PR code executed"]
        A4 --> A5[Apply patch as data → commit → push with GH_PAT]
        A5 --> A6([PAT never shares a job with PR-controlled code])
    end
```

## Test Plan

New quality gate `test/ci/QualityWorkflowPatIsolation.ts` — four "what" tests
that parse the committed workflow YAML and assert on the resulting
job/credential topology:

- `no job both runs PR-controlled code and holds the ACTIONS_PUSH PAT` — the
  regression test for this issue; fails against the pre-fix workflow, naming the
  four offending steps.
- `no checkout fetches with the ACTIONS_PUSH PAT` — pins fix 1.
- `the PAT-holding job executes no checked-out repository code` — the PAT job
  may only use `actions/checkout` / `actions/download-artifact` and must run no
  command that executes the PR tree.
- `the PAT-holding job derives its push branch from the github context, not
  from the PR-code job`
  — no `needs.*` value reaches the push, and the protected-branch guard is
  re-run.

Existing workflow gates still pass unchanged, including
`WorkflowPersistCredentialsFalse.ts` (#2727),
`QualityWorkflowScriptInjection.ts` (#2709),
`QualityWorkflowDepBumpQuarantine.ts` (#2697), `WorkflowJobTimeoutMinutes.ts`
(#2841) and `WorkflowActionPinning.ts` (#2696).

Full gate: `./quality.sh` — 8031 passed, 0 failed, 4 ignored. `actionlint`
reports no findings on the edited workflow.

## Documentation

`docs/REPO_GOVERNANCE.md` — the privileged-workflow table now scopes
`secrets.ACTIONS_PUSH` to the `push-fixes` job, with a short note on why the
split exists.



## Milestone
This PR is part of the **clean up 20260801** milestone and targets the `milestone/clean-up-20260801` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-ms9xdru6-5e07fb`<!-- vibe-worker-issue-3607 -->