### PR TITLE
Docs: rename GRQ-cluster/GRQ-teams topology labels to concept level (#3616)

### DIFF
--- a/bench/ProductionScaleEvolveDirProfile.ts
+++ b/bench/ProductionScaleEvolveDirProfile.ts
@@ -1,7 +1,7 @@
 /**
  * Issue #2307 — Production-scale evolveDir phase-timing benchmark.
  *
- * Profiles the evolveDir evolution loop at GRQ-cluster dimensions
+ * Profiles the evolveDir evolution loop at production-scale dimensions
  * (~1,500 neurons, ~20,000 synapses, 648 inputs, 2 outputs) to identify
  * which phases dominate wall-clock time at production scale — contrasting
  * with the small-data profiling from #2274 that showed breeding at 50–60%.

--- a/bench/fixtures/generateProductionFixtures.ts
+++ b/bench/fixtures/generateProductionFixtures.ts
@@ -1,6 +1,6 @@
 /**
  * generateProductionFixtures.ts — Deterministically generate production-scale
- * creature and binary training data fixtures matching GRQ-cluster dimensions.
+ * creature and binary training data fixtures matching production-scale dimensions.
  *
  * Issue #2306 — Creates benchmark fixtures for realistic profiling so that
  * bottleneck analysis reflects production workloads rather than small-data
@@ -40,7 +40,7 @@ import {
   generateProductionCreature,
 } from "../../test/propagate/large/ProductionScaleCreature.ts";
 
-/** Default configuration matching GRQ-cluster production dimensions. */
+/** Default configuration matching production-scale dimensions. */
 export const PRODUCTION_DEFAULTS = {
   /** Seed for deterministic generation. */
   seed: 2306,

--- a/docs/PREDICTIVE_CODING_BENCHMARKS.md
+++ b/docs/PREDICTIVE_CODING_BENCHMARKS.md
@@ -308,8 +308,8 @@ The complex creature topology mirrors production-scale workloads:
 - **Connectivity**: Fully connected between adjacent layers plus skip
   connections
 
-A second topology tests a production-representative GRQ-cluster pattern with 50+
-neurons and forward-only connections.
+A second topology tests a production-representative large-network pattern with
+50+ neurons and forward-only connections.
 
 ### 📊 PC vs Standard Backprop on Complex Creatures
 
@@ -339,7 +339,7 @@ neurons and forward-only connections.
 4. **Forward-only and recurrent topologies**: Both topology styles converge
    under PC training, though forward-only networks settle more predictably.
 
-5. **Production-representative topologies**: The GRQ-cluster topology (50+
+5. **Production-representative topologies**: The production-scale topology (50+
    neurons) demonstrates that PC with adaptive scaling produces valid trace tags
    and measurable weight changes on realistic workloads.
 

--- a/docs/archive/pr-summaries/pr-summary-3616.md
+++ b/docs/archive/pr-summaries/pr-summary-3616.md
@@ -1,0 +1,98 @@
+# Rename GRQ-cluster / GRQ-teams topology labels to concept level (#3616)
+
+## Summary
+
+Production-scale benchmark and test naming used the names of the **private**
+`GRQ-cluster` and `GRQ-teams` repositories as topology labels. A public reader
+running the bench suite saw test names asserting parity with a repository they
+cannot open, so the claims were unverifiable and the labels were dead weight —
+the fixtures themselves are generated synthetically in-tree and never needed the
+private name.
+
+Every affected label is reworded to concept level. No behaviour changes: only
+comments, test titles and assertion messages. `Closes #3616`.
+
+| File                                                     | Change                                                                                                                    |
+| -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `bench/ProductionScaleEvolveDirProfile.ts` (4)           | "at GRQ-cluster dimensions" → "at production-scale dimensions"                                                            |
+| `bench/fixtures/generateProductionFixtures.ts` (3, 43)   | "matching GRQ-cluster dimensions" / "GRQ-cluster production dimensions" → "production-scale dimensions"                   |
+| `test/bench/ProductionScaleEvolveDirProfile.ts`          | test title → "Production-scale creature has the expected dimensions"; assertion messages → "match production scale"       |
+| `test/bench/fixtures/GenerateProductionFixtures.ts`      | four test titles → "Production-scale creature …"; "for GRQ-cluster scale" → "for production scale"                        |
+| `test/predictiveCoding/ComplexCreatureIntegration.ts`    | test title → "PC training improves on production-representative large topology"                                           |
+| `test/creature/EvolveRunStatistics_integration.ts` (7)   | "GRQ-cluster's `result.json`" → "the downstream run-result file"                                                          |
+| `scripts/verifyBatchScorerUtilisation3238.ts` (19)       | "GRQ worker serialises into GRQ-cluster/result.json" → "production worker serialises into the downstream run-result file" |
+| `test/breed/SyntheticLocationE2E.ts` (7)                 | "GRQ-teams Europa creature" → "a large production teams creature"                                                         |
+| `test/breed/fixtures/synthetic-alignment/README.md` (16) | same rewording for the father fixture provenance note                                                                     |
+| `docs/PREDICTIVE_CODING_BENCHMARKS.md` (311, 342)        | "GRQ-cluster pattern/topology" → "large-network pattern" / "production-scale topology"                                    |
+| `docs/event-driven-evolution.md` (639)                   | "GRQ-cluster feeds this into …" → "The downstream production consumer feeds this into …"                                  |
+
+The in-tree guard family is extended so the labels cannot come back.
+
+## Evidence
+
+Backend/library change with no web interface, so there is no screenshot to
+capture. The evidence is the new guard test, which was written first and
+reproduced the finding exactly — it failed listing the same eleven locations the
+issue names, and passes after the rewording:
+
+```text
+# before the rename
+bench/ProductionScaleEvolveDirProfile.ts:4
+bench/fixtures/generateProductionFixtures.ts:3,43
+docs/PREDICTIVE_CODING_BENCHMARKS.md:311,342
+docs/event-driven-evolution.md:639
+scripts/verifyBatchScorerUtilisation3238.ts:19
+test/bench/ProductionScaleEvolveDirProfile.ts:5,21,27,38,39
+test/bench/fixtures/GenerateProductionFixtures.ts:5,38,49,54,64,72,230
+test/breed/SyntheticLocationE2E.ts:7
+test/breed/fixtures/synthetic-alignment/README.md:16
+test/creature/EvolveRunStatistics_integration.ts:7
+test/predictiveCoding/ComplexCreatureIntegration.ts:551,554,555
+FAILED | 4 passed | 1 failed
+
+# after the rename
+ok | 5 passed | 0 failed
+```
+
+Full gate: `./quality.sh` → `ok | 8089 passed (5 steps) | 0 failed | 4 ignored`.
+
+```mermaid
+flowchart LR
+    A["Bench / test titles name<br/>private GRQ-cluster, GRQ-teams"] --> B["Reword to<br/>concept level"]
+    B --> C["Guard walks bench/, scripts/,<br/>test/, live docs/"]
+    C --> D["Regression blocked:<br/>label cannot return"]
+```
+
+### Case-sensitivity carve-out
+
+The guard matches the upper-case repo tokens only, so the in-tree lower-case
+`grq-cluster` scale-preset name in
+`test/propagate/large/ProductionScaleCreature.ts` stays legal — it identifies a
+synthetic fixture preset, not a private repository. This matches the `grq-3397`
+carve-out already recorded in `test/_privateRepoRefs.ts` (#3454 / #3604), and
+keeps the change naming-only with no API surface touched.
+
+## Test Plan
+
+New guard `test/docs/BenchAndTestNoPrivateGrqTopologyLabel.ts`:
+
+- `bench, test, script and live doc trees carry no private GRQ topology label (#3616)`
+  — walks `bench/`, `scripts/`, `test/` and live `docs/` (excluding
+  `docs/archive/` and the private-repo guards that must name the tokens they
+  detect) and fails on any `GRQ-cluster` / `GRQ-teams` label. This is the
+  regression test for the finding.
+- `findPrivateGrqTopologyLabels flags GRQ-cluster and GRQ-teams labels` — happy
+  path, returns the offending 1-indexed line numbers.
+- `findPrivateGrqTopologyLabels ignores the lower-case preset and bare mnemonics`
+  — the `grq-cluster` / `grq-3397` presets and a bare `GRQ` mnemonic are not
+  flagged.
+- `findPrivateGrqTopologyLabels returns empty for concept-level prose` and
+  `… for empty input` — edge cases.
+
+Renamed (not removed) test titles — all still run and pass unchanged:
+
+- `test/bench/ProductionScaleEvolveDirProfile.ts` — 1 title.
+- `test/bench/fixtures/GenerateProductionFixtures.ts` — 4 titles.
+- `test/predictiveCoding/ComplexCreatureIntegration.ts` — 1 title.
+
+No assertions, thresholds, or fixture values were altered; only the label text.

--- a/docs/event-driven-evolution.md
+++ b/docs/event-driven-evolution.md
@@ -636,8 +636,9 @@ const { statistics } = await creature.evolveDataSet(data, opts);
 ```
 
 - **`populationSize`** — the configured population size, recorded even when it
-  came from a default (it is the primary tuning variable). GRQ-cluster feeds
-  this into the `population` column of `performance.csv`.
+  came from a default (it is the primary tuning variable). The downstream
+  production consumer feeds this into the `population` column of
+  `performance.csv`.
 - **`adaptivePopulation`** / **`finalPopulationSize`** — whether adaptive
   population sizing was enabled, and the final actual population size. The final
   size is present **only** when adaptive sizing was on; otherwise the population

--- a/scripts/verifyBatchScorerUtilisation3238.ts
+++ b/scripts/verifyBatchScorerUtilisation3238.ts
@@ -16,7 +16,8 @@
  *      (one streamed pass per invocation; the streaming guarantee lives in
  *      NEAT-AI-scorer `multi_score.rs`, one `for_each_read_chunk` call).
  *   4. The `scorerUtilisation` block, written into a `result.json` artifact in
- *      the same shape the GRQ worker serialises into GRQ-cluster/result.json.
+ *      the same shape the production worker serialises into the downstream
+ *      run-result file.
  *
  * Any discrepancy (unexpected fallback, batch path not taken) is printed
  * loudly and reflected in the artifact rather than hidden (Issue #3234).

--- a/test/bench/ProductionScaleEvolveDirProfile.ts
+++ b/test/bench/ProductionScaleEvolveDirProfile.ts
@@ -2,7 +2,7 @@
  * Issue #2307 — Tests for production-scale creature generation.
  *
  * Validates that the `generateProductionCreature` helper produces a
- * creature with the expected GRQ-cluster dimensions. This test is
+ * creature with the expected production-scale dimensions. This test is
  * purely structural (no WASM activation, no evolution) and runs fast.
  *
  * Phase timing field tests (fitnessMs, breedingMs, etc.) are covered
@@ -18,13 +18,13 @@ import {
   generateProductionCreature,
 } from "../../test/propagate/large/ProductionScaleCreature.ts";
 
-Deno.test("Production-scale creature has GRQ-cluster dimensions", () => {
+Deno.test("Production-scale creature has the expected dimensions", () => {
   const rng = createSeededRng(2307);
   const creature = generateProductionCreature(648, 2, rng, {
     scale: "grq-cluster",
   });
 
-  // GRQ-cluster target: ~1,500 neurons, ~20,000 synapses
+  // Production-scale target: ~1,500 neurons, ~20,000 synapses
   assertGreater(
     creature.neurons.length,
     1_300,
@@ -35,8 +35,16 @@ Deno.test("Production-scale creature has GRQ-cluster dimensions", () => {
     15_000,
     "Should have at least 15,000 synapses for production scale",
   );
-  assertEquals(creature.input, 648, "Input count should match GRQ-cluster");
-  assertEquals(creature.output, 2, "Output count should match GRQ-cluster");
+  assertEquals(
+    creature.input,
+    648,
+    "Input count should match production scale",
+  );
+  assertEquals(
+    creature.output,
+    2,
+    "Output count should match production scale",
+  );
 });
 
 Deno.test("Production learn/sampler creature matches network.json dimensions (grq-3397)", () => {

--- a/test/bench/fixtures/GenerateProductionFixtures.ts
+++ b/test/bench/fixtures/GenerateProductionFixtures.ts
@@ -2,7 +2,7 @@
  * Tests for the production-scale profiling fixture generator (issue #2306).
  *
  * Validates that:
- * - The creature fixture matches GRQ-cluster dimensions (~1,500 neurons, ~20,000 synapses).
+ * - The creature fixture matches production-scale dimensions (~1,500 neurons, ~20,000 synapses).
  * - The training data generator produces the correct number of binary files
  *   with correct record sizes.
  * - Generation is deterministic (seeded PRNG produces identical output).
@@ -35,7 +35,7 @@ function testConfig(suffix: string): ProductionFixtureConfig {
   };
 }
 
-Deno.test("GRQ-cluster creature has ~1,500 neurons", () => {
+Deno.test("Production-scale creature has ~1,500 neurons", () => {
   const rng = createSeededRng(2306);
   const creature = generateProductionCreature(648, 2, rng, {
     scale: "grq-cluster",
@@ -46,12 +46,12 @@ Deno.test("GRQ-cluster creature has ~1,500 neurons", () => {
   const totalNeurons = hiddenNeurons.length + outputNeurons.length;
 
   // Production target: ~1,500 neurons (accept 1,400–1,600 range)
-  assertGreater(totalNeurons, 1_400, "too few neurons for GRQ-cluster scale");
+  assertGreater(totalNeurons, 1_400, "too few neurons for production scale");
   assert(totalNeurons < 1_700, `too many neurons: ${totalNeurons}`);
   assertEquals(outputNeurons.length, 2, "output neuron count mismatch");
 });
 
-Deno.test("GRQ-cluster creature has ~20,000 synapses", () => {
+Deno.test("Production-scale creature has ~20,000 synapses", () => {
   const rng = createSeededRng(2306);
   const creature = generateProductionCreature(648, 2, rng, {
     scale: "grq-cluster",
@@ -61,7 +61,7 @@ Deno.test("GRQ-cluster creature has ~20,000 synapses", () => {
   assertGreater(
     creature.synapses.length,
     18_000,
-    "too few synapses for GRQ-cluster scale",
+    "too few synapses for production scale",
   );
   assert(
     creature.synapses.length < 22_000,
@@ -69,7 +69,7 @@ Deno.test("GRQ-cluster creature has ~20,000 synapses", () => {
   );
 });
 
-Deno.test("GRQ-cluster creature generation is deterministic", () => {
+Deno.test("Production-scale creature generation is deterministic", () => {
   const rng1 = createSeededRng(2306);
   const creature1 = generateProductionCreature(648, 2, rng1, {
     scale: "grq-cluster",
@@ -227,7 +227,7 @@ Deno.test("generateAllFixtures produces complete result", () => {
   }
 });
 
-Deno.test("GRQ-cluster creature has diverse squash functions", () => {
+Deno.test("Production-scale creature has diverse squash functions", () => {
   const rng = createSeededRng(2306);
   const creature = generateProductionCreature(648, 2, rng, {
     scale: "grq-cluster",

--- a/test/breed/SyntheticLocationE2E.ts
+++ b/test/breed/SyntheticLocationE2E.ts
@@ -3,8 +3,8 @@
  * `createCompatibleFatherFromCreatures` by Issue #2614.
  *
  * Loads two production-shape, genetically incompatible parent fixtures
- * (mother modelled on the production cluster's `network.json` shape, father modelled on the
- * GRQ-teams Europa creature) and proves that:
+ * (mother modelled on the production cluster's `network.json` shape, father
+ * modelled on a large production teams creature) and proves that:
  *
  *  1. Real-UUID overlap is below the configured `syntheticAlignmentThreshold`.
  *  2. The synthetic-UUID alignment pass produces strictly more aligned

--- a/test/breed/fixtures/synthetic-alignment/README.md
+++ b/test/breed/fixtures/synthetic-alignment/README.md
@@ -13,8 +13,9 @@ reported in Issue #2609:
 - `parent-mother.json` — modelled on the production cluster's `network.json`
   shape (cascading layered topology, fan-in to a deep hidden neuron, a shortcut
   hidden neuron from `input-0` directly to `output-1`).
-- `parent-father.json` — modelled on the GRQ-teams Europa creature shape (same
-  overall layered topology, deliberately disjoint hidden-neuron real UUIDs).
+- `parent-father.json` — modelled on a large production teams creature shape
+  (same overall layered topology, deliberately disjoint hidden-neuron real
+  UUIDs).
 
 Both creatures expose the same alignment problem the production crossover hit on
 the GitHub fleet: real-UUID overlap of `0.0` (well below the

--- a/test/creature/EvolveRunStatistics_integration.ts
+++ b/test/creature/EvolveRunStatistics_integration.ts
@@ -4,8 +4,8 @@
  *
  * A real `evolveDataSet` run on XOR must self-report the configured population
  * size, the host hardware, an echo of the caller-requested options, and a
- * score-improvement milestone summary — enough for GRQ-cluster's `result.json`
- * to be compared across machines without an external inventory.
+ * score-improvement milestone summary — enough for the downstream run-result
+ * file to be compared across machines without an external inventory.
  */
 
 import { assert, assertEquals } from "@std/assert";

--- a/test/docs/BenchAndTestNoPrivateGrqTopologyLabel.ts
+++ b/test/docs/BenchAndTestNoPrivateGrqTopologyLabel.ts
@@ -1,0 +1,123 @@
+/**
+ * Issue #3616 — bench titles, test titles, scripts and live docs must not use
+ * the names of the private `stSoftwareAU` repositories `GRQ-cluster` and
+ * `GRQ-teams` as topology labels.
+ *
+ * A public repository is fully self-contained for the public. A test named
+ * "GRQ-cluster creature has ~1,500 neurons" asserts parity with a repository a
+ * public reader cannot open, so the claim is unverifiable and the label is dead
+ * weight — the fixtures it exercises are generated synthetically in-tree and
+ * need no private name. This guard walks the real bench, test, script and live
+ * doc trees and fails if any reintroduces one of those topology labels.
+ *
+ * Matching is case-sensitive on the upper-case repo tokens, so the in-tree
+ * lower-case `grq-cluster` scale-preset name stays legal — it identifies a
+ * synthetic fixture preset, not a private repository, matching the `grq-3397`
+ * carve-out recorded in `test/_privateRepoRefs.ts`.
+ */
+
+import { assertEquals } from "@std/assert";
+import { fromFileUrl } from "@std/path";
+import { walk } from "@std/fs";
+
+/**
+ * The private repository names that must not be used as topology labels.
+ * Upper-case only — see the module note on the lower-case preset carve-out.
+ */
+const PRIVATE_TOPOLOGY_LABEL_PATTERN = /GRQ-cluster|GRQ-teams/;
+
+/**
+ * Return every line using a private `GRQ-cluster` / `GRQ-teams` repository name
+ * as a topology label.
+ *
+ * @param source raw file content (TypeScript, Markdown or shell)
+ * @returns 1-indexed line numbers carrying a private topology label
+ */
+export function findPrivateGrqTopologyLabels(source: string): number[] {
+  const hits: number[] = [];
+  const lines = source.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    if (PRIVATE_TOPOLOGY_LABEL_PATTERN.test(lines[i])) {
+      hits.push(i + 1);
+    }
+  }
+  return hits;
+}
+
+const ROOT = fromFileUrl(new URL("../..", import.meta.url));
+
+/** Trees walked by the guard, relative to the repository root. */
+const SCANNED_DIRS = ["bench", "scripts", "test", "docs"];
+
+/**
+ * Repo-relative paths exempt from the guard.
+ *
+ * `docs/archive/` is a historical record that is never rewritten, and the
+ * private-repo guards below must name the tokens they detect.
+ */
+const EXEMPT = new Set([
+  "test/_privateRepoRefs.ts",
+  "test/docs/BenchAndTestNoPrivateGrqTopologyLabel.ts",
+  "test/docs/CrossSpeciesBaselineNoPrivateRepo.ts",
+  "test/docs/LiveDocsNoPrivateGrqReference.ts",
+  "test/docs/PrivateRepoRefScanner.ts",
+  "test/scripts/AuditOptionUsageNoPrivateConsumer.ts",
+]);
+
+Deno.test("bench, test, script and live doc trees carry no private GRQ topology label (#3616)", async () => {
+  const offenders: string[] = [];
+  for (const dir of SCANNED_DIRS) {
+    for await (
+      const entry of walk(`${ROOT}${dir}`, {
+        exts: [".ts", ".md", ".sh"],
+        includeDirs: false,
+      })
+    ) {
+      const rel = entry.path.slice(ROOT.length);
+      if (rel.startsWith("docs/archive/") || EXEMPT.has(rel)) continue;
+      const hits = findPrivateGrqTopologyLabels(
+        await Deno.readTextFile(entry.path),
+      );
+      if (hits.length > 0) offenders.push(`${rel}:${hits.join(",")}`);
+    }
+  }
+  assertEquals(
+    offenders.sort(),
+    [],
+    `Private GRQ-cluster / GRQ-teams repository names are used as topology ` +
+      `labels:\n${offenders.join("\n")}\n` +
+      `Reword to concept level (e.g. "production-scale creature", "a large ` +
+      `production teams creature") so the label stays meaningful to public ` +
+      `readers.`,
+  );
+});
+
+Deno.test("findPrivateGrqTopologyLabels flags GRQ-cluster and GRQ-teams labels", () => {
+  const src = [
+    'Deno.test("GRQ-cluster creature has ~1,500 neurons", () => {',
+    "  // unrelated line",
+    " * modelled on the GRQ-teams Europa creature shape",
+  ].join("\n");
+  assertEquals(findPrivateGrqTopologyLabels(src), [1, 3]);
+});
+
+Deno.test("findPrivateGrqTopologyLabels ignores the lower-case preset and bare mnemonics", () => {
+  const src = [
+    '  const creature = generateProductionCreature(648, 2, rng, { scale: "grq-cluster" });',
+    ' * `"grq-3397"`: 1,666 neurons at 2,461 inputs.',
+    " * ~1,500 neurons, ~20,000 synapses (GRQ production scale)",
+  ].join("\n");
+  assertEquals(findPrivateGrqTopologyLabels(src), []);
+});
+
+Deno.test("findPrivateGrqTopologyLabels returns empty for concept-level prose", () => {
+  const src = [
+    'Deno.test("Production-scale creature has ~1,500 neurons", () => {',
+    "The downstream run-result file records the scorer utilisation block.",
+  ].join("\n");
+  assertEquals(findPrivateGrqTopologyLabels(src), []);
+});
+
+Deno.test("findPrivateGrqTopologyLabels returns empty for empty input", () => {
+  assertEquals(findPrivateGrqTopologyLabels(""), []);
+});

--- a/test/predictiveCoding/ComplexCreatureIntegration.ts
+++ b/test/predictiveCoding/ComplexCreatureIntegration.ts
@@ -548,11 +548,11 @@ Deno.test("PC training works on forward-only complex creature with mixed activat
 });
 
 // ---------------------------------------------------------------------------
-// Test: Production-representative topology (GRQ-cluster-scale creature)
+// Test: Production-representative topology (production-scale creature)
 // ---------------------------------------------------------------------------
 
-Deno.test("PC training improves on production-representative GRQ-cluster topology", () => {
-  // Build a creature representative of the production GRQ-cluster network.
+Deno.test("PC training improves on production-representative large topology", () => {
+  // Build a creature representative of a large production network.
   // Production creature has ~90+ neurons. We create a scaled version
   // with 50+ hidden neurons across 5 layers with diverse connectivity.
   const squashOptions = [


### PR DESCRIPTION
# Rename GRQ-cluster / GRQ-teams topology labels to concept level (#3616)

## Summary

Production-scale benchmark and test naming used the names of the **private**
`GRQ-cluster` and `GRQ-teams` repositories as topology labels. A public reader
running the bench suite saw test names asserting parity with a repository they
cannot open, so the claims were unverifiable and the labels were dead weight —
the fixtures themselves are generated synthetically in-tree and never needed the
private name.

Every affected label is reworded to concept level. No behaviour changes: only
comments, test titles and assertion messages. `Closes #3616`.

| File                                                     | Change                                                                                                                    |
| -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
| `bench/ProductionScaleEvolveDirProfile.ts` (4)           | "at GRQ-cluster dimensions" → "at production-scale dimensions"                                                            |
| `bench/fixtures/generateProductionFixtures.ts` (3, 43)   | "matching GRQ-cluster dimensions" / "GRQ-cluster production dimensions" → "production-scale dimensions"                   |
| `test/bench/ProductionScaleEvolveDirProfile.ts`          | test title → "Production-scale creature has the expected dimensions"; assertion messages → "match production scale"       |
| `test/bench/fixtures/GenerateProductionFixtures.ts`      | four test titles → "Production-scale creature …"; "for GRQ-cluster scale" → "for production scale"                        |
| `test/predictiveCoding/ComplexCreatureIntegration.ts`    | test title → "PC training improves on production-representative large topology"                                           |
| `test/creature/EvolveRunStatistics_integration.ts` (7)   | "GRQ-cluster's `result.json`" → "the downstream run-result file"                                                          |
| `scripts/verifyBatchScorerUtilisation3238.ts` (19)       | "GRQ worker serialises into GRQ-cluster/result.json" → "production worker serialises into the downstream run-result file" |
| `test/breed/SyntheticLocationE2E.ts` (7)                 | "GRQ-teams Europa creature" → "a large production teams creature"                                                         |
| `test/breed/fixtures/synthetic-alignment/README.md` (16) | same rewording for the father fixture provenance note                                                                     |
| `docs/PREDICTIVE_CODING_BENCHMARKS.md` (311, 342)        | "GRQ-cluster pattern/topology" → "large-network pattern" / "production-scale topology"                                    |
| `docs/event-driven-evolution.md` (639)                   | "GRQ-cluster feeds this into …" → "The downstream production consumer feeds this into …"                                  |

The in-tree guard family is extended so the labels cannot come back.

## Evidence

Backend/library change with no web interface, so there is no screenshot to
capture. The evidence is the new guard test, which was written first and
reproduced the finding exactly — it failed listing the same eleven locations the
issue names, and passes after the rewording:

```text
# before the rename
bench/ProductionScaleEvolveDirProfile.ts:4
bench/fixtures/generateProductionFixtures.ts:3,43
docs/PREDICTIVE_CODING_BENCHMARKS.md:311,342
docs/event-driven-evolution.md:639
scripts/verifyBatchScorerUtilisation3238.ts:19
test/bench/ProductionScaleEvolveDirProfile.ts:5,21,27,38,39
test/bench/fixtures/GenerateProductionFixtures.ts:5,38,49,54,64,72,230
test/breed/SyntheticLocationE2E.ts:7
test/breed/fixtures/synthetic-alignment/README.md:16
test/creature/EvolveRunStatistics_integration.ts:7
test/predictiveCoding/ComplexCreatureIntegration.ts:551,554,555
FAILED | 4 passed | 1 failed

# after the rename
ok | 5 passed | 0 failed
```

Full gate: `./quality.sh` → `ok | 8089 passed (5 steps) | 0 failed | 4 ignored`.

```mermaid
flowchart LR
    A["Bench / test titles name<br/>private GRQ-cluster, GRQ-teams"] --> B["Reword to<br/>concept level"]
    B --> C["Guard walks bench/, scripts/,<br/>test/, live docs/"]
    C --> D["Regression blocked:<br/>label cannot return"]
```

### Case-sensitivity carve-out

The guard matches the upper-case repo tokens only, so the in-tree lower-case
`grq-cluster` scale-preset name in
`test/propagate/large/ProductionScaleCreature.ts` stays legal — it identifies a
synthetic fixture preset, not a private repository. This matches the `grq-3397`
carve-out already recorded in `test/_privateRepoRefs.ts` (#3454 / #3604), and
keeps the change naming-only with no API surface touched.

## Test Plan

New guard `test/docs/BenchAndTestNoPrivateGrqTopologyLabel.ts`:

- `bench, test, script and live doc trees carry no private GRQ topology label (#3616)`
  — walks `bench/`, `scripts/`, `test/` and live `docs/` (excluding
  `docs/archive/` and the private-repo guards that must name the tokens they
  detect) and fails on any `GRQ-cluster` / `GRQ-teams` label. This is the
  regression test for the finding.
- `findPrivateGrqTopologyLabels flags GRQ-cluster and GRQ-teams labels` — happy
  path, returns the offending 1-indexed line numbers.
- `findPrivateGrqTopologyLabels ignores the lower-case preset and bare mnemonics`
  — the `grq-cluster` / `grq-3397` presets and a bare `GRQ` mnemonic are not
  flagged.
- `findPrivateGrqTopologyLabels returns empty for concept-level prose` and
  `… for empty input` — edge cases.

Renamed (not removed) test titles — all still run and pass unchanged:

- `test/bench/ProductionScaleEvolveDirProfile.ts` — 1 title.
- `test/bench/fixtures/GenerateProductionFixtures.ts` — 4 titles.
- `test/predictiveCoding/ComplexCreatureIntegration.ts` — 1 title.

No assertions, thresholds, or fixture values were altered; only the label text.



## Milestone
This PR is part of the **clean up 20260801** milestone and targets the `milestone/clean-up-20260801` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-msai8fsp-bae48a`<!-- vibe-worker-issue-3616 -->