### PR TITLE
Reword private stSoftwareAU/GRQ references in live option-audit docs (Issue #3615)

### DIFF
--- a/docs/OPTION_AUDIT_SLICE_A.md
+++ b/docs/OPTION_AUDIT_SLICE_A.md
@@ -27,8 +27,8 @@ Four options qualify for removal, filed as three removal issues: #3552
 
 ## Method
 
-Consumers were confirmed from `deno.json`: `stSoftwareAU/GRQ` pins
-`jsr:@stsoftware/neat-ai@6.0.0` and `stSoftwareAU/NEAT-AI-Examples` pins
+Consumers were confirmed from `deno.json`: the downstream production consumer
+pins `jsr:@stsoftware/neat-ai@6.0.0` and `stSoftwareAU/NEAT-AI-Examples` pins
 `@5.9.43`.
 
 Each key was resolved twice, against fresh clones and against the code-search
@@ -40,7 +40,7 @@ git -C GRQ                grep -n -E "(^|[^A-Za-z0-9_])<key>[[:space:]]*[:=]" --
 git -C NEAT-AI-Examples   grep -n -E "(^|[^A-Za-z0-9_])<key>[[:space:]]*[:=]" -- '*.ts' '*.js' '*.json' '*.sh'
 
 # Cross-check — per-repo only, never a bare --owner.
-gh search code "<key>" --repo stSoftwareAU/GRQ --limit 20
+gh search code "<key>" --repo <consumer-repo> --limit 20
 gh search code "<key>" --repo stSoftwareAU/NEAT-AI-Examples --limit 20
 ```
 

--- a/docs/OPTION_AUDIT_SLICE_B.md
+++ b/docs/OPTION_AUDIT_SLICE_B.md
@@ -46,8 +46,8 @@ flowchart LR
 
 Consumers were confirmed from `deno.json` via the org backstop
 (`gh search code "stsoftware/neat-ai" --owner stSoftwareAU --filename deno.json`,
-the one org-wide query that is safe because it is `--filename`-scoped):
-`stSoftwareAU/GRQ` pins `jsr:@stsoftware/neat-ai@6.0.0` and
+the one org-wide query that is safe because it is `--filename`-scoped): the
+downstream production consumer pins `jsr:@stsoftware/neat-ai@6.0.0` and
 `stSoftwareAU/NEAT-AI-Examples` pins `@5.9.43`. No third TypeScript consumer
 exists. `stSoftwareAU/NEAT-AI-Discovery` was searched as the extra Rust-side
 consumer this slice is required to cover.
@@ -63,7 +63,7 @@ git -C NEAT-AI-Examples   grep -n -F "<key>" origin/Develop
 git -C NEAT-AI-Discovery  grep -n -F "<key>" origin/Develop
 
 # Cross-check — per-repo only, never a bare --owner.
-gh search code "<key>" --repo stSoftwareAU/GRQ --limit 20
+gh search code "<key>" --repo <consumer-repo> --limit 20
 gh search code "<key>" --repo stSoftwareAU/NEAT-AI-Examples --limit 20
 gh search code "<key>" --repo stSoftwareAU/NEAT-AI-Discovery --limit 20
 ```

--- a/docs/OPTION_AUDIT_SLICE_C.md
+++ b/docs/OPTION_AUDIT_SLICE_C.md
@@ -59,10 +59,10 @@ flowchart TD
 
 ## Method
 
-The two confirmed consumers are unchanged from slice B: `stSoftwareAU/GRQ` and
-`stSoftwareAU/NEAT-AI-Examples`, both declaring `@stsoftware/neat` in
-`deno.json`. Each key was resolved against fresh clones (fetched 30 Jul 2026)
-and cross-checked against the code-search index:
+The two confirmed consumers are unchanged from slice B: the downstream
+production consumer and `stSoftwareAU/NEAT-AI-Examples`, both declaring
+`@stsoftware/neat` in `deno.json`. Each key was resolved against fresh clones
+(fetched 30 Jul 2026) and cross-checked against the code-search index:
 
 ```bash
 # Local pass — primary evidence, complete and unmetered. Searched against
@@ -71,7 +71,7 @@ git -C GRQ              grep -n -F "<key>" origin/Develop
 git -C NEAT-AI-Examples grep -n -F "<key>" origin/Develop
 
 # Cross-check — per-repo only, never a bare --owner.
-gh search code "<key>" --repo stSoftwareAU/GRQ --limit 20
+gh search code "<key>" --repo <consumer-repo> --limit 20
 gh search code "<key>" --repo stSoftwareAU/NEAT-AI-Examples --limit 20
 ```
 

--- a/docs/OPTION_AUDIT_SLICE_D.md
+++ b/docs/OPTION_AUDIT_SLICE_D.md
@@ -55,8 +55,8 @@ flowchart TD
 
 ## Method
 
-The two confirmed consumers are unchanged from slices B and C:
-`stSoftwareAU/GRQ` and `stSoftwareAU/NEAT-AI-Examples`. Both were rediscovered
+The two confirmed consumers are unchanged from slices B and C: the downstream
+production consumer and `stSoftwareAU/NEAT-AI-Examples`. Both were rediscovered
 independently in this run by the #3518 harness's org backstop
 (`--filename deno.json`), which reported exactly those two repositories as
 declaring `@stsoftware/neat-ai`.
@@ -71,7 +71,7 @@ git -C GRQ              grep -n -F "<key>" origin/Develop
 git -C NEAT-AI-Examples grep -n -F "<key>" origin/Develop
 
 # Cross-check — per-repo only, never a bare --owner.
-gh search code "<key>" --repo stSoftwareAU/GRQ --limit 20
+gh search code "<key>" --repo <consumer-repo> --limit 20
 gh search code "<key>" --repo stSoftwareAU/NEAT-AI-Examples --limit 20
 ```
 
@@ -93,7 +93,7 @@ The zero results below are therefore a property of the keys, not of the search.
 `OPTION_USAGE_AUDIT.md` warns that a bare `--owner` search saturates and reports
 a set key as unused. Slice D hit the opposite failure on the same tool:
 
-`gh search code squashBudget --repo stSoftwareAU/GRQ` returns **2 hits** where
+`gh search code squashBudget --repo <consumer-repo>` returns **2 hits** where
 `git grep -F squashBudget origin/Develop` returns none. Both are GRQ's own
 **ImproveSquash** pass and its wall-clock **budget** —
 `worker/IntelligentDesign/run.sh` (`--budgetSeconds`, `ID_STEP_BUDGET_SECONDS`)

--- a/docs/OPTION_AUDIT_SLICE_E.md
+++ b/docs/OPTION_AUDIT_SLICE_E.md
@@ -60,10 +60,10 @@ flowchart TD
 
 ## Method
 
-The two confirmed consumers are unchanged from slices B–D: `stSoftwareAU/GRQ`
-and `stSoftwareAU/NEAT-AI-Examples`. Each key was resolved against fresh clones
-(fetched 30 Jul 2026; GRQ `origin/Develop` at `5199cb241`, NEAT-AI-Examples at
-`2405d1b`).
+The two confirmed consumers are unchanged from slices B–D: the downstream
+production consumer and `stSoftwareAU/NEAT-AI-Examples`. Each key was resolved
+against fresh clones (fetched 30 Jul 2026; GRQ `origin/Develop` at `5199cb241`,
+NEAT-AI-Examples at `2405d1b`).
 
 ```bash
 # Local pass — primary evidence, complete and unmetered. git grep searches
@@ -76,7 +76,7 @@ git -C GRQ grep -n -I -F "<SCREAMING_SNAKE>" origin/Develop \
   -- '*.sh' '*.yml' '*.yaml' '*.json' '*.jsonc' 'Dockerfile*' '*.env'
 
 # Cross-check — per-repo only, never a bare --owner.
-gh search code "<key>" --repo stSoftwareAU/GRQ --limit 20
+gh search code "<key>" --repo <consumer-repo> --limit 20
 ```
 
 Every local search checks the exit code explicitly — `rc 0` hit, `rc 1` miss,
@@ -122,8 +122,7 @@ family already accounted for above.
 ### Two name collisions that would have produced wrong verdicts
 
 **`wasmCache` — a false `IN USE`.**
-`gh search code wasmCache --repo
-stSoftwareAU/GRQ` returns the full window of
+`gh search code wasmCache --repo <consumer-repo>` returns the full window of
 **20 hits**, and `git grep` returns 50. Not one of them is NEAT-AI's `wasmCache`
 option: every hit is GRQ's own `src/train/wasmCacheCap.ts`, an unrelated
 per-host LRU cap with its own `WASM_CACHE_CAP` env var. This is the same failure

--- a/docs/OPTION_AUDIT_SLICE_F.md
+++ b/docs/OPTION_AUDIT_SLICE_F.md
@@ -60,11 +60,12 @@ flowchart TD
 
 ## Method
 
-The two confirmed consumers are unchanged from slices B–D: `stSoftwareAU/GRQ`
-and `stSoftwareAU/NEAT-AI-Examples`. Both were resolved against fresh clones
-fetched 30 Jul 2026 — GRQ `origin/Develop` at `312370d`, NEAT-AI-Examples
-`origin/Develop` at `2405d1b`. `Develop` is the default branch of both
-repositories, so the local pass and the code-search index look at the same tree.
+The two confirmed consumers are unchanged from slices B–D: the downstream
+production consumer and `stSoftwareAU/NEAT-AI-Examples`. Both were resolved
+against fresh clones fetched 30 Jul 2026 — GRQ `origin/Develop` at `312370d`,
+NEAT-AI-Examples `origin/Develop` at `2405d1b`. `Develop` is the default branch
+of both repositories, so the local pass and the code-search index look at the
+same tree.
 
 ```bash
 # Local pass — primary evidence, complete and unmetered.
@@ -72,7 +73,7 @@ git -C GRQ              grep -n -F -I "<key>" origin/Develop
 git -C NEAT-AI-Examples grep -n -F -I "<key>" origin/Develop
 
 # Cross-check — per-repo only, never a bare --owner.
-gh search code "<key>" --repo stSoftwareAU/GRQ --limit 20
+gh search code "<key>" --repo <consumer-repo> --limit 20
 gh search code "<key>" --repo stSoftwareAU/NEAT-AI-Examples --limit 20
 ```
 
@@ -304,8 +305,8 @@ Two consequences for this audit:
    unreadable at any value; whether the _feature_ is later wired up through
    `SpecialistPipeline` is independent of that.
 
-The GRQ-side half-wiring is a separate root cause in a separate repository and
-is filed there as **stSoftwareAU/GRQ#3793**.
+The consumer-side half-wiring is a separate root cause in a separate repository
+and is tracked in that repository's own issue tracker, not here.
 
 ## Overlap with slice A
 

--- a/docs/archive/pr-summaries/pr-summary-3615.md
+++ b/docs/archive/pr-summaries/pr-summary-3615.md
@@ -1,0 +1,101 @@
+# PR summary — reword private `stSoftwareAU/GRQ` references in live option-audit docs
+
+## Summary
+
+The live (non-archive) option-audit documentation named the **private**
+`stSoftwareAU/GRQ` repository and shipped runnable
+`gh search code "<key>" --repo stSoftwareAU/GRQ` commands. A public repository
+must be self-contained for the public: those commands 404 for every public
+reader, so the documented audit method was unverifiable outside the
+organisation. Closes #3615.
+
+Two changes:
+
+1. **Docs reworded to concept level.** Every org-qualified `stSoftwareAU/GRQ`
+   reference in `docs/OPTION_AUDIT_SLICE_A–F.md` and
+   `docs/dna-sharing-bake-off-results.md` now reads "the downstream production
+   consumer" — the phrasing `docs/OPTION_AUDIT_CONSOLIDATED.md` already uses.
+   Example commands use a `<consumer-repo>` placeholder, and the private
+   issue-tracker pointer in slice F is replaced with concept-level wording.
+   `docs/OPTION_USAGE_AUDIT.md` was already clean.
+2. **Guard widened.** `test/docs/LiveDocsNoPrivateGrqReference.ts` previously
+   walked only three hard-coded docs, which is why the newer option-audit pages
+   reintroduced the references unchecked. It now also walks **all** of `docs/`
+   outside `docs/archive/`.
+
+### What the widened guard forbids
+
+The new walk matches the **org-qualified** forms — the ones a reader can act on
+and be 404'd by:
+
+| Form                                          | Flagged | Rationale                          |
+| --------------------------------------------- | :-----: | ---------------------------------- |
+| `stSoftwareAU/GRQ` (incl. `-cluster`/`-logs`) |   ✅    | Actionable `--repo` / path pointer |
+| A `github.com` link to that repo              |   ✅    | Link that 404s                     |
+| `GRQ#NNNN` issue slug                         |   ✅    | Private issue-tracker slug         |
+| `GRQ-22`, `grq-3397`                          |   ❌    | Bare mnemonic — names a concept    |
+
+The bare-mnemonic carve-out is not new: it is the decision already recorded in
+`test/_privateRepoRefs.ts` for #3454/#3604. The original three-doc,
+any-`GRQ`-token check is unchanged and still enforced on those docs.
+
+```mermaid
+flowchart LR
+    A["docs/ *.md"] --> B{"under docs/archive/?"}
+    B -- yes --> SKIP["skipped — archived PR summaries"]
+    B -- no --> C{"org-qualified GRQ ref?"}
+    C -- "stSoftwareAU/GRQ, GRQ#NNNN" --> FAIL["test fails with file:line"]
+    C -- "GRQ-22 mnemonic only" --> PASS["passes"]
+```
+
+## Evidence
+
+Documentation and test-only change — no web interface to screenshot.
+
+The new guard was written first and reproduced the issue's file list exactly
+before any doc was touched:
+
+```
+no live doc carries an org-qualified private GRQ reference (#3615) ... FAILED
+  Live docs name the private stSoftwareAU/GRQ repository:
+  OPTION_AUDIT_SLICE_A.md:30,43
+  OPTION_AUDIT_SLICE_B.md:50,66
+  OPTION_AUDIT_SLICE_C.md:62,74
+  OPTION_AUDIT_SLICE_D.md:59,74,96
+  OPTION_AUDIT_SLICE_E.md:63,79,126
+  OPTION_AUDIT_SLICE_F.md:63,75,308
+  dna-sharing-bake-off-results.md:194
+FAILED | 11 passed | 1 failed
+```
+
+After the rewording, the same guard passes:
+
+```
+ok | 12 passed | 0 failed (102ms)
+```
+
+Full quality gate: `./quality.sh < /dev/null` →
+`ok | 8084 passed (5 steps) | 0 failed | 4 ignored`.
+
+## Test Plan
+
+Added to `test/docs/LiveDocsNoPrivateGrqReference.ts`:
+
+- `no live doc carries an org-qualified private GRQ reference (#3615)` — walks
+  every `.md` under `docs/` except `docs/archive/`; the regression test for this
+  issue (it failed against the unfixed docs and passes after the rewording).
+- `findOrgQualifiedGrqReferences flags a repo slug and a gh search command` —
+  happy path on both offending shapes.
+- `findOrgQualifiedGrqReferences flags an issue slug and a repo link` — the
+  `GRQ#NNNN` and `github.com/…` forms.
+- `findOrgQualifiedGrqReferences ignores bare mnemonics and empty input` — edge
+  cases; guards against false positives on `GRQ-22` / `grq-3397` and on empty
+  input.
+
+No existing test was removed or modified.
+
+## Security self-check
+
+- No new external input, injection surface, endpoint, or dependency — the change
+  is Markdown prose plus a read-only test that reads files from the repo tree.
+- No secrets or hidden files staged.

--- a/docs/dna-sharing-bake-off-results.md
+++ b/docs/dna-sharing-bake-off-results.md
@@ -191,7 +191,7 @@ something the retirement invalidates — but the code behind the
 `KnobTuning(aggressive)` row is gone:
 
 - `dnaSharingMode` (`NeatOptions` / `NeatArguments`) — no consumer ever set it,
-  confirmed per-repo against `stSoftwareAU/GRQ` and
+  confirmed per-repo against the downstream production consumer and
   `stSoftwareAU/NEAT-AI-Examples`.
 - `src/config/DnaSharingPreset.ts` — the `default` preset was defined to equal
   the per-knob defaults already applied by `createNeatConfig()`, so with nobody

--- a/test/docs/LiveDocsNoPrivateGrqReference.ts
+++ b/test/docs/LiveDocsNoPrivateGrqReference.ts
@@ -12,10 +12,21 @@
  * Detection is case-sensitive on the upper-case `GRQ` token so the in-tree
  * synthetic `grq-3397` scale-preset name (a fixture, not a private repo) is not
  * flagged.
+ *
+ * Issue #3615 extends the guard beyond the three hard-coded docs above: every
+ * live doc under `docs/` (outside `docs/archive/`) is walked for an
+ * **org-qualified** private reference — a `stSoftwareAU/GRQ*` repo slug, a
+ * `github.com/stSoftwareAU/GRQ*` link, or a `GRQ#NNNN` issue slug. Those are
+ * the forms a reader can act on and be 404'd by, notably the
+ * `gh search code … --repo stSoftwareAU/GRQ` commands the option-audit slices
+ * shipped. A bare `GRQ` mnemonic (`GRQ-22` host, `GRQ-cluster` topology) still
+ * names a concept rather than pointing at an unreachable page, matching the
+ * #3454/#3604 decision recorded in `test/_privateRepoRefs.ts`.
  */
 
 import { assertEquals } from "@std/assert";
 import { fromFileUrl } from "@std/path";
+import { walk } from "@std/fs";
 
 /** Live docs that must not reference the private `GRQ*` repositories. */
 const LIVE_DOCS = [
@@ -58,6 +69,86 @@ for (const rel of LIVE_DOCS) {
     );
   });
 }
+
+/**
+ * Match an org-qualified private `GRQ*` reference — a `stSoftwareAU/GRQ*` repo
+ * slug (with or without a `github.com/` prefix) or a `GRQ#NNNN` issue slug.
+ * Bare mnemonics such as `GRQ-22` are deliberately not matched.
+ */
+const ORG_QUALIFIED_GRQ_PATTERN = /stSoftwareAU\/GRQ|GRQ#\d+/;
+
+/**
+ * Return every line carrying an org-qualified private `GRQ*` reference.
+ *
+ * @param source raw Markdown source
+ * @returns 1-indexed line numbers with an org-qualified `GRQ*` reference
+ */
+export function findOrgQualifiedGrqReferences(source: string): number[] {
+  const hits: number[] = [];
+  const lines = source.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    if (ORG_QUALIFIED_GRQ_PATTERN.test(lines[i])) {
+      hits.push(i + 1);
+    }
+  }
+  return hits;
+}
+
+const DOCS_DIR = fromFileUrl(new URL("../../docs", import.meta.url));
+const ARCHIVE_DIR = fromFileUrl(new URL("../../docs/archive", import.meta.url));
+
+Deno.test("no live doc carries an org-qualified private GRQ reference (#3615)", async () => {
+  const offenders: string[] = [];
+  for await (
+    const entry of walk(DOCS_DIR, { exts: [".md"], includeDirs: false })
+  ) {
+    if (entry.path.startsWith(ARCHIVE_DIR)) continue;
+    const hits = findOrgQualifiedGrqReferences(
+      await Deno.readTextFile(entry.path),
+    );
+    if (hits.length > 0) {
+      offenders.push(
+        `${entry.path.slice(DOCS_DIR.length + 1)}:${hits.join(",")}`,
+      );
+    }
+  }
+  assertEquals(
+    offenders.sort(),
+    [],
+    `Live docs name the private stSoftwareAU/GRQ repository:\n` +
+      `${offenders.join("\n")}\n` +
+      `Reword to concept level (e.g. "the downstream production consumer") ` +
+      `and use a "<consumer-repo>" placeholder in example commands so the ` +
+      `documented method stays runnable by public readers.`,
+  );
+});
+
+Deno.test("findOrgQualifiedGrqReferences flags a repo slug and a gh search command", () => {
+  const src = [
+    "Consumers were confirmed from `deno.json`: `stSoftwareAU/GRQ` pins",
+    'gh search code "<key>" --repo stSoftwareAU/GRQ --limit 20',
+    "Closing line.",
+  ].join("\n");
+  assertEquals(findOrgQualifiedGrqReferences(src), [1, 2]);
+});
+
+Deno.test("findOrgQualifiedGrqReferences flags an issue slug and a repo link", () => {
+  const src = [
+    "is filed there as **stSoftwareAU/GRQ#3793**.",
+    "See https://github.com/stSoftwareAU/GRQ-cluster/blob/main/net.json.",
+  ].join("\n");
+  assertEquals(findOrgQualifiedGrqReferences(src), [1, 2]);
+});
+
+Deno.test("findOrgQualifiedGrqReferences ignores bare mnemonics and empty input", () => {
+  const src = [
+    "The downstream production consumer sets `populationSize`.",
+    "GRQ-22 host snapshot: 16 GB total, 10 CPUs.",
+    "The synthetic `grq-3397` scale preset reproduces the dimensions.",
+  ].join("\n");
+  assertEquals(findOrgQualifiedGrqReferences(src), []);
+  assertEquals(findOrgQualifiedGrqReferences(""), []);
+});
 
 Deno.test("findPrivateGrqReferences flags GRQ-cluster and GRQ-logs", () => {
   const src = [


### PR DESCRIPTION
# PR summary — reword private `stSoftwareAU/GRQ` references in live option-audit docs

## Summary

The live (non-archive) option-audit documentation named the **private**
`stSoftwareAU/GRQ` repository and shipped runnable
`gh search code "<key>" --repo stSoftwareAU/GRQ` commands. A public repository
must be self-contained for the public: those commands 404 for every public
reader, so the documented audit method was unverifiable outside the
organisation. Closes #3615.

Two changes:

1. **Docs reworded to concept level.** Every org-qualified `stSoftwareAU/GRQ`
   reference in `docs/OPTION_AUDIT_SLICE_A–F.md` and
   `docs/dna-sharing-bake-off-results.md` now reads "the downstream production
   consumer" — the phrasing `docs/OPTION_AUDIT_CONSOLIDATED.md` already uses.
   Example commands use a `<consumer-repo>` placeholder, and the private
   issue-tracker pointer in slice F is replaced with concept-level wording.
   `docs/OPTION_USAGE_AUDIT.md` was already clean.
2. **Guard widened.** `test/docs/LiveDocsNoPrivateGrqReference.ts` previously
   walked only three hard-coded docs, which is why the newer option-audit pages
   reintroduced the references unchecked. It now also walks **all** of `docs/`
   outside `docs/archive/`.

### What the widened guard forbids

The new walk matches the **org-qualified** forms — the ones a reader can act on
and be 404'd by:

| Form                                          | Flagged | Rationale                          |
| --------------------------------------------- | :-----: | ---------------------------------- |
| `stSoftwareAU/GRQ` (incl. `-cluster`/`-logs`) |   ✅    | Actionable `--repo` / path pointer |
| A `github.com` link to that repo              |   ✅    | Link that 404s                     |
| `GRQ#NNNN` issue slug                         |   ✅    | Private issue-tracker slug         |
| `GRQ-22`, `grq-3397`                          |   ❌    | Bare mnemonic — names a concept    |

The bare-mnemonic carve-out is not new: it is the decision already recorded in
`test/_privateRepoRefs.ts` for #3454/#3604. The original three-doc,
any-`GRQ`-token check is unchanged and still enforced on those docs.

```mermaid
flowchart LR
    A["docs/ *.md"] --> B{"under docs/archive/?"}
    B -- yes --> SKIP["skipped — archived PR summaries"]
    B -- no --> C{"org-qualified GRQ ref?"}
    C -- "stSoftwareAU/GRQ, GRQ#NNNN" --> FAIL["test fails with file:line"]
    C -- "GRQ-22 mnemonic only" --> PASS["passes"]
```

## Evidence

Documentation and test-only change — no web interface to screenshot.

The new guard was written first and reproduced the issue's file list exactly
before any doc was touched:

```
no live doc carries an org-qualified private GRQ reference (#3615) ... FAILED
  Live docs name the private stSoftwareAU/GRQ repository:
  OPTION_AUDIT_SLICE_A.md:30,43
  OPTION_AUDIT_SLICE_B.md:50,66
  OPTION_AUDIT_SLICE_C.md:62,74
  OPTION_AUDIT_SLICE_D.md:59,74,96
  OPTION_AUDIT_SLICE_E.md:63,79,126
  OPTION_AUDIT_SLICE_F.md:63,75,308
  dna-sharing-bake-off-results.md:194
FAILED | 11 passed | 1 failed
```

After the rewording, the same guard passes:

```
ok | 12 passed | 0 failed (102ms)
```

Full quality gate: `./quality.sh < /dev/null` →
`ok | 8084 passed (5 steps) | 0 failed | 4 ignored`.

## Test Plan

Added to `test/docs/LiveDocsNoPrivateGrqReference.ts`:

- `no live doc carries an org-qualified private GRQ reference (#3615)` — walks
  every `.md` under `docs/` except `docs/archive/`; the regression test for this
  issue (it failed against the unfixed docs and passes after the rewording).
- `findOrgQualifiedGrqReferences flags a repo slug and a gh search command` —
  happy path on both offending shapes.
- `findOrgQualifiedGrqReferences flags an issue slug and a repo link` — the
  `GRQ#NNNN` and `github.com/…` forms.
- `findOrgQualifiedGrqReferences ignores bare mnemonics and empty input` — edge
  cases; guards against false positives on `GRQ-22` / `grq-3397` and on empty
  input.

No existing test was removed or modified.

## Security self-check

- No new external input, injection surface, endpoint, or dependency — the change
  is Markdown prose plus a read-only test that reads files from the repo tree.
- No secrets or hidden files staged.



## Milestone
This PR is part of the **clean up 20260801** milestone and targets the `milestone/clean-up-20260801` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-msaeqw40-4af646`<!-- vibe-worker-issue-3615 -->