### PR TITLE
Make makeFunction module-private in NeuronActivation.ts (Issue #3609)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-3609.md
+++ b/docs/archive/pr-summaries/pr-summary-3609.md
@@ -36,8 +36,7 @@ now-private helper through its only caller, `prepare()`:
   one-input/one-output creature with an `IDENTITY` squash, calls
   `neuron.prepare()`, then asserts the dynamically compiled function returns
   `value = bias + activation * weight` (0.25 + 2 × 0.5 = 1.25), that
-  `activation` matches, and that the result is written into
-  `state.activations`.
+  `activation` matches, and that the result is written into `state.activations`.
 - `prepare - traced activation records the hint value` — asserts the traced
   wrapper installed alongside the compiled function computes the same value and
   records it as `hintValue` on the neuron state.

--- a/docs/archive/pr-summaries/pr-summary-3609.md
+++ b/docs/archive/pr-summaries/pr-summary-3609.md
@@ -1,0 +1,48 @@
+# PR Summary — Issue #3609
+
+## Summary
+
+`makeFunction` in `src/neuron/NeuronActivation.ts` was exported but had no
+importer anywhere in the repository — its only caller is `prepare()` in the same
+module. Dropped the `export` keyword so the helper is module-private, removing
+public surface with no consumer. Behaviour is unchanged. Closes #3609.
+
+Verification before the edit: a word-boundary search for `makeFunction` across
+every `.ts`, `.js`, `.json`, `.md` and `.rs` file in the repo (excluding
+`node_modules` and `target/`) matched only the declaration and the single
+internal call site. There is no dynamic `import()` or string-keyed lookup of the
+symbol name.
+
+## Evidence
+
+Backend/library change with no web interface, so no screenshot applies. Evidence
+is the test suite: `deno test test/neuron/NeuronActivation.ts` passes 13 tests
+(11 pre-existing plus 2 new), and the full `./quality.sh` gate passes.
+
+```
+running 13 tests from ./test/neuron/NeuronActivation.ts
+...
+prepare - compiles an activation function for a plain squash ... ok
+prepare - traced activation records the hint value ... ok
+ok | 13 passed | 0 failed
+```
+
+## Test Plan
+
+Two behaviour tests added to `test/neuron/NeuronActivation.ts` that exercise the
+now-private helper through its only caller, `prepare()`:
+
+- `prepare - compiles an activation function for a plain squash` — builds a
+  one-input/one-output creature with an `IDENTITY` squash, calls
+  `neuron.prepare()`, then asserts the dynamically compiled function returns
+  `value = bias + activation * weight` (0.25 + 2 × 0.5 = 1.25), that
+  `activation` matches, and that the result is written into
+  `state.activations`.
+- `prepare - traced activation records the hint value` — asserts the traced
+  wrapper installed alongside the compiled function computes the same value and
+  records it as `hintValue` on the neuron state.
+
+Both tests fail if the compiled-function path regresses, so they guard the
+helper's behaviour now that it is no longer part of the module's public API.
+
+No existing tests were modified or removed.

--- a/src/neuron/NeuronActivation.ts
+++ b/src/neuron/NeuronActivation.ts
@@ -59,8 +59,10 @@ export function isFixableActivation(
 /**
  * Creates a function that calculates the activation of the neuron.
  * Uses dynamic function compilation for performance.
+ *
+ * Module-private: only `prepare()` below calls it (Issue #3609).
  */
-export function makeFunction(
+function makeFunction(
   neuron: Neuron,
   functionCache: FunctionCache,
   squashProxy: (value: number) => number,

--- a/test/neuron/NeuronActivation.ts
+++ b/test/neuron/NeuronActivation.ts
@@ -4,6 +4,7 @@ import {
   isFixableActivation,
   isNodeActivation,
 } from "@neuron/NeuronActivation.ts";
+import { Creature } from "@creature";
 
 Deno.test("isNodeActivation - returns true when activateAndTrace is defined", () => {
   const activation = {
@@ -101,4 +102,58 @@ Deno.test("Type guards return correct types", () => {
     // If type guard passes, we should be able to call activateAndTrace
     assertEquals(typeof nodeAct.activateAndTrace, "function");
   }
+});
+
+/**
+ * Issue #3609: the dynamic-compilation helper is module-private, so it is
+ * exercised through `prepare()` — the only caller.
+ */
+Deno.test("prepare - compiles an activation function for a plain squash", () => {
+  const creature = Creature.fromJSON({
+    input: 1,
+    output: 1,
+    neurons: [
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0.25 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "output-0", weight: 0.5 },
+    ],
+  });
+  const state = creature.state;
+  state.activations = new Float32Array(creature.neurons.length);
+  state.activations[0] = 2;
+
+  const neuron = creature.neurons[creature.neurons.length - 1];
+  const squashMethod = neuron.prepare();
+  assert(squashMethod, "prepare should return the squash method");
+  assertFalse(isNodeActivation(squashMethod));
+
+  // value = bias + activations[input] * weight = 0.25 + 2 * 0.5 = 1.25
+  const result = neuron.activateNeuron();
+  assertEquals(result.value, 1.25);
+  assertEquals(result.activation, 1.25); // IDENTITY
+  assertEquals(state.activations[neuron.index], 1.25);
+});
+
+Deno.test("prepare - traced activation records the hint value", () => {
+  const creature = Creature.fromJSON({
+    input: 1,
+    output: 1,
+    neurons: [
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "output-0", weight: 2 },
+    ],
+  });
+  const state = creature.state;
+  state.activations = new Float32Array(creature.neurons.length);
+  state.activations[0] = 1.5;
+
+  const neuron = creature.neurons[creature.neurons.length - 1];
+  neuron.prepare();
+
+  const result = neuron.activateAndTraceNeuron();
+  assertEquals(result.value, 3);
+  assertEquals(state.node(neuron.index).hintValue, 3);
 });


### PR DESCRIPTION
# PR Summary — Issue #3609

## Summary

`makeFunction` in `src/neuron/NeuronActivation.ts` was exported but had no
importer anywhere in the repository — its only caller is `prepare()` in the same
module. Dropped the `export` keyword so the helper is module-private, removing
public surface with no consumer. Behaviour is unchanged. Closes #3609.

Verification before the edit: a word-boundary search for `makeFunction` across
every `.ts`, `.js`, `.json`, `.md` and `.rs` file in the repo (excluding
`node_modules` and `target/`) matched only the declaration and the single
internal call site. There is no dynamic `import()` or string-keyed lookup of the
symbol name.

## Evidence

Backend/library change with no web interface, so no screenshot applies. Evidence
is the test suite: `deno test test/neuron/NeuronActivation.ts` passes 13 tests
(11 pre-existing plus 2 new), and the full `./quality.sh` gate passes.

```
running 13 tests from ./test/neuron/NeuronActivation.ts
...
prepare - compiles an activation function for a plain squash ... ok
prepare - traced activation records the hint value ... ok
ok | 13 passed | 0 failed
```

## Test Plan

Two behaviour tests added to `test/neuron/NeuronActivation.ts` that exercise the
now-private helper through its only caller, `prepare()`:

- `prepare - compiles an activation function for a plain squash` — builds a
  one-input/one-output creature with an `IDENTITY` squash, calls
  `neuron.prepare()`, then asserts the dynamically compiled function returns
  `value = bias + activation * weight` (0.25 + 2 × 0.5 = 1.25), that
  `activation` matches, and that the result is written into
  `state.activations`.
- `prepare - traced activation records the hint value` — asserts the traced
  wrapper installed alongside the compiled function computes the same value and
  records it as `hintValue` on the neuron state.

Both tests fail if the compiled-function path regresses, so they guard the
helper's behaviour now that it is no longer part of the module's public API.

No existing tests were modified or removed.



## Milestone
This PR is part of the **clean up 20260801** milestone and targets the `milestone/clean-up-20260801` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-msa0bmz2-e6df21`<!-- vibe-worker-issue-3609 -->