### PR TITLE
Make PREBUILD_SYNAPSE_THRESHOLD module-private (Issue #3611)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-3611.md
+++ b/docs/archive/pr-summaries/pr-summary-3611.md
@@ -1,0 +1,38 @@
+# Remove unused export of `PREBUILD_SYNAPSE_THRESHOLD` (Issue #3611)
+
+## Summary
+
+`PREBUILD_SYNAPSE_THRESHOLD` in `src/creature/CreatureTopology.ts` was exported
+but had no importer anywhere in the repository — it is read only by
+`prebuildInwardIndexIfLarge()` in its own module. The deprecated re-export from
+`Creature.ts` was already removed under Issue #1487, leaving the `export`
+keyword as public surface with no consumer. Dropped the keyword so the tuning
+constant (Issue #1097) is module-private. Behaviour is unchanged. Closes #3611.
+
+Verified before editing that no other `.ts` file, no `mod.ts` re-export, and no
+non-TypeScript file (docs, scripts, config) references the name — a repo-wide
+search returns only the declaration and the single internal comparison.
+
+## Evidence
+
+Backend-only change with no web interface, so there is no screenshot. Evidence
+is the quality gate:
+
+- `./quality.sh < /dev/null` → **exit 0**, `8064 passed | 0 failed | 4 ignored`.
+- `deno check` (inside the gate) is the decisive proof for this change: any
+  module still importing the constant would now fail to type-check.
+
+## Test Plan
+
+- Added
+  `test/creature/CreatureTopology.ts::prebuildInwardIndexIfLarge - only
+  builds for large creatures`
+  — calls the module function directly and asserts on the observable outcome
+  (`isInwardIndexBuilt`): a small creature does not build the inward index, a
+  creature above the threshold does. This locks the threshold behaviour at
+  module level now that the constant is private, without importing the constant
+  itself.
+- Existing coverage retained: `test/architecture/PrebuildInwardIndex.ts` already
+  exercises the same threshold through the `Creature` facade after breed,
+  mutate, and load.
+- No tests were removed or commented out.

--- a/src/creature/CreatureTopology.ts
+++ b/src/creature/CreatureTopology.ts
@@ -39,7 +39,7 @@ const INWARD_INDEX_BUILD_THRESHOLD = 3;
  * Minimum number of synapses to trigger proactive index prebuilding.
  * Issue #1097: Performance - Prebuild inward synapse index after breed/mutation batch.
  */
-export const PREBUILD_SYNAPSE_THRESHOLD = 1000;
+const PREBUILD_SYNAPSE_THRESHOLD = 1000;
 
 /**
  * Get a self-connection for the neuron at the given index.

--- a/test/creature/CreatureTopology.ts
+++ b/test/creature/CreatureTopology.ts
@@ -14,8 +14,10 @@ import {
   getSynapse,
   hasConnection,
   inwardConnections,
+  isInwardIndexBuilt,
   outwardConnections,
   prebuildInwardIndex,
+  prebuildInwardIndexIfLarge,
   selfConnection,
   type TopologyCaches,
 } from "@creature/CreatureTopology.ts";
@@ -257,4 +259,32 @@ Deno.test("facade delegation matches direct module calls", async () => {
 
   // hasConnection via facade
   assert(creature.hasConnection(syn.from, syn.to));
+});
+
+Deno.test("prebuildInwardIndexIfLarge - only builds for large creatures", async () => {
+  await initWasmForTests();
+
+  const small = new Creature(2, 1, { layers: [{ count: 2 }] });
+  creatureValidate(small);
+  const smallCaches = makeCaches();
+  prebuildInwardIndexIfLarge(small, smallCaches);
+  assertEquals(
+    isInwardIndexBuilt(smallCaches),
+    false,
+    "Small creature should not trigger the prebuild threshold",
+  );
+
+  const large = new Creature(20, 5, { layers: [{ count: 40 }, { count: 30 }] });
+  creatureValidate(large);
+  assert(
+    large.synapses.length >= 1000,
+    "Fixture must exceed the prebuild threshold",
+  );
+  const largeCaches = makeCaches();
+  prebuildInwardIndexIfLarge(large, largeCaches);
+  assertEquals(
+    isInwardIndexBuilt(largeCaches),
+    true,
+    "Large creature should trigger the prebuild threshold",
+  );
 });


### PR DESCRIPTION
# Remove unused export of `PREBUILD_SYNAPSE_THRESHOLD` (Issue #3611)

## Summary

`PREBUILD_SYNAPSE_THRESHOLD` in `src/creature/CreatureTopology.ts` was exported
but had no importer anywhere in the repository — it is read only by
`prebuildInwardIndexIfLarge()` in its own module. The deprecated re-export from
`Creature.ts` was already removed under Issue #1487, leaving the `export`
keyword as public surface with no consumer. Dropped the keyword so the tuning
constant (Issue #1097) is module-private. Behaviour is unchanged. Closes #3611.

Verified before editing that no other `.ts` file, no `mod.ts` re-export, and no
non-TypeScript file (docs, scripts, config) references the name — a repo-wide
search returns only the declaration and the single internal comparison.

## Evidence

Backend-only change with no web interface, so there is no screenshot. Evidence
is the quality gate:

- `./quality.sh < /dev/null` → **exit 0**, `8064 passed | 0 failed | 4 ignored`.
- `deno check` (inside the gate) is the decisive proof for this change: any
  module still importing the constant would now fail to type-check.

## Test Plan

- Added
  `test/creature/CreatureTopology.ts::prebuildInwardIndexIfLarge - only
  builds for large creatures`
  — calls the module function directly and asserts on the observable outcome
  (`isInwardIndexBuilt`): a small creature does not build the inward index, a
  creature above the threshold does. This locks the threshold behaviour at
  module level now that the constant is private, without importing the constant
  itself.
- Existing coverage retained: `test/architecture/PrebuildInwardIndex.ts` already
  exercises the same threshold through the `Creature` facade after breed,
  mutate, and load.
- No tests were removed or commented out.



## Milestone
This PR is part of the **clean up 20260801** milestone and targets the `milestone/clean-up-20260801` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-msa76s9e-777e30`<!-- vibe-worker-issue-3611 -->