### PR TITLE
Extract the shared Deno + WASM-sync CI preamble into a composite action (Issue #3608)

### DIFF
--- a/.github/actions/setup-neat/action.yml
+++ b/.github/actions/setup-neat/action.yml
@@ -1,0 +1,41 @@
+name: Set up NEAT-AI CI job
+description: >-
+  Shared preamble for NEAT-AI CI jobs — installs Deno 2.x and verifies the
+  vendored wasm_activation/pkg matches the NEAT-AI-core revision pinned in
+  deno.json.
+
+# Issue #3608 — this preamble was copy-pasted across six jobs in four
+# workflows, so every pin bump or policy change needed six coordinated edits.
+# Keeping it here makes the next such change a one-file edit.
+#
+# `actions/checkout` deliberately stays inline in each calling job. A local
+# `uses: ./…` action is loaded from $GITHUB_WORKSPACE, so the repository must
+# already be checked out before this file can be read — a checkout step here
+# could never run.
+
+inputs:
+  verify-wasm:
+    description: >-
+      Run `./build.sh --verify-only` to confirm the vendored WASM bundle
+      matches deno.json's neatCore.rev. Set to "false" only for jobs that
+      never load the WASM bundle (e.g. artefact-merge jobs).
+    required: false
+    default: "true"
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Deno
+      # denoland/setup-deno@v2.0.4
+      uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282
+      with:
+        deno-version: v2.x
+
+    # `--verify-only` matches the CI policy in docs/CORE_DEPENDENCY_POLICY.md:
+    # CI must never resolve NEAT-AI-core HEAD or auto-advance neatCore.rev
+    # (Issue #2439). It fails loud when the vendored bundle has drifted from
+    # the pin or has been tampered with.
+    - name: Sync WASM package from NEAT-AI-core
+      if: ${{ inputs.verify-wasm == 'true' }}
+      shell: bash
+      run: ./build.sh --verify-only

--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -55,12 +55,9 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup Deno
-        # denoland/setup-deno@v2.0.4
-        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282
-
-      - name: Sync WASM package from NEAT-AI-core
-        run: ./build.sh --verify-only
+      # Shared preamble — Deno 2.x plus the WASM pin check (Issue #3608).
+      - name: Setup Deno and sync WASM package
+        uses: ./.github/actions/setup-neat
 
       - name: Run benchmark smoke pass
         run: |
@@ -95,12 +92,9 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup Deno
-        # denoland/setup-deno@v2.0.4
-        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282
-
-      - name: Sync WASM package from NEAT-AI-core
-        run: ./build.sh --verify-only
+      # Shared preamble — Deno 2.x plus the WASM pin check (Issue #3608).
+      - name: Setup Deno and sync WASM package
+        uses: ./.github/actions/setup-neat
 
       - name: Run score-per-hour harness against the baseline trajectory
         # Same seeded config as bench/baseline_score_trajectory.json. The gate

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -75,13 +75,10 @@ jobs:
         with:
           persist-credentials: false
 
-      # Set up Deno 2.x
-      - name: Setup Deno
-        # denoland/setup-deno@v2.0.4
-        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282
-
-      - name: Sync WASM package from NEAT-AI-core
-        run: ./build.sh --verify-only
+      # Set up Deno 2.x and verify the vendored WASM bundle matches
+      # deno.json's neatCore.rev (Issue #3608 — shared preamble).
+      - name: Setup Deno and sync WASM package
+        uses: ./.github/actions/setup-neat
 
       - id: run_shard
         name: Run test shard
@@ -259,9 +256,12 @@ jobs:
         with:
           persist-credentials: false
 
+      # This job only merges shard artefacts and uploads them — it never loads
+      # the WASM bundle, so it opts out of the sync (Issue #3608).
       - name: Setup Deno
-        # denoland/setup-deno@v2.0.4
-        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282
+        uses: ./.github/actions/setup-neat
+        with:
+          verify-wasm: "false"
 
       # File-count parity gate: assert the partition covers every test/**/*.ts
       # exactly once across all shards (no gaps, no double-runs).

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,19 +35,12 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup Deno
-        # denoland/setup-deno@v2.0.4
-        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282
-        with:
-          deno-version: v2.x
-
-      # Issue #2439: --verify-only matches CI policy in
-      # docs/CORE_DEPENDENCY_POLICY.md — CI must not resolve NEAT-AI-core
-      # HEAD or auto-advance neatCore.rev. The vendored wasm_activation/pkg
-      # is committed and pinned by deno.json neatCore.rev; verify it is in
-      # sync before publishing to JSR.
-      - name: Verify WASM package matches deno.json neatCore.rev
-        run: ./build.sh --verify-only
+      # Shared preamble (Issue #3608): installs Deno 2.x — whose `deno publish`
+      # attaches the Sigstore provenance verified below (Issue #3333) — and
+      # verifies the vendored wasm_activation/pkg still matches deno.json's
+      # neatCore.rev before publishing to JSR (Issue #2439).
+      - name: Setup Deno and verify WASM package
+        uses: ./.github/actions/setup-neat
 
       # Issue #2904: skip publishing when deno.json's version is already on JSR.
       # Every push to Develop runs this workflow, but the package version only

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -172,10 +172,14 @@ jobs:
       # Note: gitleaks-action@v2 automatically detects PRs and scans the diff
       # For workflow_dispatch, it scans the entire repository by default
 
-      # Set up Deno 2.x
-      - name: Setup Deno
-        # denoland/setup-deno@v2.0.4
-        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282
+      # Set up Deno 2.x and verify the vendored WASM bundle matches
+      # deno.json's neatCore.rev. Shared with coverage.yaml, bench.yaml and
+      # publish.yml via the local composite action (Issue #3608), so the
+      # setup-deno pin and the `./build.sh --verify-only` policy live in one
+      # file. Local `uses: ./…` actions load from the workspace, so this must
+      # follow the checkout above.
+      - name: Setup Deno and sync WASM package
+        uses: ./.github/actions/setup-neat
 
       # Note: dep bumps flow through the scheduled
       # `.github/workflows/deno-outdated.yml` workflow, which raises a
@@ -184,9 +188,6 @@ jobs:
       # was newest at run-time and auto-committed the lockfile changes
       # under the bot's signature, bypassing contributor review and the
       # bump quarantine for external deps (Issue #2697).
-
-      - name: Sync WASM package from NEAT-AI-core
-        run: ./build.sh --verify-only
 
       - name: Report WASM sync changes
         run: |

--- a/docs/CI_EXTERNAL_NEAT_AI_CORE.md
+++ b/docs/CI_EXTERNAL_NEAT_AI_CORE.md
@@ -8,15 +8,27 @@
 
 ## What the workflows do today
 
-The two workflows that touch the NEAT-AI-core dependency both call
+Every job that touches the NEAT-AI-core dependency calls
 `./build.sh --verify-only`. The verify-only mode performs no network calls and
 no mutation — it simply checks that the on-disk `wasm_activation/pkg/**` matches
 `deno.json` `neatCore.rev`.
 
-| Workflow                                                            | Job       | Step                                                 | Command                    |
-| ------------------------------------------------------------------- | --------- | ---------------------------------------------------- | -------------------------- |
-| [`.github/workflows/quality.yml`](../.github/workflows/quality.yml) | `quality` | _Sync WASM package from NEAT-AI-core_                | `./build.sh --verify-only` |
-| [`.github/workflows/publish.yml`](../.github/workflows/publish.yml) | `publish` | _Verify WASM package matches deno.json neatCore.rev_ | `./build.sh --verify-only` |
+Since Issue #3608 that call lives in exactly one file — the local composite
+action [`.github/actions/setup-neat`](../.github/actions/setup-neat/action.yml),
+which installs Deno 2.x and then runs the verify step. Jobs reach it via
+`uses: ./.github/actions/setup-neat`:
+
+| Workflow                                                                | Job                         | WASM sync |
+| ----------------------------------------------------------------------- | --------------------------- | --------- |
+| [`.github/workflows/quality.yml`](../.github/workflows/quality.yml)     | `quality`                   | yes       |
+| [`.github/workflows/coverage.yaml`](../.github/workflows/coverage.yaml) | `coverage`                  | yes       |
+| [`.github/workflows/coverage.yaml`](../.github/workflows/coverage.yaml) | `merge`                     | no        |
+| [`.github/workflows/bench.yaml`](../.github/workflows/bench.yaml)       | `smoke`                     | yes       |
+| [`.github/workflows/bench.yaml`](../.github/workflows/bench.yaml)       | `score-per-hour-regression` | yes       |
+| [`.github/workflows/publish.yml`](../.github/workflows/publish.yml)     | `publish`                   | yes       |
+
+The `merge` job only aggregates shard artefacts and never loads the bundle, so
+it opts out with `verify-wasm: "false"`.
 
 The publish workflow uses verify-only deliberately: the default `GITHUB_TOKEN`
 cannot read commits from `NEAT-AI-core`, so any attempt to resolve `Develop`
@@ -25,20 +37,27 @@ HEAD from the publish job would fail (see
 
 ## Required workflow pattern
 
-If you add another workflow that needs the WASM bundle, follow this pattern —
-verify only, never resolve HEAD:
+If you add another job that needs the WASM bundle, reuse the composite action
+rather than re-pinning `denoland/setup-deno` and re-typing the verify command:
 
 ```yaml
-- name: Setup Deno
-  uses: denoland/setup-deno@v2
+- name: Checkout Code
+  # actions/checkout@v6.0.2
+  uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+  with:
+    persist-credentials: false
 
-- name: Verify WASM package matches deno.json neatCore.rev
-  run: ./build.sh --verify-only
+- name: Setup Deno and sync WASM package
+  uses: ./.github/actions/setup-neat
 ```
 
-Place this step before any `deno check`, `deno test`, or publish step. Bumping
-`neatCore.rev` is an explicit human (or worker) action, not something CI does on
-its own.
+`actions/checkout` stays inline: a local `uses: ./…` action is loaded from
+`$GITHUB_WORKSPACE`, so the repository must already be checked out before the
+composite action can be read.
+
+Place the composite step before any `deno check`, `deno test`, or publish step.
+Bumping `neatCore.rev` is an explicit human (or worker) action, not something CI
+does on its own.
 
 ## Sync policy enforcement
 

--- a/docs/archive/pr-summaries/pr-summary-3608.md
+++ b/docs/archive/pr-summaries/pr-summary-3608.md
@@ -1,0 +1,155 @@
+# Extract the shared CI preamble into a composite action
+
+## Summary
+
+The SHA-pinned `denoland/setup-deno` step and the `./build.sh --verify-only`
+(WASM package sync) step were copy-pasted across six jobs in four workflows, so
+every pin bump or policy change needed six coordinated edits. Both now live in
+one local composite action, `.github/actions/setup-neat`, referenced as
+`uses: ./.github/actions/setup-neat`. Closes #3608.
+
+**`actions/checkout` deliberately stays inline in each job.** The issue's
+suggested action.yml put checkout inside the composite, but that cannot work: a
+local `uses: ./…` action is loaded from `$GITHUB_WORKSPACE`, so the calling job
+must already have checked the repository out before the composite action file
+can be read
+([GitHub docs](https://docs.github.com/actions/creating-actions/creating-a-composite-action)).
+A checkout step inside the composite could never run. The constraint is
+documented in the action file and pinned by a test so nobody "helpfully" moves
+checkout in and breaks every workflow.
+
+Consolidated call sites:
+
+| Workflow        | Job                         | WASM sync          |
+| --------------- | --------------------------- | ------------------ |
+| `quality.yml`   | `quality`                   | yes                |
+| `coverage.yaml` | `coverage`                  | yes                |
+| `coverage.yaml` | `merge`                     | no (`verify-wasm`) |
+| `bench.yaml`    | `smoke`                     | yes                |
+| `bench.yaml`    | `score-per-hour-regression` | yes                |
+| `publish.yml`   | `publish`                   | yes                |
+
+The `merge` job only aggregates shard artefacts and never loads the bundle, so
+it opts out with `verify-wasm: "false"`. The input defaults to `"true"`, so the
+sync is opt-out — a new job cannot silently skip it.
+
+Step ordering is unchanged in every job: the composite runs exactly where
+`Setup Deno` used to, immediately followed by the WASM sync. In particular
+`quality.yml` still executes no PR-controlled code before the credentialed
+gitleaks step (Issue #3607), and the PAT-holding `push-fixes` job is untouched —
+it uses no composite action.
+
+## Evidence
+
+Backend/CI change with no web interface, so there is no screenshot. Evidence is
+the test suite plus a clean `actionlint` run over the workflows.
+
+```mermaid
+flowchart TB
+    subgraph before["Before — six copies"]
+        Q1[quality.yml quality] --> P1["setup-deno@667a34cd<br/>./build.sh --verify-only"]
+        C1[coverage.yaml coverage] --> P2["setup-deno@667a34cd<br/>./build.sh --verify-only"]
+        C2[coverage.yaml merge] --> P3["setup-deno@667a34cd"]
+        B1[bench.yaml smoke] --> P4["setup-deno@667a34cd<br/>./build.sh --verify-only"]
+        B2[bench.yaml score-per-hour] --> P5["setup-deno@667a34cd<br/>./build.sh --verify-only"]
+        PU1[publish.yml publish] --> P6["setup-deno@667a34cd<br/>./build.sh --verify-only"]
+    end
+
+    subgraph after["After — one definition"]
+        Q2[quality.yml quality] --> CA
+        C3[coverage.yaml coverage] --> CA
+        C4["coverage.yaml merge<br/>verify-wasm: false"] --> CA
+        B3[bench.yaml smoke] --> CA
+        B4[bench.yaml score-per-hour] --> CA
+        PU2[publish.yml publish] --> CA
+        CA["./.github/actions/setup-neat<br/>setup-deno@667a34cd<br/>./build.sh --verify-only"]
+    end
+```
+
+Each job still runs `actions/checkout` inline first, because the composite
+action is read from the checked-out workspace:
+
+```mermaid
+sequenceDiagram
+    participant Job as CI job
+    participant WS as $GITHUB_WORKSPACE
+    participant CA as setup-neat
+
+    Job->>WS: actions/checkout (persist-credentials false)
+    Note over Job,WS: must run inline — the action file<br/>does not exist until now
+    Job->>CA: uses ./.github/actions/setup-neat
+    CA->>Job: denoland/setup-deno v2.x
+    CA->>Job: ./build.sh --verify-only (if verify-wasm)
+```
+
+Local run of the full quality gate:
+
+```text
+ok | 8060 passed (5 steps) | 0 failed | 4 ignored (7m0s)
+```
+
+`actionlint` (which validates local `uses: ./…` references resolve) exits 0 over
+the whole `.github/workflows/` tree.
+
+## Test Plan
+
+Added `test/ci/SetupNeatCompositeAction.ts` — 29 "what" tests parsing the
+committed YAML:
+
+- the composite action exists, declares `runs.using: composite`, and carries a
+  description;
+- it installs Deno via `denoland/setup-deno` and runs `./build.sh --verify-only`
+  with `shell: bash`;
+- it never invokes a bare `./build.sh` (Issue #2439 — CI must not auto-advance
+  `neatCore.rev`);
+- the WASM sync is gated on a `verify-wasm` input defaulting to `"true"`;
+- **it contains no `actions/checkout` step** — the regression guard for the
+  local-action loading constraint;
+- per call site (six jobs): the job references the composite exactly once,
+  checks out _before_ it, no longer inlines `denoland/setup-deno` or
+  `./build.sh`, and requests the expected `verify-wasm` value.
+
+Modified existing tests (documented, no test removed or disabled):
+
+- `test/ci/WorkflowActionPinning.ts` — now scans `.github/actions/*/action.yml`
+  alongside `.github/workflows/*.y*ml`, so moving a `uses:` into a composite
+  action does not move it out of the SHA-pinning gate. Local `./…` references
+  are exempt by construction: they carry no `@ref`, so `extractUses` never
+  returns them.
+- `test/scripts/PublishWorkflow.ts` — the `./build.sh --verify-only` invariant
+  moved out of `publish.yml` into the composite action, so the two tests now
+  follow the workflow's local `uses: ./…` references instead of grepping the
+  workflow text alone. The asserted invariant is unchanged: the publish job must
+  reach a verify-only build, and no reachable step may run a bare `./build.sh`.
+
+Unaffected and still green: `WorkflowPersistCredentialsFalse.ts` (checkout stays
+inline everywhere), `QualityWorkflowPatIsolation.ts` (the PAT job uses no
+composite action), `ProvenancePublishWorkflow.ts`,
+`CodeownersWorkflowsCoverage.ts` (CODEOWNERS already covers
+`/.github/actions/`).
+
+## Documentation
+
+`docs/CI_EXTERNAL_NEAT_AI_CORE.md` — the "what the workflows do today" table now
+lists all six jobs and points at the composite action; the "required workflow
+pattern" snippet shows the inline checkout plus
+`uses: ./.github/actions/setup-neat`, and explains why checkout cannot move in.
+
+## Pre-PR Security Self-Check
+
+- **Input validation** — n/a; no new runtime code paths. The composite's one
+  input is compared against the literal `'true'` in an `if:` expression.
+- **Secrets** — no secrets added or staged; the composite carries none.
+- **Injection surface** — the composite's single `run:` step is a fixed literal
+  (`./build.sh --verify-only`) with no interpolation of any context value.
+- **Output encoding** — n/a.
+- **Authentication/authorisation** — unchanged. `persist-credentials: false`
+  stays on every checkout; the `push-fixes` job that holds
+  `secrets.ACTIONS_PUSH` uses no composite action, preserving the Issue #3607
+  isolation.
+- **Error handling** — `./build.sh --verify-only` still fails the job loudly on
+  a drifted or tampered WASM bundle; the `verify-wasm` input defaults to `true`
+  so a new job cannot skip the gate by omission.
+- **Dependencies** — no new dependency. `denoland/setup-deno` keeps its existing
+  40-char SHA pin (`667a34cd…`, v2.0.4), now guarded in one place by
+  `WorkflowActionPinning.ts`.

--- a/test/ci/SetupNeatCompositeAction.ts
+++ b/test/ci/SetupNeatCompositeAction.ts
@@ -1,0 +1,286 @@
+/**
+ * Issue #3608 — the repeated "Deno + WASM sync" CI preamble lives in exactly
+ * one place: the local composite action `.github/actions/setup-neat`.
+ *
+ * The same two steps — SHA-pinned `denoland/setup-deno`, then
+ * `./build.sh --verify-only` (NEAT-AI-core WASM sync) — were copy-pasted across
+ * six jobs in four workflows, so every pin bump or policy change needed six
+ * coordinated edits. The `persist-credentials: false` hardening shows the cost:
+ * it was rolled out as five separate issues (#3349, #3350, #3351, #3353,
+ * #3355), one per copy.
+ *
+ * `actions/checkout` deliberately stays inline in each job. A local
+ * `uses: ./…` action is resolved from `$GITHUB_WORKSPACE`, so the calling job
+ * must already have checked the repository out before the composite action can
+ * be loaded — a checkout *inside* the composite could never run.
+ *
+ * These are "what" tests: they parse the committed YAML and assert on the
+ * resulting topology, not on the wording of any step. SHA-pinning of the
+ * third-party actions inside the composite is covered by
+ * `WorkflowActionPinning.ts`, which scans `.github/actions/` too.
+ */
+
+import { assert, assertEquals } from "@std/assert";
+import { fromFileUrl, join } from "@std/path";
+import { parse } from "@std/yaml";
+
+const REPO_ROOT = fromFileUrl(new URL("../../", import.meta.url));
+const ACTION_DIR = ".github/actions/setup-neat";
+const ACTION_PATH = `${ACTION_DIR}/action.yml`;
+/** How workflows reference the composite action. */
+const ACTION_REF = `./${ACTION_DIR}`;
+
+interface Step {
+  name?: string;
+  uses?: string;
+  run?: string;
+  if?: string;
+  shell?: string;
+  with?: Record<string, unknown>;
+}
+
+interface CompositeAction {
+  name?: string;
+  description?: string;
+  inputs?: Record<string, { description?: string; default?: unknown }>;
+  runs?: { using?: string; steps?: Step[] };
+}
+
+interface Job {
+  steps?: Step[];
+}
+
+interface Workflow {
+  jobs?: Record<string, Job>;
+}
+
+async function readYaml<T>(relPath: string): Promise<T> {
+  return parse(await Deno.readTextFile(join(REPO_ROOT, relPath))) as T;
+}
+
+async function readAction(): Promise<CompositeAction> {
+  return await readYaml<CompositeAction>(ACTION_PATH);
+}
+
+function actionSteps(action: CompositeAction): Step[] {
+  return action.runs?.steps ?? [];
+}
+
+function isCheckout(step: Step): boolean {
+  return typeof step.uses === "string" &&
+    step.uses.startsWith("actions/checkout@");
+}
+
+function stepLabel(step: Step): string {
+  return step.name ?? step.uses ?? step.run?.trim().split("\n")[0] ??
+    "<unnamed>";
+}
+
+/**
+ * Every job whose preamble was consolidated onto the composite action, and
+ * whether that job needs the WASM sync. The coverage `merge` job only reads
+ * shard artefacts, so it opts out via `verify-wasm: "false"`.
+ */
+const CALL_SITES: { workflow: string; job: string; verifyWasm: boolean }[] = [
+  {
+    workflow: ".github/workflows/quality.yml",
+    job: "quality",
+    verifyWasm: true,
+  },
+  {
+    workflow: ".github/workflows/coverage.yaml",
+    job: "coverage",
+    verifyWasm: true,
+  },
+  {
+    workflow: ".github/workflows/coverage.yaml",
+    job: "merge",
+    verifyWasm: false,
+  },
+  { workflow: ".github/workflows/bench.yaml", job: "smoke", verifyWasm: true },
+  {
+    workflow: ".github/workflows/bench.yaml",
+    job: "score-per-hour-regression",
+    verifyWasm: true,
+  },
+  {
+    workflow: ".github/workflows/publish.yml",
+    job: "publish",
+    verifyWasm: true,
+  },
+];
+
+async function readJob(workflow: string, jobId: string): Promise<Job> {
+  const wf = await readYaml<Workflow>(workflow);
+  const job = wf.jobs?.[jobId];
+  assert(job, `${workflow} must define a \`${jobId}\` job`);
+  return job;
+}
+
+Deno.test(
+  "the setup-neat composite action exists and is a composite action (Issue #3608)",
+  async () => {
+    const action = await readAction();
+    assertEquals(
+      action.runs?.using,
+      "composite",
+      `${ACTION_PATH} must declare \`runs.using: composite\``,
+    );
+    assert(
+      typeof action.description === "string" && action.description.length > 0,
+      `${ACTION_PATH} must carry a description (GitHub rejects an action without one)`,
+    );
+  },
+);
+
+Deno.test(
+  "the composite action sets up Deno and syncs the WASM package (Issue #3608)",
+  async () => {
+    const steps = actionSteps(await readAction());
+
+    const deno = steps.find((s) =>
+      typeof s.uses === "string" && s.uses.startsWith("denoland/setup-deno@")
+    );
+    assert(
+      deno !== undefined,
+      `${ACTION_PATH} must install Deno via denoland/setup-deno so the pin lives in one place`,
+    );
+
+    const wasm = steps.find((s) =>
+      /\.\/build\.sh\s+--verify-only/.test(s.run ?? "")
+    );
+    assert(
+      wasm !== undefined,
+      `${ACTION_PATH} must run \`./build.sh --verify-only\` so the WASM sync lives in one place`,
+    );
+    assertEquals(
+      wasm.shell,
+      "bash",
+      `${ACTION_PATH} \`run:\` steps must declare \`shell: bash\` (required in composite actions)`,
+    );
+  },
+);
+
+Deno.test(
+  "the composite action never resolves NEAT-AI-core HEAD (Issue #3608, #2439)",
+  async () => {
+    const source = await Deno.readTextFile(join(REPO_ROOT, ACTION_PATH));
+    // CI must not auto-advance deno.json neatCore.rev — every build.sh call
+    // carries an explicit flag.
+    assert(
+      !/\.\/build\.sh(?:\s*$|\s+(?!--))/m.test(source),
+      `${ACTION_PATH} must not call ./build.sh without --verify-only (Issue #2439)`,
+    );
+  },
+);
+
+Deno.test(
+  "the WASM sync is gated on the verify-wasm input (Issue #3608)",
+  async () => {
+    const action = await readAction();
+    const input = action.inputs?.["verify-wasm"];
+    assert(
+      input !== undefined,
+      `${ACTION_PATH} must declare a \`verify-wasm\` input so jobs that need no WASM bundle can opt out`,
+    );
+    assertEquals(
+      String(input.default),
+      "true",
+      `${ACTION_PATH} \`verify-wasm\` must default to "true" — the sync is opt-out, so a new job cannot silently skip it`,
+    );
+
+    const wasm = actionSteps(action).find((s) =>
+      /\.\/build\.sh/.test(s.run ?? "")
+    );
+    assert(
+      typeof wasm?.if === "string" &&
+        /inputs\.verify-wasm/.test(wasm.if),
+      `${ACTION_PATH} must gate the WASM sync step on \`inputs.verify-wasm\``,
+    );
+  },
+);
+
+Deno.test(
+  "the composite action does not check out the repository (Issue #3608)",
+  async () => {
+    const steps = actionSteps(await readAction());
+    const checkout = steps.find(isCheckout);
+    assert(
+      checkout === undefined,
+      `${ACTION_PATH} must not run actions/checkout. A local \`uses: ./…\` ` +
+        "action is loaded from $GITHUB_WORKSPACE, so the calling job must " +
+        "already have checked the repository out — a checkout inside the " +
+        "composite could never run. Keep checkout inline in each job.",
+    );
+  },
+);
+
+for (const { workflow, job, verifyWasm } of CALL_SITES) {
+  Deno.test(
+    `${workflow} job "${job}" uses the setup-neat composite action (Issue #3608)`,
+    async () => {
+      const steps = (await readJob(workflow, job)).steps ?? [];
+      const uses = steps.filter((s) => s.uses === ACTION_REF);
+      assertEquals(
+        uses.length,
+        1,
+        `${workflow} job "${job}" must reference \`${ACTION_REF}\` exactly once`,
+      );
+    },
+  );
+
+  Deno.test(
+    `${workflow} job "${job}" checks out before the composite action (Issue #3608)`,
+    async () => {
+      const steps = (await readJob(workflow, job)).steps ?? [];
+      const checkoutAt = steps.findIndex(isCheckout);
+      const actionAt = steps.findIndex((s) => s.uses === ACTION_REF);
+      assert(
+        checkoutAt >= 0,
+        `${workflow} job "${job}" must keep an inline actions/checkout step — a local composite action cannot check the repository out for itself`,
+      );
+      assert(
+        checkoutAt < actionAt,
+        `${workflow} job "${job}" must check out before \`${ACTION_REF}\`; the action is loaded from $GITHUB_WORKSPACE`,
+      );
+    },
+  );
+
+  Deno.test(
+    `${workflow} job "${job}" no longer inlines the shared preamble (Issue #3608)`,
+    async () => {
+      const steps = (await readJob(workflow, job)).steps ?? [];
+      for (const step of steps) {
+        assert(
+          !(step.uses ?? "").startsWith("denoland/setup-deno@"),
+          `${workflow} job "${job}" step "${
+            stepLabel(step)
+          }" inlines denoland/setup-deno — use \`${ACTION_REF}\` so the pin lives in one place`,
+        );
+        assert(
+          !/\.\/build\.sh\b/.test(step.run ?? ""),
+          `${workflow} job "${job}" step "${
+            stepLabel(step)
+          }" inlines ./build.sh — use \`${ACTION_REF}\` so the WASM sync lives in one place`,
+        );
+      }
+    },
+  );
+
+  Deno.test(
+    `${workflow} job "${job}" requests verify-wasm=${verifyWasm} (Issue #3608)`,
+    async () => {
+      const steps = (await readJob(workflow, job)).steps ?? [];
+      const step = steps.find((s) => s.uses === ACTION_REF);
+      assert(step, `${workflow} job "${job}" must use \`${ACTION_REF}\``);
+      const raw = step.with?.["verify-wasm"];
+      // Omitted means the "true" default.
+      const resolved = raw === undefined ? "true" : String(raw);
+      assertEquals(
+        resolved,
+        String(verifyWasm),
+        `${workflow} job "${job}" must run with verify-wasm=${verifyWasm}`,
+      );
+    },
+  );
+}

--- a/test/ci/WorkflowActionPinning.ts
+++ b/test/ci/WorkflowActionPinning.ts
@@ -13,6 +13,12 @@
  * This test scans every workflow file and asserts that each pinned action is
  * a 40-character lowercase hex SHA and carries a nearby comment naming the
  * resolved tag (so reviewers can verify provenance).
+ *
+ * Issue #3608 — local composite actions under `.github/actions/` are scanned
+ * too. They run inside the same jobs and pin the same third-party actions, so
+ * moving a `uses:` there must not move it out of this gate. Local `./…`
+ * references are exempt by construction: they carry no `@ref`, so
+ * `extractUses` never returns them.
  */
 
 import { assert, assertMatch } from "@std/assert";
@@ -21,25 +27,41 @@ import { extractUses } from "./ShellcheckWorkflowPinning.ts";
 
 const REPO_ROOT = fromFileUrl(new URL("../../", import.meta.url));
 const WORKFLOWS_DIR = join(REPO_ROOT, ".github/workflows");
+const ACTIONS_DIR = join(REPO_ROOT, ".github/actions");
 
-async function listWorkflowFiles(): Promise<string[]> {
-  const names: string[] = [];
+/** Every workflow file plus every local composite action definition. */
+async function listActionYamlFiles(): Promise<string[]> {
+  const paths: string[] = [];
   for await (const entry of Deno.readDir(WORKFLOWS_DIR)) {
     if (!entry.isFile) continue;
     if (!/\.ya?ml$/.test(entry.name)) continue;
-    names.push(entry.name);
+    paths.push(join(WORKFLOWS_DIR, entry.name));
   }
-  names.sort();
-  return names;
+  const candidates: string[] = [];
+  for await (const entry of Deno.readDir(ACTIONS_DIR)) {
+    if (!entry.isDirectory) continue;
+    candidates.push(
+      join(ACTIONS_DIR, entry.name, "action.yml"),
+      join(ACTIONS_DIR, entry.name, "action.yaml"),
+    );
+  }
+  const stats = await Promise.all(
+    candidates.map((path) => Deno.stat(path).catch(() => null)),
+  );
+  candidates.forEach((path, i) => {
+    if (stats[i]?.isFile) paths.push(path);
+  });
+  paths.sort();
+  return paths;
 }
 
 async function readAllWorkflows(): Promise<
   { name: string; source: string }[]
 > {
-  const files = await listWorkflowFiles();
-  const reads = files.map(async (name) => ({
-    name,
-    source: await Deno.readTextFile(join(WORKFLOWS_DIR, name)),
+  const files = await listActionYamlFiles();
+  const reads = files.map(async (path) => ({
+    name: path.slice(REPO_ROOT.length),
+    source: await Deno.readTextFile(path),
   }));
   return await Promise.all(reads);
 }

--- a/test/scripts/PublishWorkflow.ts
+++ b/test/scripts/PublishWorkflow.ts
@@ -12,21 +12,50 @@ import { assert } from "@std/assert";
  * "CI MUST NOT advance deno.json neatCore.rev automatically" — bumps are
  * an explicit human/worker action. The publish workflow must therefore
  * call `./build.sh --verify-only`, matching quality.yml.
+ *
+ * Issue #3608 moved the shared `./build.sh --verify-only` step out of the
+ * workflow and into the local composite action `.github/actions/setup-neat`,
+ * so these tests now follow that reference instead of grepping the workflow
+ * text alone. The invariant is unchanged: the publish job must reach a
+ * verify-only build, and no reachable step may run a bare `./build.sh`.
  */
 
 const PUBLISH_WORKFLOW = ".github/workflows/publish.yml";
+const SETUP_ACTION = ".github/actions/setup-neat/action.yml";
+
+/**
+ * The workflow plus every local composite action it references — the full set
+ * of files that can invoke `build.sh` on the publish job's behalf.
+ */
+async function readReachableSources(): Promise<string> {
+  const workflow = await Deno.readTextFile(PUBLISH_WORKFLOW);
+  const localRefs = [...workflow.matchAll(/uses:\s*(\.\/\S+)/g)].map((m) =>
+    m[1]
+  );
+  assert(
+    localRefs.includes(`./${SETUP_ACTION.replace("/action.yml", "")}`),
+    `${PUBLISH_WORKFLOW} must reference the shared ./${
+      SETUP_ACTION.replace("/action.yml", "")
+    } composite action (issue #3608).`,
+  );
+  const actions = await Promise.all(
+    localRefs.map((ref) => Deno.readTextFile(`${ref.slice(2)}/action.yml`)),
+  );
+  return [workflow, ...actions].join("\n");
+}
 
 Deno.test("publish.yml runs build.sh in verify-only mode", async () => {
-  const content = await Deno.readTextFile(PUBLISH_WORKFLOW);
+  const content = await readReachableSources();
   assert(
     content.includes("./build.sh --verify-only"),
-    `${PUBLISH_WORKFLOW} must invoke ./build.sh --verify-only so CI does not ` +
-      `try to resolve NEAT-AI-core HEAD via gh (issue #2439).`,
+    `${PUBLISH_WORKFLOW} (or a composite action it uses) must invoke ` +
+      `./build.sh --verify-only so CI does not try to resolve NEAT-AI-core ` +
+      `HEAD via gh (issue #2439).`,
   );
 });
 
 Deno.test("publish.yml does not auto-advance neatCore.rev", async () => {
-  const content = await Deno.readTextFile(PUBLISH_WORKFLOW);
+  const content = await readReachableSources();
   // No bare `./build.sh` invocation (must always carry --verify-only or
   // an explicit --rev flag). Whitespace-tolerant: any character class
   // after build.sh other than a flag would catch a regression.


### PR DESCRIPTION
# Extract the shared CI preamble into a composite action

## Summary

The SHA-pinned `denoland/setup-deno` step and the `./build.sh --verify-only`
(WASM package sync) step were copy-pasted across six jobs in four workflows, so
every pin bump or policy change needed six coordinated edits. Both now live in
one local composite action, `.github/actions/setup-neat`, referenced as
`uses: ./.github/actions/setup-neat`. Closes #3608.

**`actions/checkout` deliberately stays inline in each job.** The issue's
suggested action.yml put checkout inside the composite, but that cannot work: a
local `uses: ./…` action is loaded from `$GITHUB_WORKSPACE`, so the calling job
must already have checked the repository out before the composite action file
can be read
([GitHub docs](https://docs.github.com/actions/creating-actions/creating-a-composite-action)).
A checkout step inside the composite could never run. The constraint is
documented in the action file and pinned by a test so nobody "helpfully" moves
checkout in and breaks every workflow.

Consolidated call sites:

| Workflow        | Job                         | WASM sync          |
| --------------- | --------------------------- | ------------------ |
| `quality.yml`   | `quality`                   | yes                |
| `coverage.yaml` | `coverage`                  | yes                |
| `coverage.yaml` | `merge`                     | no (`verify-wasm`) |
| `bench.yaml`    | `smoke`                     | yes                |
| `bench.yaml`    | `score-per-hour-regression` | yes                |
| `publish.yml`   | `publish`                   | yes                |

The `merge` job only aggregates shard artefacts and never loads the bundle, so
it opts out with `verify-wasm: "false"`. The input defaults to `"true"`, so the
sync is opt-out — a new job cannot silently skip it.

Step ordering is unchanged in every job: the composite runs exactly where
`Setup Deno` used to, immediately followed by the WASM sync. In particular
`quality.yml` still executes no PR-controlled code before the credentialed
gitleaks step (Issue #3607), and the PAT-holding `push-fixes` job is untouched —
it uses no composite action.

## Evidence

Backend/CI change with no web interface, so there is no screenshot. Evidence is
the test suite plus a clean `actionlint` run over the workflows.

```mermaid
flowchart TB
    subgraph before["Before — six copies"]
        Q1[quality.yml quality] --> P1["setup-deno@667a34cd<br/>./build.sh --verify-only"]
        C1[coverage.yaml coverage] --> P2["setup-deno@667a34cd<br/>./build.sh --verify-only"]
        C2[coverage.yaml merge] --> P3["setup-deno@667a34cd"]
        B1[bench.yaml smoke] --> P4["setup-deno@667a34cd<br/>./build.sh --verify-only"]
        B2[bench.yaml score-per-hour] --> P5["setup-deno@667a34cd<br/>./build.sh --verify-only"]
        PU1[publish.yml publish] --> P6["setup-deno@667a34cd<br/>./build.sh --verify-only"]
    end

    subgraph after["After — one definition"]
        Q2[quality.yml quality] --> CA
        C3[coverage.yaml coverage] --> CA
        C4["coverage.yaml merge<br/>verify-wasm: false"] --> CA
        B3[bench.yaml smoke] --> CA
        B4[bench.yaml score-per-hour] --> CA
        PU2[publish.yml publish] --> CA
        CA["./.github/actions/setup-neat<br/>setup-deno@667a34cd<br/>./build.sh --verify-only"]
    end
```

Each job still runs `actions/checkout` inline first, because the composite
action is read from the checked-out workspace:

```mermaid
sequenceDiagram
    participant Job as CI job
    participant WS as $GITHUB_WORKSPACE
    participant CA as setup-neat

    Job->>WS: actions/checkout (persist-credentials false)
    Note over Job,WS: must run inline — the action file<br/>does not exist until now
    Job->>CA: uses ./.github/actions/setup-neat
    CA->>Job: denoland/setup-deno v2.x
    CA->>Job: ./build.sh --verify-only (if verify-wasm)
```

Local run of the full quality gate:

```text
ok | 8060 passed (5 steps) | 0 failed | 4 ignored (7m0s)
```

`actionlint` (which validates local `uses: ./…` references resolve) exits 0 over
the whole `.github/workflows/` tree.

## Test Plan

Added `test/ci/SetupNeatCompositeAction.ts` — 29 "what" tests parsing the
committed YAML:

- the composite action exists, declares `runs.using: composite`, and carries a
  description;
- it installs Deno via `denoland/setup-deno` and runs `./build.sh --verify-only`
  with `shell: bash`;
- it never invokes a bare `./build.sh` (Issue #2439 — CI must not auto-advance
  `neatCore.rev`);
- the WASM sync is gated on a `verify-wasm` input defaulting to `"true"`;
- **it contains no `actions/checkout` step** — the regression guard for the
  local-action loading constraint;
- per call site (six jobs): the job references the composite exactly once,
  checks out _before_ it, no longer inlines `denoland/setup-deno` or
  `./build.sh`, and requests the expected `verify-wasm` value.

Modified existing tests (documented, no test removed or disabled):

- `test/ci/WorkflowActionPinning.ts` — now scans `.github/actions/*/action.yml`
  alongside `.github/workflows/*.y*ml`, so moving a `uses:` into a composite
  action does not move it out of the SHA-pinning gate. Local `./…` references
  are exempt by construction: they carry no `@ref`, so `extractUses` never
  returns them.
- `test/scripts/PublishWorkflow.ts` — the `./build.sh --verify-only` invariant
  moved out of `publish.yml` into the composite action, so the two tests now
  follow the workflow's local `uses: ./…` references instead of grepping the
  workflow text alone. The asserted invariant is unchanged: the publish job must
  reach a verify-only build, and no reachable step may run a bare `./build.sh`.

Unaffected and still green: `WorkflowPersistCredentialsFalse.ts` (checkout stays
inline everywhere), `QualityWorkflowPatIsolation.ts` (the PAT job uses no
composite action), `ProvenancePublishWorkflow.ts`,
`CodeownersWorkflowsCoverage.ts` (CODEOWNERS already covers
`/.github/actions/`).

## Documentation

`docs/CI_EXTERNAL_NEAT_AI_CORE.md` — the "what the workflows do today" table now
lists all six jobs and points at the composite action; the "required workflow
pattern" snippet shows the inline checkout plus
`uses: ./.github/actions/setup-neat`, and explains why checkout cannot move in.

## Pre-PR Security Self-Check

- **Input validation** — n/a; no new runtime code paths. The composite's one
  input is compared against the literal `'true'` in an `if:` expression.
- **Secrets** — no secrets added or staged; the composite carries none.
- **Injection surface** — the composite's single `run:` step is a fixed literal
  (`./build.sh --verify-only`) with no interpolation of any context value.
- **Output encoding** — n/a.
- **Authentication/authorisation** — unchanged. `persist-credentials: false`
  stays on every checkout; the `push-fixes` job that holds
  `secrets.ACTIONS_PUSH` uses no composite action, preserving the Issue #3607
  isolation.
- **Error handling** — `./build.sh --verify-only` still fails the job loudly on
  a drifted or tampered WASM bundle; the `verify-wasm` input defaults to `true`
  so a new job cannot skip the gate by omission.
- **Dependencies** — no new dependency. `denoland/setup-deno` keeps its existing
  40-char SHA pin (`667a34cd…`, v2.0.4), now guarded in one place by
  `WorkflowActionPinning.ts`.



## Milestone
This PR is part of the **clean up 20260801** milestone and targets the `milestone/clean-up-20260801` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-msa0bmz2-e6df21`<!-- vibe-worker-issue-3608 -->