### PR TITLE
Docs: reword bare private-repo slugs in archived PR summaries and close guard gap (#3617)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-3234.md
+++ b/docs/archive/pr-summaries/pr-summary-3234.md
@@ -7,8 +7,8 @@ on the `evolve*/train` result. Previously `Fitness.calculate()` tracked a single
 the batch path breaks and every creature quietly falls back to the slow worker
 path — looked identical to a healthy run. This change splits that count by
 backend and adds an explicit batch-fallback tally so the split is visible in the
-run result (and therefore in the GRQ-cluster `result.json`). Telemetry only — no
-change to scoring numbers or the batch/worker partition.
+run result (and therefore in the downstream run-result file). Telemetry only —
+no change to scoring numbers or the batch/worker partition.
 
 **Closes #3234.**
 

--- a/docs/archive/pr-summaries/pr-summary-3237.md
+++ b/docs/archive/pr-summaries/pr-summary-3237.md
@@ -8,7 +8,7 @@ scored via the Rust **batch** path — one `rust_scorer` invocation per generati
 silently swallowed. Both tests drive `Fitness.calculate()` across several
 generations and accumulate each generation's per-backend counts into the
 run-level `ScorerUtilisationTotals` (the same telemetry surfaced on the
-`evolve*` result and in the GRQ-cluster `result.json`), then assert on the
+`evolve*` result and in the downstream run-result file), then assert on the
 aggregate. Closes #3237.
 
 The per-backend instrumentation this issue depends on

--- a/docs/archive/pr-summaries/pr-summary-3397.md
+++ b/docs/archive/pr-summaries/pr-summary-3397.md
@@ -7,7 +7,7 @@ path — the deliverable that the other #3396 sub-issues derive their priorities
 from. Closes #3397.
 
 The report (`docs/PROFILING_REPORT_3397.md`) profiles exactly what
-`worker/learn.sh` and `worker/sampler.sh` drive, on the GRQ-cluster production
+`worker/learn.sh` and `worker/sampler.sh` drive, on the production-scale
 topology (**1,666 neurons, ~21,513 synapses, 2,461 inputs**), with a
 reproducible `bench/` command, and:
 

--- a/docs/archive/pr-summaries/pr-summary-3422.md
+++ b/docs/archive/pr-summaries/pr-summary-3422.md
@@ -3,7 +3,7 @@
 ## Summary
 
 Every `evolve*` result (`evolveDir`, `evolveDataSet`, `evolveEnv`, `evolveRL`)
-now carries a run-level `statistics` block so GRQ-cluster's `result.json` is
+now carries a run-level `statistics` block so the downstream run-result file is
 self-contained enough to compare configurations across the ~20-machine
 production fleet and judge which gives the best **rate** of score improvement.
 Final score alone is insufficient because runs plateau — the same final number

--- a/docs/archive/pr-summaries/pr-summary-3427.md
+++ b/docs/archive/pr-summaries/pr-summary-3427.md
@@ -4,7 +4,7 @@ The `requestedOptions` echo added by #3422 (`serialiseOptionsEcho` in
 `src/creature/EvolveOptionsEcho.ts`) recorded every caller-supplied option,
 replacing values that cannot round-trip through JSON with a `"[function]"` /
 `"[unserialisable]"` marker. Those marker entries — notably `creatures` (the
-seed-creature array), which landed as `"[unserialisable]"` in every GRQ-cluster
+seed-creature array), which landed as `"[unserialisable]"` in every production
 snapshot — are pure noise with no tuning value.
 
 This change drops **every** marker-valued entry from the echo: any option whose
@@ -16,9 +16,10 @@ seed array echoes as `0`; when the caller supplies no `creatures` option at all,
 nothing is echoed. Serialisable options (e.g. `creatureStore`) are unaffected.
 
 The now-unused `OPTION_FUNCTION_MARKER` / `OPTION_UNSERIALISABLE_MARKER` exports
-are removed. Historic snapshot files already committed in GRQ-cluster are not
-rewritten; the new field shape applies to future runs once GRQ picks up a
-NEAT-AI release containing this fix (release is human-gated, out of scope here).
+are removed. Historic snapshot files already committed in the downstream
+run-result store are not rewritten; the new field shape applies to future runs
+once GRQ picks up a NEAT-AI release containing this fix (release is human-gated,
+out of scope here).
 
 Closes #3427.
 

--- a/docs/archive/pr-summaries/pr-summary-3519.md
+++ b/docs/archive/pr-summaries/pr-summary-3519.md
@@ -3,9 +3,9 @@
 ## Summary
 
 Classified all **46** non-`discovery*` top-level scalar and flag options
-declared in `src/config/NeatArguments.ts` against real consumer usage in
-`stSoftwareAU/GRQ` and `stSoftwareAU/NEAT-AI-Examples`, and filed a removal
-issue for every qualifying key. Closes #3519.
+declared in `src/config/NeatArguments.ts` against real consumer usage in the
+downstream production consumer and `stSoftwareAU/NEAT-AI-Examples`, and filed a
+removal issue for every qualifying key. Closes #3519.
 
 | Verdict                       | Count |
 | ----------------------------- | ----: |

--- a/docs/archive/pr-summaries/pr-summary-3520.md
+++ b/docs/archive/pr-summaries/pr-summary-3520.md
@@ -4,9 +4,9 @@
 
 Classified all **33 `discovery*` / discovery-adjacent top-level options** in
 `src/config/NeatArguments.ts` plus the **3 discovery-scoped nested configs** (36
-keys total, none skipped) against real consumer usage in `stSoftwareAU/GRQ`,
-`stSoftwareAU/NEAT-AI-Examples`, and — as this slice specifically requires — the
-Rust crate `stSoftwareAU/NEAT-AI-Discovery`.
+keys total, none skipped) against real consumer usage in the downstream
+production consumer, `stSoftwareAU/NEAT-AI-Examples`, and — as this slice
+specifically requires — the Rust crate `stSoftwareAU/NEAT-AI-Discovery`.
 
 **Result: 19 `IN USE`, 16 `KEEP (load-bearing default)`, 1 `QUALIFIES`.**
 

--- a/docs/archive/pr-summaries/pr-summary-3521.md
+++ b/docs/archive/pr-summaries/pr-summary-3521.md
@@ -5,7 +5,7 @@
 Slice C of the #3505 option-removal audit. Classifies the **10 nested config
 objects governing population and selection dynamics** — both the top-level
 `NeatOptions` key and every field inside each interface, **59 classifications**
-in total — against real consumer usage in `stSoftwareAU/GRQ` and
+in total — against real consumer usage in the downstream production consumer and
 `stSoftwareAU/NEAT-AI-Examples`. Closes #3521.
 
 | Verdict                       | Parent keys | Fields | Total |

--- a/docs/archive/pr-summaries/pr-summary-3522.md
+++ b/docs/archive/pr-summaries/pr-summary-3522.md
@@ -5,8 +5,8 @@
 Slice D of the #3505 option-removal audit. Classifies the **12 nested config
 objects governing training, regularisation and data shaping** — the top-level
 `NeatOptions` key _and_ every field inside each interface — against consumer
-usage in `stSoftwareAU/GRQ` and `stSoftwareAU/NEAT-AI-Examples`. **69
-classifications, none skipped.** Closes #3522.
+usage in the downstream production consumer and `stSoftwareAU/NEAT-AI-Examples`.
+**69 classifications, none skipped.** Closes #3522.
 
 | Verdict                       | Parent keys | Fields |  Total |
 | ----------------------------- | ----------: | -----: | -----: |
@@ -41,10 +41,10 @@ keys: `predictiveCoding` (a `worker/sampler.sh` variant emitting
 
 **The code-search index can produce a false _used_, not just a false _unused_.**
 `OPTION_USAGE_AUDIT.md` documents `--owner` saturation hiding a set key. Slice D
-hit the mirror image: `gh search code squashBudget --repo stSoftwareAU/GRQ`
-returns 2 hits that `git grep -F` does not, because GitHub splits camelCase and
-matched GRQ's own **ImproveSquash** wall-clock **budget**. Resting on the index
-alone would have recorded `squashBudget` as `IN USE`.
+hit the mirror image: `gh search code squashBudget` scoped to the downstream
+production consumer returns 2 hits that `git grep -F` does not, because GitHub
+splits camelCase and matched GRQ's own **ImproveSquash** wall-clock **budget**.
+Resting on the index alone would have recorded `squashBudget` as `IN USE`.
 
 **The `squashBudget` `CoerceNumeric` asymmetry the brief flagged is intentional,
 not a bug.** `CoerceNumeric<T>` returns arrays unchanged, and
@@ -83,7 +83,7 @@ KEY=dnaSharingMode REPO=NEAT-AI-Examples RC=1 HITS=0
 The #3518 harness ran its own copy of both controls in this session and reported
 `✅ controls passed` before being stopped, and independently rediscovered the
 consumer set via its org backstop:
-`🔎 consumers declaring @stsoftware/neat-ai: stSoftwareAU/GRQ, stSoftwareAU/NEAT-AI-Examples`.
+`🔎 consumers declaring @stsoftware/neat-ai: <downstream production consumer>, stSoftwareAU/NEAT-AI-Examples`.
 
 **Per-key sweep** — fresh clones, GRQ `origin/Develop` at `bc622f5`, 30 Jul
 2026. `rc 0` hit, `rc 1` miss, `rc > 1` would have been reported as

--- a/docs/archive/pr-summaries/pr-summary-3523.md
+++ b/docs/archive/pr-summaries/pr-summary-3523.md
@@ -7,7 +7,8 @@ infrastructure nested configs (`memory`, `wasmCache`, `workerThreadCap`,
 `parallelEvaluation`), the internal `RustScorerConfig`, and the six injection
 points (`logger`, `rng`, `onTrainingEvent`, `creatureStore`, `experimentStore`,
 `traceStore`) — the top-level key and every field — against consumer usage in
-`stSoftwareAU/GRQ` and `stSoftwareAU/NEAT-AI-Examples`. **Closes #3523.**
+the downstream production consumer and `stSoftwareAU/NEAT-AI-Examples`. **Closes
+#3523.**
 
 **33 classifications: 15 `IN USE`, 15 `KEEP (load-bearing default)`, 3
 `QUALIFIES`.** Follow-ups #3565 (decision) and #3566 (removal) filed;

--- a/docs/archive/pr-summaries/pr-summary-3524.md
+++ b/docs/archive/pr-summaries/pr-summary-3524.md
@@ -4,7 +4,7 @@
 
 Classifies the four experimental / research nested configs — `mcmc`,
 `hyperparameterEvolution`, `opd` and `specialist` — plus every field inside
-each, against consumer usage in `stSoftwareAU/GRQ` and
+each, against consumer usage in the downstream production consumer and
 `stSoftwareAU/NEAT-AI-Examples`. **43 classifications, none skipped: 0 `IN USE`,
 0 `KEEP (load-bearing default)`, 43 `QUALIFIES`.** Closes #3524.
 

--- a/docs/archive/pr-summaries/pr-summary-3554.md
+++ b/docs/archive/pr-summaries/pr-summary-3554.md
@@ -8,8 +8,8 @@ the `KnobTuningStrategy` primitive that was its only writer. Closes #3554.
 The evidence for "inert" held up on re-verification:
 
 - **Nobody sets it.** `git grep -F dnaSharingMode` returns 0 files in
-  `stSoftwareAU/NEAT-AI-Examples`, and `gh search code` returns 0 hits in
-  `stSoftwareAU/GRQ` and `stSoftwareAU/NEAT-AI-Examples`.
+  `stSoftwareAU/NEAT-AI-Examples`, and `gh search code` returns 0 hits in the
+  downstream production consumer and `stSoftwareAU/NEAT-AI-Examples`.
 - **The default was inert by construction.** `DEFAULT_DNA_SHARING_PRESET` was
   defined to equal the per-knob defaults `createNeatConfig()` already applied,
   so with nobody setting the option the preset resolved to the values that

--- a/docs/archive/pr-summaries/pr-summary-3558.md
+++ b/docs/archive/pr-summaries/pr-summary-3558.md
@@ -12,9 +12,10 @@ no-op. Worse, two shipped surfaces advertised behaviour that never happened:
 working feature — including a troubleshooting step users would follow to fix a
 diversity problem.
 
-Neither confirmed consumer (`stSoftwareAU/GRQ`, `stSoftwareAU/NEAT-AI-Examples`)
-sets the key or uses `LARGE_NETWORK_PRESET`, so nothing downstream changes.
-Behaviour cannot regress here because no behaviour was ever attached.
+Neither confirmed consumer (the downstream production consumer,
+`stSoftwareAU/NEAT-AI-Examples`) sets the key or uses `LARGE_NETWORK_PRESET`, so
+nothing downstream changes. Behaviour cannot regress here because no behaviour
+was ever attached.
 
 Closes #3558.
 

--- a/docs/archive/pr-summaries/pr-summary-3617.md
+++ b/docs/archive/pr-summaries/pr-summary-3617.md
@@ -1,0 +1,95 @@
+# Reword bare private-repo slugs in archived PR summaries and close the guard gap (#3617)
+
+## Summary
+
+Fourteen archived PR summaries still pointed public readers at the private
+downstream production repositories, in two forms the archive guard did not
+match: the bare org-qualified consumer slug, and an un-prefixed private repo
+name used as a topology / run-result label. Both were reworded to concept level,
+and the shared detector was widened so the archive cannot drift back. **Closes
+#3617.**
+
+Two changes:
+
+1. **Detector widened** (`test/_privateRepoRefs.ts`). `PRIVATE_REPO_PATTERN` now
+   also flags any org-qualified private slug —
+   `stSoftwareAU\/(?:GRQ|VibeCoding)` followed by a word boundary, which
+   subsumes the old `github.com/…` alternative — and un-prefixed repo names
+   `GRQ-(?:cluster|logs|teams)` between word boundaries. The bare `GRQ` token,
+   host/log/preset mnemonics (`GRQ-21`, `GRQ-3-rocket.log`, `GRQ-side`) and the
+   lower-case `grq-3397` fixture stay clean, per the #3454 mnemonic decision;
+   the bare token is policed separately by the live-doc and `src`/`test` guards.
+2. **Fourteen archived summaries reworded** to the wording precedent set by
+   #3455/#3616 — "the downstream production consumer", "the downstream
+   run-result file/store", "the production-scale topology", "every production
+   snapshot".
+
+| File                                        | Reworded                                                                 |
+| ------------------------------------------- | ------------------------------------------------------------------------ |
+| `pr-summary-3519.md` (7)                    | consumer slug → "the downstream production consumer"                     |
+| `pr-summary-3520.md` (7)                    | consumer slug → "the downstream production consumer"                     |
+| `pr-summary-3521.md` (8)                    | consumer slug → "the downstream production consumer"                     |
+| `pr-summary-3522.md` (8, 44, 86)            | consumer slug, `gh search code --repo` pointer, and the tool-output line |
+| `pr-summary-3523.md` (10)                   | consumer slug → "the downstream production consumer"                     |
+| `pr-summary-3524.md` (7)                    | consumer slug → "the downstream production consumer"                     |
+| `pr-summary-3554.md` (12)                   | consumer slug → "the downstream production consumer"                     |
+| `pr-summary-3558.md` (15)                   | consumer slug → "the downstream production consumer"                     |
+| `pr-summary-worker-start-heartbeat.md` (13) | consumer slug → "A downstream production `team` run"                     |
+| `pr-summary-3234.md` (10)                   | private `result.json` label → "the downstream run-result file"           |
+| `pr-summary-3237.md` (11)                   | private `result.json` label → "the downstream run-result file"           |
+| `pr-summary-3397.md` (10)                   | private topology label → "the production-scale topology"                 |
+| `pr-summary-3422.md` (6)                    | private `result.json` label → "the downstream run-result file"           |
+| `pr-summary-3427.md` (7, 19)                | "every production snapshot" / "the downstream run-result store"          |
+
+The clean-up series that documents this class of removal (#3451–#3462,
+#3613–#3616) must quote the patterns it removed, so those summaries joined the
+guard's existing audit-narrative allowlist rather than being reworded. This
+summary is deliberately **not** allowlisted — it describes the rewordings at
+concept level and quotes only regex source, so the widened guard scans it like
+any other archived doc.
+
+## Evidence
+
+Backend/test-only change; no web interface to screenshot. Regression evidence is
+the widened detector run against the pre-fix files (`git show HEAD:<file>`),
+which reproduces exactly the fourteen offenders the issue lists and is clean
+after the reword:
+
+```text
+pr-summary-3234.md:10   pr-summary-3237.md:11   pr-summary-3397.md:10
+pr-summary-3422.md:6    pr-summary-3427.md:7,19 pr-summary-3519.md:7
+pr-summary-3520.md:7    pr-summary-3521.md:8    pr-summary-3522.md:8,44,86
+pr-summary-3523.md:10   pr-summary-3524.md:7    pr-summary-3554.md:12
+pr-summary-3558.md:15   pr-summary-worker-start-heartbeat.md:13
+```
+
+```mermaid
+flowchart LR
+    A["Archived summary names a<br/>private repo (bare slug or<br/>un-prefixed repo name)"] --> B{"widened<br/>PRIVATE_REPO_PATTERN"}
+    B -- "audit narrative<br/>(#3451–#3462, #3613–#3616)" --> C["allowlisted —<br/>must quote what it removed"]
+    B -- "match" --> D["guard fails with file:line"]
+    B -- "mnemonic / bare token /<br/>concept-level prose" --> E["passes"]
+    D --> F["reword to concept level"] --> E
+```
+
+## Test Plan
+
+- `findPrivateRepoRefs flags a bare org-qualified downstream consumer slug
+  (#3617)`
+  — new unit case; the two fixture lines previously asserted **clean** and now
+  assert flagged. This is a deliberate contract change (documented in the file
+  header), not a relaxed test.
+- `findPrivateRepoRefs flags an un-prefixed private repo name (#3617)` — new
+  unit case covering the `-cluster`, `-teams` and `-logs` forms plus a clean
+  interleaved line.
+- `findPrivateRepoRefs ignores the bare GRQ token on its own (#3604)` — new
+  clean case pinning the carve-out the widened pattern must not swallow.
+- `findPrivateRepoRefs ignores bare host/log/preset mnemonics (#3604)` —
+  unchanged, still passes.
+- `no private stSoftwareAU repo slugs or links in docs/archive (#3455)` — the
+  existing tree-walking guard, now failing against the unfixed archive and
+  passing after the reword.
+- `bump-deps.sh` / `AGENTS.md` / `BumpDepsScript.ts`
+  `has no private repo
+  reference (#3458)` — the sibling consumers of the
+  shared detector, unchanged and still clean under the widened pattern.

--- a/docs/archive/pr-summaries/pr-summary-worker-start-heartbeat.md
+++ b/docs/archive/pr-summaries/pr-summary-worker-start-heartbeat.md
@@ -10,7 +10,7 @@ Child WASM phase timings unknown — the worker never answered the init handshak
 (may be stuck loading WASM, CPU-starved, or OOM).
 ```
 
-A `stSoftwareAU/GRQ` `team` run lost five worker slots to that 60-second
+A downstream production `team` run lost five worker slots to that 60-second
 handshake with `cache=hit`, `bundleLoadMs=2`, `instantiateMs=1`,
 `wasmTotalMs=20` and `workerError=none` — the parent loaded and instantiated the
 bundle in 20 ms, so "stuck loading WASM" was already ruled out, yet nothing in

--- a/test/_privateRepoRefs.ts
+++ b/test/_privateRepoRefs.ts
@@ -18,23 +18,26 @@
  *
  * - a private issue-tracker slug (`GRQ#3472`, `VibeCoding#1613`, and their
  *   org-qualified forms);
- * - an org-qualified private repo path (`stSoftwareAU/GRQ-cluster`,
- *   `stSoftwareAU/VibeCoding`);
- * - a link into a private repository
- *   (`github.com/stSoftwareAU/GRQ-cluster/blob/...`).
+ * - any org-qualified private repo path, including the bare downstream
+ *   consumer (`stSoftwareAU/GRQ`, `stSoftwareAU/GRQ-cluster`,
+ *   `stSoftwareAU/VibeCoding`) — this also covers links into a private
+ *   repository (`github.com/stSoftwareAU/GRQ-cluster/blob/...`);
+ * - an un-prefixed private repo name (`GRQ-cluster`, `GRQ-logs`, `GRQ-teams`),
+ *   which names the repository just as unambiguously as the org-qualified
+ *   form (Issue #3617).
  *
  * Deliberately **not** matched — these name a concept rather than pointing at
  * an unreachable page, consistent with the #3454 mnemonic decision:
  *
  * - the public `stSoftwareAU/NEAT-AI` repository;
- * - a bare `stSoftwareAU/GRQ` / `stSoftwareAU/GRQ-logs` repo name used to
- *   identify the downstream consumer or its log store (no `#` slug, no link);
- * - bare host/log/preset mnemonics (`GRQ-21`, `GRQ-3-rocket.log`) and the
- *   lower-case in-tree `grq-3397` scale-preset fixture — matching is
+ * - the bare `GRQ` token on its own ("the GRQ corpus"), which the live-doc and
+ *   `src`/`test` guards police separately;
+ * - bare host/log/preset mnemonics (`GRQ-21`, `GRQ-3-rocket.log`, `GRQ-side`)
+ *   and the lower-case in-tree `grq-3397` scale-preset fixture — matching is
  *   case-sensitive on the upper-case repo tokens.
  */
 export const PRIVATE_REPO_PATTERN =
-  /(?:GRQ|VibeCoding)#\d+|stSoftwareAU\/(?:GRQ-cluster|VibeCoding)|github\.com\/stSoftwareAU\/(?:GRQ|VibeCoding)/;
+  /(?:GRQ|VibeCoding)#\d+|stSoftwareAU\/(?:GRQ|VibeCoding)\b|\bGRQ-(?:cluster|logs|teams)\b/;
 
 /**
  * Return every 1-indexed line number carrying a private-repo issue slug,

--- a/test/docs/ArchiveDocsNoPrivateRepoSlugs.ts
+++ b/test/docs/ArchiveDocsNoPrivateRepoSlugs.ts
@@ -30,11 +30,25 @@ const ARCHIVE_DIR = fromFileUrl(new URL("../../docs/archive", import.meta.url));
  * was removed, so scanning them would be a self-referential false positive —
  * they are the audit, not offenders. Any new summary that necessarily cites the
  * private-repo patterns it removes belongs here.
+ *
+ * Issue #3617 widened the detector to bare org-qualified private slugs and
+ * un-prefixed private repo names (see `test/_privateRepoRefs.ts`), which pulled
+ * the rest of the clean-up series (#3451–#3462, #3613–#3616) into this list for
+ * the same self-referential reason.
  */
 const AUDIT_NARRATIVE_DOCS = new Set([
+  "pr-summary-3451.md",
   "pr-summary-3452.md",
+  "pr-summary-3453.md",
   "pr-summary-3454.md",
   "pr-summary-3455.md",
+  "pr-summary-3456.md",
+  "pr-summary-3457.md",
+  "pr-summary-3461.md",
+  "pr-summary-3462.md",
+  "pr-summary-3613.md",
+  "pr-summary-3615.md",
+  "pr-summary-3616.md",
 ]);
 
 Deno.test("no private stSoftwareAU repo slugs or links in docs/archive (#3455)", async () => {

--- a/test/docs/PrivateRepoRefScanner.ts
+++ b/test/docs/PrivateRepoRefScanner.ts
@@ -10,6 +10,13 @@
  *
  * This file is a private-repo *detector*: it embeds the forbidden slugs and
  * links verbatim as fixtures to verify its own detection logic.
+ *
+ * Issue #3617 widened the contract: a bare org-qualified `stSoftwareAU/GRQ`
+ * slug and an un-prefixed `GRQ-cluster` / `GRQ-logs` / `GRQ-teams` repo name
+ * are now flagged, because both name a private repository the reader cannot
+ * open. The former "a bare downstream consumer repo name" clean fixture
+ * therefore moved into `FLAGGED` — a deliberate contract change, not a relaxed
+ * test. The bare `GRQ` token stays clean and keeps its own coverage.
  */
 
 import { assertEquals } from "@std/assert";
@@ -61,6 +68,24 @@ const FLAGGED: ScannerCase[] = [
     name: "an org-qualified private repo path",
     lines: ["statistics derived from `stSoftwareAU/GRQ-cluster`."],
     expected: [1],
+  },
+  {
+    name: "a bare org-qualified downstream consumer slug (#3617)",
+    lines: [
+      "Neither confirmed consumer (stSoftwareAU/GRQ, NEAT-AI-Examples) uses it.",
+      "Logs were captured from the private stSoftwareAU/GRQ-logs repository.",
+    ],
+    expected: [1, 2],
+  },
+  {
+    name: "an un-prefixed private repo name (#3617)",
+    lines: [
+      "the run-level statistics land in the GRQ-cluster `result.json`.",
+      "Clean middle line.",
+      "profiled on the GRQ-teams production topology.",
+      "captured from the GRQ-logs archive.",
+    ],
+    expected: [1, 3, 4],
   },
   {
     name: "a private-repo blob link",
@@ -118,10 +143,10 @@ const CLEAN: ScannerCase[] = [
     expected: [],
   },
   {
-    name: "a bare downstream consumer repo name",
+    name: "the bare GRQ token on its own",
     lines: [
-      "Neither confirmed consumer (stSoftwareAU/GRQ, NEAT-AI-Examples) uses it.",
-      "Logs were captured from the private stSoftwareAU/GRQ-logs repository.",
+      "Measured on the GRQ corpus with the production creature.",
+      "The full GRQ evolve wall-clock A/B needs production hardware.",
     ],
     expected: [],
   },


### PR DESCRIPTION
# Reword bare private-repo slugs in archived PR summaries and close the guard gap (#3617)

## Summary

Fourteen archived PR summaries still pointed public readers at the private
downstream production repositories, in two forms the archive guard did not
match: the bare org-qualified consumer slug, and an un-prefixed private repo
name used as a topology / run-result label. Both were reworded to concept level,
and the shared detector was widened so the archive cannot drift back. **Closes
#3617.**

Two changes:

1. **Detector widened** (`test/_privateRepoRefs.ts`). `PRIVATE_REPO_PATTERN` now
   also flags any org-qualified private slug —
   `stSoftwareAU\/(?:GRQ|VibeCoding)` followed by a word boundary, which
   subsumes the old `github.com/…` alternative — and un-prefixed repo names
   `GRQ-(?:cluster|logs|teams)` between word boundaries. The bare `GRQ` token,
   host/log/preset mnemonics (`GRQ-21`, `GRQ-3-rocket.log`, `GRQ-side`) and the
   lower-case `grq-3397` fixture stay clean, per the #3454 mnemonic decision;
   the bare token is policed separately by the live-doc and `src`/`test` guards.
2. **Fourteen archived summaries reworded** to the wording precedent set by
   #3455/#3616 — "the downstream production consumer", "the downstream
   run-result file/store", "the production-scale topology", "every production
   snapshot".

| File                                        | Reworded                                                                 |
| ------------------------------------------- | ------------------------------------------------------------------------ |
| `pr-summary-3519.md` (7)                    | consumer slug → "the downstream production consumer"                     |
| `pr-summary-3520.md` (7)                    | consumer slug → "the downstream production consumer"                     |
| `pr-summary-3521.md` (8)                    | consumer slug → "the downstream production consumer"                     |
| `pr-summary-3522.md` (8, 44, 86)            | consumer slug, `gh search code --repo` pointer, and the tool-output line |
| `pr-summary-3523.md` (10)                   | consumer slug → "the downstream production consumer"                     |
| `pr-summary-3524.md` (7)                    | consumer slug → "the downstream production consumer"                     |
| `pr-summary-3554.md` (12)                   | consumer slug → "the downstream production consumer"                     |
| `pr-summary-3558.md` (15)                   | consumer slug → "the downstream production consumer"                     |
| `pr-summary-worker-start-heartbeat.md` (13) | consumer slug → "A downstream production `team` run"                     |
| `pr-summary-3234.md` (10)                   | private `result.json` label → "the downstream run-result file"           |
| `pr-summary-3237.md` (11)                   | private `result.json` label → "the downstream run-result file"           |
| `pr-summary-3397.md` (10)                   | private topology label → "the production-scale topology"                 |
| `pr-summary-3422.md` (6)                    | private `result.json` label → "the downstream run-result file"           |
| `pr-summary-3427.md` (7, 19)                | "every production snapshot" / "the downstream run-result store"          |

The clean-up series that documents this class of removal (#3451–#3462,
#3613–#3616) must quote the patterns it removed, so those summaries joined the
guard's existing audit-narrative allowlist rather than being reworded. This
summary is deliberately **not** allowlisted — it describes the rewordings at
concept level and quotes only regex source, so the widened guard scans it like
any other archived doc.

## Evidence

Backend/test-only change; no web interface to screenshot. Regression evidence is
the widened detector run against the pre-fix files (`git show HEAD:<file>`),
which reproduces exactly the fourteen offenders the issue lists and is clean
after the reword:

```text
pr-summary-3234.md:10   pr-summary-3237.md:11   pr-summary-3397.md:10
pr-summary-3422.md:6    pr-summary-3427.md:7,19 pr-summary-3519.md:7
pr-summary-3520.md:7    pr-summary-3521.md:8    pr-summary-3522.md:8,44,86
pr-summary-3523.md:10   pr-summary-3524.md:7    pr-summary-3554.md:12
pr-summary-3558.md:15   pr-summary-worker-start-heartbeat.md:13
```

```mermaid
flowchart LR
    A["Archived summary names a<br/>private repo (bare slug or<br/>un-prefixed repo name)"] --> B{"widened<br/>PRIVATE_REPO_PATTERN"}
    B -- "audit narrative<br/>(#3451–#3462, #3613–#3616)" --> C["allowlisted —<br/>must quote what it removed"]
    B -- "match" --> D["guard fails with file:line"]
    B -- "mnemonic / bare token /<br/>concept-level prose" --> E["passes"]
    D --> F["reword to concept level"] --> E
```

## Test Plan

- `findPrivateRepoRefs flags a bare org-qualified downstream consumer slug
  (#3617)`
  — new unit case; the two fixture lines previously asserted **clean** and now
  assert flagged. This is a deliberate contract change (documented in the file
  header), not a relaxed test.
- `findPrivateRepoRefs flags an un-prefixed private repo name (#3617)` — new
  unit case covering the `-cluster`, `-teams` and `-logs` forms plus a clean
  interleaved line.
- `findPrivateRepoRefs ignores the bare GRQ token on its own (#3604)` — new
  clean case pinning the carve-out the widened pattern must not swallow.
- `findPrivateRepoRefs ignores bare host/log/preset mnemonics (#3604)` —
  unchanged, still passes.
- `no private stSoftwareAU repo slugs or links in docs/archive (#3455)` — the
  existing tree-walking guard, now failing against the unfixed archive and
  passing after the reword.
- `bump-deps.sh` / `AGENTS.md` / `BumpDepsScript.ts`
  `has no private repo
  reference (#3458)` — the sibling consumers of the
  shared detector, unchanged and still clean under the widened pattern.



## Milestone
This PR is part of the **clean up 20260801** milestone and targets the `milestone/clean-up-20260801` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-msai8fsp-bae48a`<!-- vibe-worker-issue-3617 -->