### PR TITLE
🟢 dead-code: unused export `INWARD_INDEX_BUILD_THRESHOLD` in CreatureTopology.ts (Issue #3610)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-3610.md
+++ b/docs/archive/pr-summaries/pr-summary-3610.md
@@ -2,14 +2,14 @@
 
 ## Summary
 
-`INWARD_INDEX_BUILD_THRESHOLD` in `src/creature/CreatureTopology.ts` was exported
-but had no importer anywhere in the repository — it is read only from
+`INWARD_INDEX_BUILD_THRESHOLD` in `src/creature/CreatureTopology.ts` was
+exported but had no importer anywhere in the repository — it is read only from
 `lookupInwardConnections` in its own module. Dropped the `export` keyword so the
 constant stays module-private; the value and its internal use are unchanged, so
 behaviour is identical. Closes #3610.
 
-A repository-wide search (all file types, excluding `.git`/`target`) confirms the
-name appears only in `src/creature/CreatureTopology.ts` — no re-export from
+A repository-wide search (all file types, excluding `.git`/`target`) confirms
+the name appears only in `src/creature/CreatureTopology.ts` — no re-export from
 `mod.ts`, no dynamic or string-keyed lookup.
 
 ## Evidence
@@ -17,13 +17,14 @@ name appears only in `src/creature/CreatureTopology.ts` — no re-export from
 Backend/library change with no web interface, so no screenshot applies. Evidence
 is the test run:
 
-- `deno test --allow-all test/creature/CreatureTopology.ts` — 12 passed, 0 failed.
+- `deno test --allow-all test/creature/CreatureTopology.ts` — 12 passed, 0
+  failed.
 - `./quality.sh` passes (lint, format, type-check, full test suite).
 
-The behavioural contract the constant governs — switching from linear scan to the
-secondary index after enough cache misses — is covered by the new test below,
-which asserts both code paths return identical results without referencing the
-constant itself.
+The behavioural contract the constant governs — switching from linear scan to
+the secondary index after enough cache misses — is covered by the new test
+below, which asserts both code paths return identical results without
+referencing the constant itself.
 
 ```mermaid
 flowchart LR
@@ -37,9 +38,10 @@ flowchart LR
 
 ## Test Plan
 
-- Added `test/creature/CreatureTopology.ts::"inwardConnections - index path
-  matches linear-scan path"` — queries every neuron on a shared cache so the miss
-  counter crosses the internal build threshold part-way through, asserting the
-  linear-scan and index results both match a brute-force scan of
-  `creature.synapses`.
+- Added
+  `test/creature/CreatureTopology.ts::"inwardConnections - index path
+  matches linear-scan path"`
+  — queries every neuron on a shared cache so the miss counter crosses the
+  internal build threshold part-way through, asserting the linear-scan and index
+  results both match a brute-force scan of `creature.synapses`.
 - All existing `test/creature/CreatureTopology.ts` tests unchanged and passing.

--- a/docs/archive/pr-summaries/pr-summary-3610.md
+++ b/docs/archive/pr-summaries/pr-summary-3610.md
@@ -1,0 +1,45 @@
+# Remove unused export `INWARD_INDEX_BUILD_THRESHOLD`
+
+## Summary
+
+`INWARD_INDEX_BUILD_THRESHOLD` in `src/creature/CreatureTopology.ts` was exported
+but had no importer anywhere in the repository — it is read only from
+`lookupInwardConnections` in its own module. Dropped the `export` keyword so the
+constant stays module-private; the value and its internal use are unchanged, so
+behaviour is identical. Closes #3610.
+
+A repository-wide search (all file types, excluding `.git`/`target`) confirms the
+name appears only in `src/creature/CreatureTopology.ts` — no re-export from
+`mod.ts`, no dynamic or string-keyed lookup.
+
+## Evidence
+
+Backend/library change with no web interface, so no screenshot applies. Evidence
+is the test run:
+
+- `deno test --allow-all test/creature/CreatureTopology.ts` — 12 passed, 0 failed.
+- `./quality.sh` passes (lint, format, type-check, full test suite).
+
+The behavioural contract the constant governs — switching from linear scan to the
+secondary index after enough cache misses — is covered by the new test below,
+which asserts both code paths return identical results without referencing the
+constant itself.
+
+```mermaid
+flowchart LR
+    A[inwardConnections] --> B{index built?}
+    B -- yes --> C[binary search on index]
+    B -- no --> D[miss counter++]
+    D --> E{counter >= threshold<br/>module-private const}
+    E -- yes --> F[build index] --> C
+    E -- no --> G[linear scan]
+```
+
+## Test Plan
+
+- Added `test/creature/CreatureTopology.ts::"inwardConnections - index path
+  matches linear-scan path"` — queries every neuron on a shared cache so the miss
+  counter crosses the internal build threshold part-way through, asserting the
+  linear-scan and index results both match a brute-force scan of
+  `creature.synapses`.
+- All existing `test/creature/CreatureTopology.ts` tests unchanged and passing.

--- a/src/creature/CreatureTopology.ts
+++ b/src/creature/CreatureTopology.ts
@@ -33,7 +33,7 @@ export interface TopologyCaches {
  * Threshold for switching from linear scan to building the secondary index.
  * Issue #1010: Performance optimisation for large creatures.
  */
-export const INWARD_INDEX_BUILD_THRESHOLD = 3;
+const INWARD_INDEX_BUILD_THRESHOLD = 3;
 
 /**
  * Minimum number of synapses to trigger proactive index prebuilding.

--- a/test/creature/CreatureTopology.ts
+++ b/test/creature/CreatureTopology.ts
@@ -199,6 +199,40 @@ Deno.test("prebuildInwardIndex - builds secondary index", async () => {
   );
 });
 
+Deno.test("inwardConnections - index path matches linear-scan path", async () => {
+  await initWasmForTests();
+  const creature = new Creature(3, 2, {
+    layers: [{ count: 4 }, { count: 3 }],
+  });
+  creatureValidate(creature);
+
+  const caches = makeCaches();
+  // Query every neuron so the miss counter crosses the internal build
+  // threshold part-way through: early lookups use the linear scan, later
+  // ones use the secondary index. Both must agree with a brute-force scan.
+  for (let indx = 0; indx < creature.neurons.length; indx++) {
+    const expected = creature.synapses.filter((syn) => syn.to === indx);
+    const actual = inwardConnections(creature, caches, indx);
+    assertEquals(
+      actual.length,
+      expected.length,
+      `Inward count mismatch for neuron ${indx}`,
+    );
+    for (const syn of expected) {
+      assert(
+        actual.some((a) => a.from === syn.from && a.to === syn.to),
+        `Missing inward synapse ${syn.from}->${syn.to}`,
+      );
+    }
+  }
+
+  assertNotEquals(
+    caches.synapsesIndexedByTo,
+    null,
+    "Index should be built once the miss threshold is crossed",
+  );
+});
+
 Deno.test("facade delegation matches direct module calls", async () => {
   await initWasmForTests();
   const creature = new Creature(2, 1, {


### PR DESCRIPTION
# Remove unused export `INWARD_INDEX_BUILD_THRESHOLD`

## Summary

`INWARD_INDEX_BUILD_THRESHOLD` in `src/creature/CreatureTopology.ts` was exported
but had no importer anywhere in the repository — it is read only from
`lookupInwardConnections` in its own module. Dropped the `export` keyword so the
constant stays module-private; the value and its internal use are unchanged, so
behaviour is identical. Closes #3610.

A repository-wide search (all file types, excluding `.git`/`target`) confirms the
name appears only in `src/creature/CreatureTopology.ts` — no re-export from
`mod.ts`, no dynamic or string-keyed lookup.

## Evidence

Backend/library change with no web interface, so no screenshot applies. Evidence
is the test run:

- `deno test --allow-all test/creature/CreatureTopology.ts` — 12 passed, 0 failed.
- `./quality.sh` passes (lint, format, type-check, full test suite).

The behavioural contract the constant governs — switching from linear scan to the
secondary index after enough cache misses — is covered by the new test below,
which asserts both code paths return identical results without referencing the
constant itself.

```mermaid
flowchart LR
    A[inwardConnections] --> B{index built?}
    B -- yes --> C[binary search on index]
    B -- no --> D[miss counter++]
    D --> E{counter >= threshold<br/>module-private const}
    E -- yes --> F[build index] --> C
    E -- no --> G[linear scan]
```

## Test Plan

- Added `test/creature/CreatureTopology.ts::"inwardConnections - index path
  matches linear-scan path"` — queries every neuron on a shared cache so the miss
  counter crosses the internal build threshold part-way through, asserting the
  linear-scan and index results both match a brute-force scan of
  `creature.synapses`.
- All existing `test/creature/CreatureTopology.ts` tests unchanged and passing.



## Milestone
This PR is part of the **clean up 20260801** milestone and targets the `milestone/clean-up-20260801` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-msa43c1w-a834b8`<!-- vibe-worker-issue-3610 -->