### PR TITLE
🟡 Generation-loop tail copy-pasted across evolveDir, evolveEnv and evolveRL (Issue #3636)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "6.2.3",
+  "version": "6.2.4",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/archive/pr-summaries/pr-summary-3636.md
+++ b/docs/archive/pr-summaries/pr-summary-3636.md
@@ -1,0 +1,90 @@
+# Extract the shared generation-loop tail (Issue #3636)
+
+## Summary
+
+The end-of-generation bookkeeping — champion adoption, the optionally timed
+checkpoint write, phase-timing and scorer-utilisation accumulation, the
+score-trajectory snapshot, the `generation_complete` and `plateau_detected`
+emissions, and the cost-aware early-stop decision — was copy-pasted into all
+three training loops in `src/creature/CreatureTraining.ts` (`evolveDir`,
+`evolveEnv`, `evolveRL`). Six separate changes (#3210, #3234, #3422, #3402,
+#3263, #2947) each had to be applied three times, and the copies had already
+drifted: `evolveEnv` and `evolveRL` parsed the error tag through an `"Infinity"`
+ternary that `evolveDir` lacked.
+
+This PR moves that rule into one place — `finishGeneration()` in the new
+`src/creature/EvolveGenerationTail.ts` — with three call sites. Genuinely
+variant-specific work stays in each loop: `evolveDir`'s score/error consistency
+assert and `evolveRL`'s milestone capture. No mode flags are passed to the
+helper.
+
+Behaviour is unchanged. The drifted error-tag parse is unified on the explicit
+`"Infinity"` form, which was already behaviourally inert
+(`Number.parseFloat("Infinity") === Infinity`, and the following
+`Number.isFinite` assert rejects it either way — a non-finite error tag still
+fails loud in all three loops).
+
+`CreatureTraining.ts` drops 275 net lines (1833 → 1558). No public API or event
+payload changed, so `docs/api/EVOLUTION.md` needs no update.
+
+Closes #3636.
+
+## Evidence
+
+Backend/library change — no web interface to screenshot. Verified by the unit
+tests below plus the existing `evolveDir` / `evolveEnv` / `evolveRL` integration
+suites (which assert on the emitted `generation_complete` payloads, the
+run-level `phaseTimingTotals` / `scorerUtilisation` totals, the RL milestone
+sequence, and the early-stop and hard-deadline behaviour).
+
+Before — the same tail inlined three times:
+
+```mermaid
+flowchart TB
+    subgraph before [Before]
+        A1[evolveDir loop] --> T1[adopt champion → checkpoint → accumulate<br/>→ trajectory → events → early stop]
+        A2[evolveEnv loop] --> T2[adopt champion → checkpoint → accumulate<br/>→ trajectory → events → early stop]
+        A3[evolveRL loop] --> T3[adopt champion → checkpoint → accumulate<br/>→ trajectory → events → early stop]
+    end
+```
+
+After — one helper, three call sites, variant-specific work left in the loops:
+
+```mermaid
+flowchart TB
+    subgraph after [After]
+        B1[evolveDir loop] --> F[finishGeneration]
+        B2[evolveEnv loop] --> F
+        B3[evolveRL loop] --> F
+        B1 --> V1[score/error consistency assert]
+        B3 --> V3[RL milestone capture]
+        F --> O[champion state + stop decision]
+    end
+```
+
+Quality gate: `./quality.sh` run clean (fmt, lint, bash syntax, type-check,
+discovery, WASM sync, full test suite).
+
+## Test Plan
+
+New unit tests in `test/creature/EvolveGenerationTail.ts` call the real
+`finishGeneration()` with real configs, accumulators and creatures:
+
+- `adopts an improved champion` — champion clone, best score/error, and the
+  score-trajectory point (including the cumulative scored-count).
+- `keeps the champion when no improvement` — champion, error, and trajectory
+  untouched on a tie.
+- `fails loud on a non-finite error tag` — `Infinity`, `NaN` and unparseable
+  tags all reject rather than adopting an incomparable champion.
+- `fails loud on a negative error tag`.
+- `emits generation_complete` — asserts every field of the payload.
+- `emits plateau_detected only on a plateau`.
+- `accumulates timings and scorer counts` — two generations summed into the
+  run-level accumulators.
+- `times the checkpoint write` — `checkpointWriteMs` present and the population
+  actually written to the store.
+- `leaves phase timing untouched without a store`.
+- Stop decision — early stop on `targetError`, the iteration limit, SIGTERM
+  interruption, a passed `endTimeMS`, and staying un-completed mid-run.
+
+No existing tests were modified or removed.

--- a/src/creature/CreatureTraining.ts
+++ b/src/creature/CreatureTraining.ts
@@ -26,10 +26,6 @@ import { createNeatConfig } from "@config/NeatConfig.ts";
 import { EVOLUTION_ONLY_TRAIN_PER_GEN } from "@config/TrainPerGen.ts";
 import type { NeatOptions } from "@config/NeatOptions.ts";
 import { Costs } from "@costs";
-import {
-  isBetterChampion,
-  shouldEarlyStop,
-} from "@costs/CostAwareEarlyStop.ts";
 import { WorkerHandler } from "@multithreading/workers/WorkerHandler.ts";
 import { Neat } from "@neat/Neat.ts";
 import { computeHardDeadlineTS } from "@neat/HardDeadline.ts";
@@ -46,7 +42,6 @@ import {
 import { buildOutgoingSynapsesMap } from "@propagate/sparse/CalculatePathsToOutput.ts";
 import { SparseConfig } from "@propagate/sparse/SparseConfig.ts";
 import { exportJSONWithRuntimeIds } from "@architecture/PopulateRuntimeIdsFromCreature.ts";
-import { buildWarmupEventFields } from "@architecture/CreatureFactory.ts";
 import { BufferPool } from "@utils/BufferPool.ts";
 import {
   type DiscoveryDirResult,
@@ -73,12 +68,11 @@ import type { Fitness } from "@architecture/Fitness.ts";
 import type { EpisodeAdapter } from "@creature/EpisodeAdapter.ts";
 import { buildRLSeedSet } from "@creature/EvolveRLSeedSet.ts";
 import {
-  adoptChampionClone,
   disposeEvolvePopulation,
   releaseEvolveCaches,
 } from "@creature/EvolveTeardown.ts";
+import { finishGeneration } from "@creature/EvolveGenerationTail.ts";
 import {
-  accumulatePhaseTiming,
   createPhaseTimingAccumulator,
   finalisePhaseTimingTotals,
 } from "@creature/PhaseTimingTotals.ts";
@@ -86,10 +80,8 @@ import {
 // run-level phase-timing totals shape (Issue #3210).
 export type { PhaseTimingTotals } from "@creature/PhaseTimingTotals.ts";
 import {
-  accumulateScorerUtilisation,
   createScorerUtilisationAccumulator,
   finaliseScorerUtilisationTotals,
-  type ScorerUtilisationCounts,
 } from "@creature/ScorerUtilisationTotals.ts";
 // Re-export so `import * as training` consumers (e.g. Creature.ts) can name the
 // run-level scorer-utilisation totals shape (Issue #3234).
@@ -112,25 +104,8 @@ export type {
   ScoreImprovementMilestone,
   ScoreImprovementMilestones,
 } from "@creature/EvolveRunStatistics.ts";
-import {
-  createScoreTrajectory,
-  recordScoreImprovement,
-} from "@creature/ScoreImprovementMilestones.ts";
+import { createScoreTrajectory } from "@creature/ScoreImprovementMilestones.ts";
 import { serialiseOptionsEcho } from "@creature/EvolveOptionsEcho.ts";
-
-/**
- * Snapshot the per-backend scorer-utilisation counts published by `Fitness`
- * after a generation's `evolve()` cycle (Issue #3234). Read once per
- * generation into the run-level accumulator.
- */
-function readScorerUtilisation(fitness: Fitness): ScorerUtilisationCounts {
-  return {
-    batchScorerInvocations: fitness.lastBatchScorerInvocations,
-    creaturesBatchScored: fitness.lastCreaturesBatchScored,
-    creaturesPerCreatureScored: fitness.lastCreaturesPerCreatureScored,
-    batchFallbackOccurred: fitness.lastBatchFallbackOccurred,
-  };
-}
 
 /**
  * Propagate expected values backward through the network for all output neurons.
@@ -528,7 +503,6 @@ export async function evolveDir(
 
   let iterationStartMS = Date.now();
   let generation = 0;
-  const targetError = config.targetError;
   const iterations = config.iterations;
   // Issue #3210: sum the always-on per-generation phase timings across the run.
   const phaseTimingAccumulator = createPhaseTimingAccumulator();
@@ -541,129 +515,45 @@ export async function evolveDir(
     // deno-lint-ignore no-await-in-loop
     const result = await neat.evolve(bestCreature);
 
-    const fittest = result.fittest;
-    const fittestScore = fittest.score!;
-    assert(fittestScore >= bestScore, "Score is less than best score");
-    // Issue #3422: note whether this generation improved the champion so the
-    // trajectory point is recorded once the scored-count is up to date below.
-    let championImproved = false;
-    // Issue #2787: route champion comparison through the cost-aware helper.
-    // Today this remains a strict `score > bestScore` for every cost
-    // (NaN-safe) so existing runs do not regress; the seam is in place for
-    // future cost-specific tie-breaks.
-    if (isBetterChampion(fittestScore, bestScore, config.costName)) {
-      const errorTmp = getTag(fittest, "error");
-      assert(errorTmp, "No error tag found");
-
-      error = Number.parseFloat(errorTmp);
-      assert(Number.isFinite(error), "Error is not finite");
-      assert(error >= 0, "Error is negative");
-      const tolerance = 1e-10;
-      assert(
-        fittestScore - 1 <= -error + tolerance,
-        `Score (absolute) less than error (score=${fittestScore}, error=${error})`,
-      );
-      bestScore = fittestScore;
-      // Issue #2276: Use shallowClone() instead of exportJSONWithRuntimeIds +
-      // fromJSON round-trip. shallowClone() is 2.4–3.5x faster (Issue #1586)
-      // and preserves all necessary state including runtime IDs and UUIDs.
-      // Issue #3434: dispose the superseded champion clone before overwriting
-      // it so its topology arrays / WASM activation are released immediately.
-      bestCreature = adoptChampionClone(
-        bestCreature,
-        fittest,
-        bestScore,
-      ) as InstanceType<typeof CreatureClass>;
-      championImproved = true;
-    }
-
-    const now = Date.now();
-    const timedOut = endTimeMS ? now > endTimeMS : false;
-
     generation++;
 
-    // Issue #2251: Time checkpoint write so it flows through onTrainingEvent
-    // Issue #2275: Async checkpoint writes unblock the event loop
-    let phaseTiming = result.phaseTiming;
-    if (config.checkpointEveryGeneration && config.creatureStore) {
-      const checkpointStart = Date.now();
-      // deno-lint-ignore no-await-in-loop
-      await writeCreatures(neat, config.creatureStore);
-      phaseTiming = {
-        ...result.phaseTiming,
-        checkpointWriteMs: Date.now() - checkpointStart,
-      };
-    }
-
-    // Issue #1615: Emit generation_complete event
-    // Issue #2239: Include per-phase timing diagnostics from evolve()
-    // Issue #2330: Forward compact throughput counters (wall-clock, queue
-    // depths, approximate worker wait) on the same event.
-    // Issue #3210: fold this generation's (checkpoint-merged) phase timing
-    // into the whole-run running totals returned alongside `time`.
-    accumulatePhaseTiming(phaseTimingAccumulator, phaseTiming);
-    // Issue #3234: fold this generation's per-backend scorer-utilisation counts
-    // into the whole-run totals returned alongside `phaseTimingTotals`.
-    accumulateScorerUtilisation(
-      scorerUtilisationAccumulator,
-      readScorerUtilisation(neat.fitness),
-    );
-
-    // Issue #3422: on a champion improvement, snapshot the best-score curve with
-    // the now-current cumulative scored-count so the milestone summary can be
-    // derived at run end without persisting a per-generation series.
-    if (championImproved) {
-      recordScoreImprovement(scoreTrajectory, {
-        score: bestScore,
-        generation,
-        timeMs: now - start,
-        scoredCount: scorerUtilisationAccumulator.creaturesBatchScored +
-          scorerUtilisationAccumulator.creaturesPerCreatureScored,
-      });
-    }
-
-    const generationElapsedMs = now -
-      (generation === 1 ? start : iterationStartMS);
-    emitTrainingEvent(config.onTrainingEvent, {
-      kind: "generation_complete",
-      timestamp: Temporal.Now.instant().toString(),
+    // Issue #3636: the end-of-generation bookkeeping (champion adoption, timed
+    // checkpoint, run-total accumulation, score trajectory, lifecycle events,
+    // cost-aware early stop) is shared with evolveEnv and evolveRL.
+    // deno-lint-ignore no-await-in-loop
+    const tail = await finishGeneration({
+      neat,
+      config,
+      result,
       generation,
-      bestFitness: fittestScore,
-      averageFitness: result.averageScore,
-      populationSize: neat.population.length,
-      // Issue #3402: population topology averages for memory-profile diagnosis.
-      averageNeurons: result.topologyAverages.averageNeurons,
-      averageSynapses: result.topologyAverages.averageSynapses,
-      elapsedMs: generationElapsedMs,
-      phaseTiming,
-      throughput: result.throughput,
-      // Issue #3263: diagnostic squash mix for the squash-budget experiment.
-      squashHistogram: result.squashHistogram,
-      // Issue #2947: surface the lineage-accumulated warm-up counter and the
-      // derived lock state (present only while warm-up is configured).
-      ...buildWarmupEventFields(neat.warmupGenerations, neat.currentGeneration),
+      start,
+      iterationStartMS,
+      endTimeMS,
+      interrupted,
+      bestScore,
+      error,
+      bestCreature,
+      phaseTimingAccumulator,
+      scorerUtilisationAccumulator,
+      scoreTrajectory,
     });
+    bestCreature = tail.bestCreature as
+      | InstanceType<typeof CreatureClass>
+      | undefined;
+    bestScore = tail.bestScore;
+    error = tail.error;
+    const now = tail.now;
+    const completed = tail.completed;
 
-    // Issue #1615: Emit plateau_detected event when on plateau
-    if (result.plateau.onPlateau) {
-      emitTrainingEvent(config.onTrainingEvent, {
-        kind: "plateau_detected",
-        timestamp: Temporal.Now.instant().toString(),
-        generation,
-        stagnationCount: result.plateau.generationsOnPlateau,
-        plateauThreshold: config.plateauDetection.windowSize,
-        improvementRate: result.plateau.improvementRate,
-        mutationMultiplier: result.plateau.mutationMultiplier,
-      });
+    // evolveDir-specific: supervised scores are `1 - error` (plus the growth
+    // penalty), so a new champion's score and error must stay consistent.
+    if (tail.championImproved) {
+      const tolerance = 1e-10;
+      assert(
+        bestScore - 1 <= -error + tolerance,
+        `Score (absolute) less than error (score=${bestScore}, error=${error})`,
+      );
     }
-
-    // Issue #2787: cost-aware early-stop. For built-in costs the threshold
-    // is clamped into the cost's natural range (e.g. unit-range CROSS_ENTROPY
-    // clamped to [0, 1] vs unbounded MSE); custom JS costs fall back to the legacy
-    // `error <= targetError` comparator as a regression guard.
-    const earlyStop = shouldEarlyStop(error, targetError, config.costName);
-    const completed = interrupted || timedOut || earlyStop ||
-      generation >= iterations;
 
     if (
       config.log &&
@@ -677,7 +567,7 @@ export async function evolveDir(
         "Generation",
         generation,
         "score",
-        fittest.score,
+        result.fittest.score,
         avgTxt,
         "error",
         error,
@@ -899,7 +789,6 @@ export async function evolveEnv<S, A>(
 
   let iterationStartMS = Date.now();
   let generation = 0;
-  const targetError = config.targetError;
   const iterations = config.iterations;
   // Issue #3210: sum the always-on per-generation phase timings across the run.
   const phaseTimingAccumulator = createPhaseTimingAccumulator();
@@ -915,114 +804,31 @@ export async function evolveEnv<S, A>(
     // deno-lint-ignore no-await-in-loop
     const result = await neat.evolve(bestCreature);
 
-    const fittest = result.fittest;
-    const fittestScore = fittest.score!;
-    assert(fittestScore >= bestScore, "Score is less than best score");
-    // Issue #3422: note whether this generation improved the champion so the
-    // trajectory point is recorded once the scored-count is up to date below.
-    let championImproved = false;
-    // Issue #2787: route champion comparison through the cost-aware helper.
-    // Today this remains a strict `score > bestScore` for every cost
-    // (NaN-safe) so existing runs do not regress; the seam is in place for
-    // future cost-specific tie-breaks.
-    if (isBetterChampion(fittestScore, bestScore, config.costName)) {
-      const errorTmp = getTag(fittest, "error");
-      assert(errorTmp, "No error tag found");
-
-      const parsedError = errorTmp === "Infinity"
-        ? Number.POSITIVE_INFINITY
-        : Number.parseFloat(errorTmp);
-      assert(Number.isFinite(parsedError), "Error is not finite");
-      assert(parsedError >= 0, "Error is negative");
-      error = parsedError;
-      bestScore = fittestScore;
-      // Issue #3434: dispose the superseded champion clone before overwriting.
-      bestCreature = adoptChampionClone(
-        bestCreature,
-        fittest,
-        bestScore,
-      ) as InstanceType<typeof CreatureClass>;
-      championImproved = true;
-    }
-
-    const now = Date.now();
-    const timedOut = endTimeMS ? now > endTimeMS : false;
-
-    let phaseTiming = result.phaseTiming;
-    if (config.checkpointEveryGeneration && config.creatureStore) {
-      const checkpointStart = Date.now();
-      // deno-lint-ignore no-await-in-loop
-      await writeCreatures(neat, config.creatureStore);
-      phaseTiming = {
-        ...result.phaseTiming,
-        checkpointWriteMs: Date.now() - checkpointStart,
-      };
-    }
-
-    // Issue #3210: fold this generation's (checkpoint-merged) phase timing
-    // into the whole-run running totals returned alongside `time`.
-    accumulatePhaseTiming(phaseTimingAccumulator, phaseTiming);
-    // Issue #3234: fold this generation's per-backend scorer-utilisation counts
-    // into the whole-run totals returned alongside `phaseTimingTotals`.
-    accumulateScorerUtilisation(
-      scorerUtilisationAccumulator,
-      readScorerUtilisation(neat.fitness),
-    );
-
-    // Issue #3422: on a champion improvement, snapshot the best-score curve with
-    // the now-current cumulative scored-count so the milestone summary can be
-    // derived at run end without persisting a per-generation series.
-    if (championImproved) {
-      recordScoreImprovement(scoreTrajectory, {
-        score: bestScore,
-        generation,
-        timeMs: now - start,
-        scoredCount: scorerUtilisationAccumulator.creaturesBatchScored +
-          scorerUtilisationAccumulator.creaturesPerCreatureScored,
-      });
-    }
-
-    const generationElapsedMs = now -
-      (generation === 1 ? start : iterationStartMS);
-    emitTrainingEvent(config.onTrainingEvent, {
-      kind: "generation_complete",
-      timestamp: Temporal.Now.instant().toString(),
+    // Issue #3636: shared end-of-generation bookkeeping (see finishGeneration).
+    // deno-lint-ignore no-await-in-loop
+    const tail = await finishGeneration({
+      neat,
+      config,
+      result,
       generation,
-      bestFitness: fittestScore,
-      averageFitness: result.averageScore,
-      populationSize: neat.population.length,
-      // Issue #3402: population topology averages for memory-profile diagnosis.
-      averageNeurons: result.topologyAverages.averageNeurons,
-      averageSynapses: result.topologyAverages.averageSynapses,
-      elapsedMs: generationElapsedMs,
-      phaseTiming,
-      throughput: result.throughput,
-      // Issue #3263: diagnostic squash mix for the squash-budget experiment.
-      squashHistogram: result.squashHistogram,
-      // Issue #2947: surface the lineage-accumulated warm-up counter and the
-      // derived lock state (present only while warm-up is configured).
-      ...buildWarmupEventFields(neat.warmupGenerations, neat.currentGeneration),
+      start,
+      iterationStartMS,
+      endTimeMS,
+      interrupted,
+      bestScore,
+      error,
+      bestCreature,
+      phaseTimingAccumulator,
+      scorerUtilisationAccumulator,
+      scoreTrajectory,
     });
-
-    if (result.plateau.onPlateau) {
-      emitTrainingEvent(config.onTrainingEvent, {
-        kind: "plateau_detected",
-        timestamp: Temporal.Now.instant().toString(),
-        generation,
-        stagnationCount: result.plateau.generationsOnPlateau,
-        plateauThreshold: config.plateauDetection.windowSize,
-        improvementRate: result.plateau.improvementRate,
-        mutationMultiplier: result.plateau.mutationMultiplier,
-      });
-    }
-
-    // Issue #2787: cost-aware early-stop. For built-in costs the threshold
-    // is clamped into the cost's natural range (e.g. unit-range CROSS_ENTROPY
-    // clamped to [0, 1] vs unbounded MSE); custom JS costs fall back to the legacy
-    // `error <= targetError` comparator as a regression guard.
-    const earlyStop = shouldEarlyStop(error, targetError, config.costName);
-    const completed = interrupted || timedOut || earlyStop ||
-      generation >= iterations;
+    bestCreature = tail.bestCreature as
+      | InstanceType<typeof CreatureClass>
+      | undefined;
+    bestScore = tail.bestScore;
+    error = tail.error;
+    const now = tail.now;
+    const completed = tail.completed;
 
     if (
       config.log &&
@@ -1036,7 +842,7 @@ export async function evolveEnv<S, A>(
         "Generation",
         generation,
         "score",
-        fittest.score,
+        result.fittest.score,
         avgTxt,
         "error",
         error,
@@ -1433,7 +1239,6 @@ export async function evolveRL<S, A>(
 
   let iterationStartMS = Date.now();
   let generation = 0;
-  const targetError = config.targetError;
   const iterations = config.iterations;
   // Issue #3210: sum the always-on per-generation phase timings across the run.
   const phaseTimingAccumulator = createPhaseTimingAccumulator();
@@ -1459,104 +1264,32 @@ export async function evolveRL<S, A>(
 
     const fittest = result.fittest;
     const fittestScore = fittest.score!;
-    assert(fittestScore >= bestScore, "Score is less than best score");
-    // Issue #3422: note whether this generation improved the champion so the
-    // trajectory point is recorded once the scored-count is up to date below.
-    let championImproved = false;
-    // Issue #2787: route champion comparison through the cost-aware helper.
-    // Today this remains a strict `score > bestScore` for every cost
-    // (NaN-safe) so existing runs do not regress; the seam is in place for
-    // future cost-specific tie-breaks.
-    if (isBetterChampion(fittestScore, bestScore, config.costName)) {
-      const errorTmp = getTag(fittest, "error");
-      assert(errorTmp, "No error tag found");
 
-      const parsedError = errorTmp === "Infinity"
-        ? Number.POSITIVE_INFINITY
-        : Number.parseFloat(errorTmp);
-      assert(Number.isFinite(parsedError), "Error is not finite");
-      assert(parsedError >= 0, "Error is negative");
-      error = parsedError;
-      bestScore = fittestScore;
-      // Issue #3434: dispose the superseded champion clone before overwriting.
-      bestCreature = adoptChampionClone(
-        bestCreature,
-        fittest,
-        bestScore,
-      ) as InstanceType<typeof CreatureClass>;
-      championImproved = true;
-    }
-
-    const now = Date.now();
-    const timedOut = endTimeMS ? now > endTimeMS : false;
-
-    let phaseTiming = result.phaseTiming;
-    if (config.checkpointEveryGeneration && config.creatureStore) {
-      const checkpointStart = Date.now();
-      // deno-lint-ignore no-await-in-loop
-      await writeCreatures(neat, config.creatureStore);
-      phaseTiming = {
-        ...result.phaseTiming,
-        checkpointWriteMs: Date.now() - checkpointStart,
-      };
-    }
-
-    // Issue #3210: fold this generation's (checkpoint-merged) phase timing
-    // into the whole-run running totals returned alongside `time`.
-    accumulatePhaseTiming(phaseTimingAccumulator, phaseTiming);
-    // Issue #3234: fold this generation's per-backend scorer-utilisation counts
-    // into the whole-run totals returned alongside `phaseTimingTotals`.
-    accumulateScorerUtilisation(
-      scorerUtilisationAccumulator,
-      readScorerUtilisation(neat.fitness),
-    );
-
-    // Issue #3422: on a champion improvement, snapshot the best-score curve with
-    // the now-current cumulative scored-count so the milestone summary can be
-    // derived at run end without persisting a per-generation series.
-    if (championImproved) {
-      recordScoreImprovement(scoreTrajectory, {
-        score: bestScore,
-        generation,
-        timeMs: now - start,
-        scoredCount: scorerUtilisationAccumulator.creaturesBatchScored +
-          scorerUtilisationAccumulator.creaturesPerCreatureScored,
-      });
-    }
-
-    const generationElapsedMs = now -
-      (generation === 1 ? start : iterationStartMS);
-    emitTrainingEvent(config.onTrainingEvent, {
-      kind: "generation_complete",
-      timestamp: Temporal.Now.instant().toString(),
+    // Issue #3636: shared end-of-generation bookkeeping (see finishGeneration).
+    // deno-lint-ignore no-await-in-loop
+    const tail = await finishGeneration({
+      neat,
+      config,
+      result,
       generation,
-      bestFitness: fittestScore,
-      averageFitness: result.averageScore,
-      populationSize: neat.population.length,
-      // Issue #3402: population topology averages for memory-profile diagnosis.
-      averageNeurons: result.topologyAverages.averageNeurons,
-      averageSynapses: result.topologyAverages.averageSynapses,
-      elapsedMs: generationElapsedMs,
-      phaseTiming,
-      throughput: result.throughput,
-      // Issue #3263: diagnostic squash mix for the squash-budget experiment.
-      squashHistogram: result.squashHistogram,
-      // Issue #2947: surface the lineage-accumulated warm-up counter and the
-      // derived lock state (present only while warm-up is configured).
-      ...buildWarmupEventFields(neat.warmupGenerations, neat.currentGeneration),
+      start,
+      iterationStartMS,
+      endTimeMS,
+      interrupted,
+      bestScore,
+      error,
+      bestCreature,
+      phaseTimingAccumulator,
+      scorerUtilisationAccumulator,
+      scoreTrajectory,
     });
-
-    if (result.plateau.onPlateau) {
-      emitTrainingEvent(config.onTrainingEvent, {
-        kind: "plateau_detected",
-        timestamp: Temporal.Now.instant().toString(),
-        generation,
-        stagnationCount: result.plateau.generationsOnPlateau,
-        plateauThreshold: config.plateauDetection.windowSize,
-        improvementRate: result.plateau.improvementRate,
-        mutationMultiplier: result.plateau.mutationMultiplier,
-      });
-    }
+    bestCreature = tail.bestCreature as
+      | InstanceType<typeof CreatureClass>
+      | undefined;
+    bestScore = tail.bestScore;
+    error = tail.error;
+    const now = tail.now;
+    const completed = tail.completed;
 
     // Issue #2647: remember the most recent generation's snapshot inputs so a
     // synthetic final milestone can be built after the loop exits between
@@ -1592,14 +1325,6 @@ export async function evolveRL<S, A>(
         ...milestone,
       });
     }
-
-    // Issue #2787: cost-aware early-stop. For built-in costs the threshold
-    // is clamped into the cost's natural range (e.g. unit-range CROSS_ENTROPY
-    // clamped to [0, 1] vs unbounded MSE); custom JS costs fall back to the legacy
-    // `error <= targetError` comparator as a regression guard.
-    const earlyStop = shouldEarlyStop(error, targetError, config.costName);
-    const completed = interrupted || timedOut || earlyStop ||
-      generation >= iterations;
 
     if (
       config.log &&

--- a/src/creature/EvolveGenerationTail.ts
+++ b/src/creature/EvolveGenerationTail.ts
@@ -1,0 +1,272 @@
+/**
+ * EvolveGenerationTail.ts — the end-of-generation bookkeeping shared by
+ * `evolveDir`, `evolveEnv`, and `evolveRL` (Issue #3636).
+ *
+ * Every training loop in `CreatureTraining.ts` ends a generation the same way:
+ * adopt the champion when it improved, optionally write a timed checkpoint,
+ * fold the generation's phase timings and scorer-utilisation counts into the
+ * run totals, snapshot the score trajectory, emit `generation_complete` (plus
+ * `plateau_detected` on a plateau), and decide whether the run is finished.
+ *
+ * That sequence used to be copy-pasted three times, so every change to the
+ * rule — a new `generation_complete` field, a different early-stop comparator —
+ * had to land identically in three places (#3210, #3234, #3422, #3402, #3263,
+ * #2947 each did). The copies had already drifted. {@link finishGeneration} is
+ * the single home for the rule; genuinely variant-specific work (evolveDir's
+ * score/error consistency assert, evolveRL's milestone capture) stays in the
+ * caller's loop.
+ */
+
+import { assert } from "@std/assert";
+import { getTag } from "@stsoftware/tags/mod";
+import type { Creature } from "@creature";
+import type { NeatConfig } from "@config/NeatConfig.ts";
+import type { GenerationPhaseTiming } from "@config/TrainingEvent.ts";
+import type { EvolveResult as GenerationEvolveResult } from "@neat/NeatEvolution.ts";
+import {
+  isBetterChampion,
+  shouldEarlyStop,
+} from "@costs/CostAwareEarlyStop.ts";
+import {
+  type CheckpointSource,
+  writeCreatures,
+} from "@creature/CheckpointWriter.ts";
+import { adoptChampionClone } from "@creature/EvolveTeardown.ts";
+import {
+  accumulatePhaseTiming,
+  type PhaseTimingAccumulator,
+} from "@creature/PhaseTimingTotals.ts";
+import {
+  accumulateScorerUtilisation,
+  type ScorerUtilisationAccumulator,
+  type ScorerUtilisationCounts,
+} from "@creature/ScorerUtilisationTotals.ts";
+import {
+  recordScoreImprovement,
+  type ScoreTrajectory,
+} from "@creature/ScoreImprovementMilestones.ts";
+import { buildWarmupEventFields } from "@architecture/CreatureFactory.ts";
+import { emitTrainingEvent } from "@neat/TrainingEventEmitter.ts";
+
+/**
+ * The per-generation scorer counters published by `Fitness` — satisfied by
+ * both the dataset `Fitness` and the episodic/RL scorers (Issue #3234).
+ */
+export interface ScorerUtilisationSource {
+  readonly lastBatchScorerInvocations: number;
+  readonly lastCreaturesBatchScored: number;
+  readonly lastCreaturesPerCreatureScored: number;
+  readonly lastBatchFallbackOccurred: boolean;
+}
+
+/**
+ * The `Neat` state the generation tail reads — satisfied by `Neat` itself.
+ * Structural (rather than a `Neat` import) so the helper stays directly
+ * testable and free of the `Neat` → `Creature` → `CreatureTraining` cycle.
+ */
+export interface GenerationTailSource extends CheckpointSource {
+  readonly fitness: ScorerUtilisationSource;
+}
+
+/** Everything the shared tail needs from one generation of a training loop. */
+export interface GenerationTailContext {
+  readonly neat: GenerationTailSource;
+  readonly config: NeatConfig;
+  /** This generation's `neat.evolve()` result. */
+  readonly result: GenerationEvolveResult;
+  /** Generation number, already incremented for this cycle. */
+  readonly generation: number;
+  /** Run start timestamp in ms. */
+  readonly start: number;
+  /** Timestamp the previous logged generation finished, in ms. */
+  readonly iterationStartMS: number;
+  /** Soft deadline in ms; `0` when no timeout is configured. */
+  readonly endTimeMS: number;
+  /** True once SIGTERM / an abort signal has been observed. */
+  readonly interrupted: boolean;
+  /** Best score seen so far across the run. */
+  readonly bestScore: number;
+  /** Error of the current champion; `Infinity` before the first champion. */
+  readonly error: number;
+  /** Current champion clone, or `undefined` before the first champion. */
+  readonly bestCreature: Creature | undefined;
+  readonly phaseTimingAccumulator: PhaseTimingAccumulator;
+  readonly scorerUtilisationAccumulator: ScorerUtilisationAccumulator;
+  readonly scoreTrajectory: ScoreTrajectory;
+}
+
+/** The loop state {@link finishGeneration} hands back to its caller. */
+export interface GenerationTailOutcome {
+  /** Champion clone after this generation (unchanged when no improvement). */
+  readonly bestCreature: Creature | undefined;
+  /** Best score after this generation. */
+  readonly bestScore: number;
+  /** Champion error after this generation. */
+  readonly error: number;
+  /** True when this generation produced a new champion. */
+  readonly championImproved: boolean;
+  /** Timestamp taken once, after champion adoption. */
+  readonly now: number;
+  /** True when the soft deadline has passed. */
+  readonly timedOut: boolean;
+  /** This generation's phase timing, including any checkpoint write. */
+  readonly phaseTiming: GenerationPhaseTiming;
+  /** True when the cost-aware early-stop threshold was met. */
+  readonly earlyStop: boolean;
+  /** True when the run should finish after this generation. */
+  readonly completed: boolean;
+}
+
+/**
+ * Snapshot the per-backend scorer-utilisation counts published by the scorer
+ * after a generation's `evolve()` cycle (Issue #3234).
+ */
+function readScorerUtilisation(
+  fitness: ScorerUtilisationSource,
+): ScorerUtilisationCounts {
+  return {
+    batchScorerInvocations: fitness.lastBatchScorerInvocations,
+    creaturesBatchScored: fitness.lastCreaturesBatchScored,
+    creaturesPerCreatureScored: fitness.lastCreaturesPerCreatureScored,
+    batchFallbackOccurred: fitness.lastBatchFallbackOccurred,
+  };
+}
+
+/**
+ * Run the end-of-generation bookkeeping shared by every training loop.
+ *
+ * @param ctx This generation's loop state.
+ * @returns The updated champion state plus the stop decision for the loop.
+ */
+export async function finishGeneration(
+  ctx: GenerationTailContext,
+): Promise<GenerationTailOutcome> {
+  const { config, neat, result, generation } = ctx;
+
+  const fittest = result.fittest;
+  const fittestScore = fittest.score!;
+  assert(fittestScore >= ctx.bestScore, "Score is less than best score");
+
+  let error = ctx.error;
+  let bestScore = ctx.bestScore;
+  let bestCreature = ctx.bestCreature;
+  let championImproved = false;
+
+  // Issue #2787: route champion comparison through the cost-aware helper.
+  // Today this remains a strict `score > bestScore` for every cost (NaN-safe)
+  // so existing runs do not regress; the seam is in place for future
+  // cost-specific tie-breaks.
+  if (isBetterChampion(fittestScore, bestScore, config.costName)) {
+    const errorTmp = getTag(fittest, "error");
+    assert(errorTmp, "No error tag found");
+
+    const parsedError = errorTmp === "Infinity"
+      ? Number.POSITIVE_INFINITY
+      : Number.parseFloat(errorTmp);
+    assert(Number.isFinite(parsedError), "Error is not finite");
+    assert(parsedError >= 0, "Error is negative");
+    error = parsedError;
+    bestScore = fittestScore;
+    // Issue #3434: dispose the superseded champion clone before overwriting it
+    // so its topology arrays / WASM activation are released immediately.
+    bestCreature = adoptChampionClone(bestCreature, fittest, bestScore);
+    championImproved = true;
+  }
+
+  const now = Date.now();
+  const timedOut = ctx.endTimeMS ? now > ctx.endTimeMS : false;
+
+  // Issue #2251: Time the checkpoint write so it flows through onTrainingEvent.
+  // Issue #2275: Async checkpoint writes unblock the event loop.
+  let phaseTiming = result.phaseTiming;
+  if (config.checkpointEveryGeneration && config.creatureStore) {
+    const checkpointStart = Date.now();
+    await writeCreatures(neat, config.creatureStore);
+    phaseTiming = {
+      ...result.phaseTiming,
+      checkpointWriteMs: Date.now() - checkpointStart,
+    };
+  }
+
+  // Issue #3210: fold this generation's (checkpoint-merged) phase timing into
+  // the whole-run running totals returned alongside `time`.
+  accumulatePhaseTiming(ctx.phaseTimingAccumulator, phaseTiming);
+  // Issue #3234: fold this generation's per-backend scorer-utilisation counts
+  // into the whole-run totals returned alongside `phaseTimingTotals`.
+  accumulateScorerUtilisation(
+    ctx.scorerUtilisationAccumulator,
+    readScorerUtilisation(neat.fitness),
+  );
+
+  // Issue #3422: on a champion improvement, snapshot the best-score curve with
+  // the now-current cumulative scored-count so the milestone summary can be
+  // derived at run end without persisting a per-generation series.
+  if (championImproved) {
+    recordScoreImprovement(ctx.scoreTrajectory, {
+      score: bestScore,
+      generation,
+      timeMs: now - ctx.start,
+      scoredCount: ctx.scorerUtilisationAccumulator.creaturesBatchScored +
+        ctx.scorerUtilisationAccumulator.creaturesPerCreatureScored,
+    });
+  }
+
+  // Issue #1615: Emit generation_complete event.
+  // Issue #2239: Include per-phase timing diagnostics from evolve().
+  // Issue #2330: Forward compact throughput counters (wall-clock, queue
+  // depths, approximate worker wait) on the same event.
+  const generationElapsedMs = now -
+    (generation === 1 ? ctx.start : ctx.iterationStartMS);
+  emitTrainingEvent(config.onTrainingEvent, {
+    kind: "generation_complete",
+    timestamp: Temporal.Now.instant().toString(),
+    generation,
+    bestFitness: fittestScore,
+    averageFitness: result.averageScore,
+    populationSize: neat.population.length,
+    // Issue #3402: population topology averages for memory-profile diagnosis.
+    averageNeurons: result.topologyAverages.averageNeurons,
+    averageSynapses: result.topologyAverages.averageSynapses,
+    elapsedMs: generationElapsedMs,
+    phaseTiming,
+    throughput: result.throughput,
+    // Issue #3263: diagnostic squash mix for the squash-budget experiment.
+    squashHistogram: result.squashHistogram,
+    // Issue #2947: surface the lineage-accumulated warm-up counter and the
+    // derived lock state (present only while warm-up is configured).
+    ...buildWarmupEventFields(neat.warmupGenerations, neat.currentGeneration),
+  });
+
+  // Issue #1615: Emit plateau_detected event when on plateau.
+  if (result.plateau.onPlateau) {
+    emitTrainingEvent(config.onTrainingEvent, {
+      kind: "plateau_detected",
+      timestamp: Temporal.Now.instant().toString(),
+      generation,
+      stagnationCount: result.plateau.generationsOnPlateau,
+      plateauThreshold: config.plateauDetection.windowSize,
+      improvementRate: result.plateau.improvementRate,
+      mutationMultiplier: result.plateau.mutationMultiplier,
+    });
+  }
+
+  // Issue #2787: cost-aware early-stop. For built-in costs the threshold is
+  // clamped into the cost's natural range (e.g. unit-range CROSS_ENTROPY
+  // clamped to [0, 1] vs unbounded MSE); custom JS costs fall back to the
+  // legacy `error <= targetError` comparator as a regression guard.
+  const earlyStop = shouldEarlyStop(error, config.targetError, config.costName);
+  const completed = ctx.interrupted || timedOut || earlyStop ||
+    generation >= config.iterations;
+
+  return {
+    bestCreature,
+    bestScore,
+    error,
+    championImproved,
+    now,
+    timedOut,
+    phaseTiming,
+    earlyStop,
+    completed,
+  };
+}

--- a/test/creature/EvolveGenerationTail.ts
+++ b/test/creature/EvolveGenerationTail.ts
@@ -1,0 +1,372 @@
+/**
+ * Tests for the shared end-of-generation bookkeeping used by `evolveDir`,
+ * `evolveEnv`, and `evolveRL` (Issue #3636).
+ *
+ * These call the real {@link finishGeneration} with real configs, real
+ * accumulators and real creatures, asserting on the observable outcome —
+ * adopted champion, emitted events, accumulated totals, stop decision. No
+ * timing APIs are relied upon, so they are deterministic under the parallel
+ * test runner.
+ */
+
+import {
+  assert,
+  assertEquals,
+  AssertionError,
+  assertNotStrictEquals,
+  assertRejects,
+} from "@std/assert";
+import { addTag } from "@stsoftware/tags/mod";
+import { Creature } from "@creature";
+import { createNeatConfig } from "@config/NeatConfig.ts";
+import type {
+  GenerationPhaseTiming,
+  GenerationThroughputMetrics,
+  TrainingEvent,
+} from "@config/TrainingEvent.ts";
+import type { NeatOptions } from "@config/NeatOptions.ts";
+import type { EvolveResult } from "@neat/NeatEvolution.ts";
+import {
+  finishGeneration,
+  type GenerationTailContext,
+  type GenerationTailSource,
+} from "@creature/EvolveGenerationTail.ts";
+import { createPhaseTimingAccumulator } from "@creature/PhaseTimingTotals.ts";
+import { createScorerUtilisationAccumulator } from "@creature/ScorerUtilisationTotals.ts";
+import { createScoreTrajectory } from "@creature/ScoreImprovementMilestones.ts";
+
+const PHASE_TIMING: GenerationPhaseTiming = {
+  fitnessMs: 10,
+  breedingMs: 4,
+  resultProcessingMs: 1,
+  totalMs: 20,
+  mutationMs: 2,
+  deduplicationMs: 1,
+  speciationMs: 1,
+  sortMs: 1,
+  writeScoresMs: 1,
+};
+
+const THROUGHPUT: GenerationThroughputMetrics = {
+  wallClockMs: 20,
+  nonFitnessMs: 10,
+  generationsPerHour: 180000,
+  fastBusyMs: 5,
+  fastIdleMs: 15,
+  fastQueueMaxDepth: 1,
+  fastWaitMs: 0,
+  heavyBusyMs: 0,
+  heavyIdleMs: 0,
+  heavyQueueMaxDepth: 0,
+  heavyWaitMs: 0,
+  scoredCreatureCount: 4,
+  scorerMs: 10,
+  creaturesPerSec: 200,
+  corruptParentSkips: 0,
+};
+
+/** A creature tagged as `evolve()` leaves its fittest. */
+function makeFittest(score: number, errorTag: string): Creature {
+  const creature = new Creature(2, 1);
+  creature.score = score;
+  addTag(creature, "error", errorTag);
+  return creature;
+}
+
+function makeResult(
+  fittest: Creature,
+  overrides: Partial<EvolveResult> = {},
+): EvolveResult {
+  return {
+    fittest,
+    averageScore: -0.5,
+    plateau: {
+      onPlateau: false,
+      generationsOnPlateau: 0,
+      improvementRate: null,
+      mutationMultiplier: 1,
+    },
+    phaseTiming: PHASE_TIMING,
+    throughput: THROUGHPUT,
+    squashHistogram: { LOGISTIC: 3 },
+    topologyAverages: { averageNeurons: 4, averageSynapses: 6 },
+    ...overrides,
+  };
+}
+
+function makeSource(
+  population: Creature[],
+  utilisation: Partial<GenerationTailSource["fitness"]> = {},
+): GenerationTailSource {
+  return {
+    population,
+    warmupGenerations: 0,
+    currentGeneration: 1,
+    fitness: {
+      lastBatchScorerInvocations: 1,
+      lastCreaturesBatchScored: 3,
+      lastCreaturesPerCreatureScored: 2,
+      lastBatchFallbackOccurred: false,
+      ...utilisation,
+    },
+  };
+}
+
+/** Build a context with fresh accumulators; overrides tune a single field. */
+function makeContext(
+  result: EvolveResult,
+  options: NeatOptions = {},
+  overrides: Partial<GenerationTailContext> = {},
+): GenerationTailContext {
+  const now = Date.now();
+  return {
+    neat: makeSource([result.fittest]),
+    config: createNeatConfig({ iterations: 100, targetError: 0, ...options }),
+    result,
+    generation: 1,
+    start: now,
+    iterationStartMS: now,
+    endTimeMS: 0,
+    interrupted: false,
+    bestScore: -Infinity,
+    error: Infinity,
+    bestCreature: undefined,
+    phaseTimingAccumulator: createPhaseTimingAccumulator(),
+    scorerUtilisationAccumulator: createScorerUtilisationAccumulator(),
+    scoreTrajectory: createScoreTrajectory(),
+    ...overrides,
+  };
+}
+
+Deno.test("finishGeneration adopts an improved champion", async () => {
+  const fittest = makeFittest(-0.25, "0.25");
+  const ctx = makeContext(makeResult(fittest));
+
+  const outcome = await finishGeneration(ctx);
+
+  assertEquals(outcome.championImproved, true);
+  assertEquals(outcome.bestScore, -0.25);
+  assertEquals(outcome.error, 0.25);
+  assert(outcome.bestCreature !== undefined, "champion clone expected");
+  assertNotStrictEquals(
+    outcome.bestCreature,
+    fittest,
+    "champion must be a clone, not the live fittest",
+  );
+  assertEquals(outcome.bestCreature.score, -0.25);
+  assertEquals(ctx.scoreTrajectory.points.length, 1);
+  assertEquals(ctx.scoreTrajectory.points[0].generation, 1);
+  assertEquals(ctx.scoreTrajectory.points[0].score, -0.25);
+  // scoredCount is read after the utilisation accumulator advanced (3 + 2).
+  assertEquals(ctx.scoreTrajectory.points[0].scoredCount, 5);
+});
+
+Deno.test("finishGeneration keeps the champion when no improvement", async () => {
+  // The champion is bred forward as an elite, so the generation's fittest can
+  // tie the best score but never fall below it.
+  const previous = makeFittest(-0.1, "0.1");
+  const fittest = makeFittest(-0.1, "0.1");
+  const ctx = makeContext(makeResult(fittest), {}, {
+    bestScore: -0.1,
+    error: 0.1,
+    bestCreature: previous,
+  });
+
+  const outcome = await finishGeneration(ctx);
+
+  assertEquals(outcome.championImproved, false);
+  assertEquals(outcome.bestScore, -0.1);
+  assertEquals(outcome.error, 0.1);
+  assertEquals(outcome.bestCreature, previous);
+  assertEquals(ctx.scoreTrajectory.points.length, 0);
+});
+
+Deno.test("finishGeneration fails loud on a non-finite error tag", async () => {
+  // All three loops reject an unbounded error tag rather than adopting a
+  // champion whose error cannot be compared against `targetError`.
+  await Promise.all(
+    ["Infinity", "NaN", "not-a-number"].map((tag) =>
+      assertRejects(
+        () => finishGeneration(makeContext(makeResult(makeFittest(-1, tag)))),
+        AssertionError,
+        "Error is not finite",
+      )
+    ),
+  );
+});
+
+Deno.test("finishGeneration fails loud on a negative error tag", async () => {
+  const ctx = makeContext(makeResult(makeFittest(-1, "-0.5")));
+
+  await assertRejects(
+    () => finishGeneration(ctx),
+    AssertionError,
+    "Error is negative",
+  );
+});
+
+Deno.test("finishGeneration emits generation_complete", async () => {
+  const events: TrainingEvent[] = [];
+  const fittest = makeFittest(-0.25, "0.25");
+  const result = makeResult(fittest);
+  const ctx = makeContext(result, {
+    onTrainingEvent: (event: TrainingEvent) => events.push(event),
+  });
+
+  await finishGeneration(ctx);
+
+  assertEquals(events.length, 1);
+  const event = events[0];
+  assert(event.kind === "generation_complete", "expected generation_complete");
+  assertEquals(event.generation, 1);
+  assertEquals(event.bestFitness, -0.25);
+  assertEquals(event.averageFitness, -0.5);
+  assertEquals(event.populationSize, 1);
+  assertEquals(event.averageNeurons, 4);
+  assertEquals(event.averageSynapses, 6);
+  assertEquals(event.phaseTiming, PHASE_TIMING);
+  assertEquals(event.throughput, THROUGHPUT);
+  assertEquals(event.squashHistogram, { LOGISTIC: 3 });
+});
+
+Deno.test("finishGeneration emits plateau_detected only on a plateau", async () => {
+  const events: TrainingEvent[] = [];
+  const onTrainingEvent = (event: TrainingEvent) => events.push(event);
+
+  const calm = makeContext(makeResult(makeFittest(-0.25, "0.25")), {
+    onTrainingEvent,
+  });
+  await finishGeneration(calm);
+  assertEquals(events.filter((e) => e.kind === "plateau_detected").length, 0);
+
+  const stuck = makeContext(
+    makeResult(makeFittest(-0.25, "0.25"), {
+      plateau: {
+        onPlateau: true,
+        generationsOnPlateau: 7,
+        improvementRate: 0,
+        mutationMultiplier: 2,
+      },
+    }),
+    { onTrainingEvent },
+  );
+  await finishGeneration(stuck);
+
+  const plateaus = events.filter((e) => e.kind === "plateau_detected");
+  assertEquals(plateaus.length, 1);
+  assert(plateaus[0].kind === "plateau_detected");
+  assertEquals(plateaus[0].stagnationCount, 7);
+  assertEquals(plateaus[0].mutationMultiplier, 2);
+});
+
+Deno.test("finishGeneration accumulates timings and scorer counts", async () => {
+  const ctx = makeContext(makeResult(makeFittest(-0.5, "0.5")));
+  await finishGeneration(ctx);
+
+  const second = {
+    ...ctx,
+    generation: 2,
+    bestScore: -0.5,
+    error: 0.5,
+    result: makeResult(makeFittest(-0.25, "0.25")),
+  };
+  await finishGeneration(second);
+
+  assertEquals(ctx.phaseTimingAccumulator.generations, 2);
+  assertEquals(ctx.phaseTimingAccumulator.fitnessMs, 20);
+  assertEquals(ctx.phaseTimingAccumulator.breedingMs, 8);
+  assertEquals(ctx.scorerUtilisationAccumulator.generations, 2);
+  assertEquals(ctx.scorerUtilisationAccumulator.creaturesBatchScored, 6);
+  assertEquals(ctx.scorerUtilisationAccumulator.creaturesPerCreatureScored, 4);
+  assertEquals(ctx.scorerUtilisationAccumulator.batchFallbackGenerations, 0);
+});
+
+Deno.test("finishGeneration times the checkpoint write", async () => {
+  const dir = await Deno.makeTempDir({ prefix: "generation-tail-" });
+  try {
+    const fittest = makeFittest(-0.25, "0.25");
+    const ctx = makeContext(makeResult(fittest), {
+      creatureStore: dir,
+      checkpointEveryGeneration: true,
+    });
+
+    const outcome = await finishGeneration(ctx);
+
+    assert(
+      outcome.phaseTiming.checkpointWriteMs !== undefined,
+      "checkpoint write must be timed onto the generation's phase timing",
+    );
+    assert(outcome.phaseTiming.checkpointWriteMs >= 0);
+    // The population was actually written out.
+    const written: string[] = [];
+    for await (const entry of Deno.readDir(dir)) written.push(entry.name);
+    assertEquals(written, ["1.json"]);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("finishGeneration leaves phase timing untouched without a store", async () => {
+  const ctx = makeContext(makeResult(makeFittest(-0.25, "0.25")), {
+    checkpointEveryGeneration: true,
+  });
+
+  const outcome = await finishGeneration(ctx);
+
+  assertEquals(outcome.phaseTiming, PHASE_TIMING);
+});
+
+Deno.test("finishGeneration completes when the error meets targetError", async () => {
+  const ctx = makeContext(makeResult(makeFittest(-0.05, "0.05")), {
+    targetError: 0.1,
+  });
+
+  const outcome = await finishGeneration(ctx);
+
+  assertEquals(outcome.earlyStop, true);
+  assertEquals(outcome.completed, true);
+});
+
+Deno.test("finishGeneration completes at the iteration limit", async () => {
+  const ctx = makeContext(makeResult(makeFittest(-0.5, "0.5")), {
+    iterations: 3,
+  }, { generation: 3 });
+
+  const outcome = await finishGeneration(ctx);
+
+  assertEquals(outcome.earlyStop, false);
+  assertEquals(outcome.completed, true);
+});
+
+Deno.test("finishGeneration completes when interrupted", async () => {
+  const ctx = makeContext(makeResult(makeFittest(-0.5, "0.5")), {}, {
+    interrupted: true,
+  });
+
+  const outcome = await finishGeneration(ctx);
+
+  assertEquals(outcome.timedOut, false);
+  assertEquals(outcome.completed, true);
+});
+
+Deno.test("finishGeneration reports a timeout past endTimeMS", async () => {
+  const ctx = makeContext(makeResult(makeFittest(-0.5, "0.5")), {}, {
+    endTimeMS: Date.now() - 60_000,
+  });
+
+  const outcome = await finishGeneration(ctx);
+
+  assertEquals(outcome.timedOut, true);
+  assertEquals(outcome.completed, true);
+});
+
+Deno.test("finishGeneration keeps running mid-run", async () => {
+  const ctx = makeContext(makeResult(makeFittest(-0.5, "0.5")), {
+    iterations: 10,
+    targetError: 0,
+  }, { generation: 2 });
+
+  const outcome = await finishGeneration(ctx);
+
+  assertEquals(outcome.completed, false);
+});


### PR DESCRIPTION
# Extract the shared generation-loop tail (Issue #3636)

## Summary

The end-of-generation bookkeeping — champion adoption, the optionally timed
checkpoint write, phase-timing and scorer-utilisation accumulation, the
score-trajectory snapshot, the `generation_complete` and `plateau_detected`
emissions, and the cost-aware early-stop decision — was copy-pasted into all
three training loops in `src/creature/CreatureTraining.ts` (`evolveDir`,
`evolveEnv`, `evolveRL`). Six separate changes (#3210, #3234, #3422, #3402,
#3263, #2947) each had to be applied three times, and the copies had already
drifted: `evolveEnv` and `evolveRL` parsed the error tag through an `"Infinity"`
ternary that `evolveDir` lacked.

This PR moves that rule into one place — `finishGeneration()` in the new
`src/creature/EvolveGenerationTail.ts` — with three call sites. Genuinely
variant-specific work stays in each loop: `evolveDir`'s score/error consistency
assert and `evolveRL`'s milestone capture. No mode flags are passed to the
helper.

Behaviour is unchanged. The drifted error-tag parse is unified on the explicit
`"Infinity"` form, which was already behaviourally inert
(`Number.parseFloat("Infinity") === Infinity`, and the following
`Number.isFinite` assert rejects it either way — a non-finite error tag still
fails loud in all three loops).

`CreatureTraining.ts` drops 275 net lines (1833 → 1558). No public API or event
payload changed, so `docs/api/EVOLUTION.md` needs no update.

Closes #3636.

## Evidence

Backend/library change — no web interface to screenshot. Verified by the unit
tests below plus the existing `evolveDir` / `evolveEnv` / `evolveRL` integration
suites (which assert on the emitted `generation_complete` payloads, the
run-level `phaseTimingTotals` / `scorerUtilisation` totals, the RL milestone
sequence, and the early-stop and hard-deadline behaviour).

Before — the same tail inlined three times:

```mermaid
flowchart TB
    subgraph before [Before]
        A1[evolveDir loop] --> T1[adopt champion → checkpoint → accumulate<br/>→ trajectory → events → early stop]
        A2[evolveEnv loop] --> T2[adopt champion → checkpoint → accumulate<br/>→ trajectory → events → early stop]
        A3[evolveRL loop] --> T3[adopt champion → checkpoint → accumulate<br/>→ trajectory → events → early stop]
    end
```

After — one helper, three call sites, variant-specific work left in the loops:

```mermaid
flowchart TB
    subgraph after [After]
        B1[evolveDir loop] --> F[finishGeneration]
        B2[evolveEnv loop] --> F
        B3[evolveRL loop] --> F
        B1 --> V1[score/error consistency assert]
        B3 --> V3[RL milestone capture]
        F --> O[champion state + stop decision]
    end
```

Quality gate: `./quality.sh` run clean (fmt, lint, bash syntax, type-check,
discovery, WASM sync, full test suite).

## Test Plan

New unit tests in `test/creature/EvolveGenerationTail.ts` call the real
`finishGeneration()` with real configs, accumulators and creatures:

- `adopts an improved champion` — champion clone, best score/error, and the
  score-trajectory point (including the cumulative scored-count).
- `keeps the champion when no improvement` — champion, error, and trajectory
  untouched on a tie.
- `fails loud on a non-finite error tag` — `Infinity`, `NaN` and unparseable
  tags all reject rather than adopting an incomparable champion.
- `fails loud on a negative error tag`.
- `emits generation_complete` — asserts every field of the payload.
- `emits plateau_detected only on a plateau`.
- `accumulates timings and scorer counts` — two generations summed into the
  run-level accumulators.
- `times the checkpoint write` — `checkpointWriteMs` present and the population
  actually written to the store.
- `leaves phase timing untouched without a store`.
- Stop decision — early stop on `targetError`, the iteration limit, SIGTERM
  interruption, a passed `endTimeMS`, and staying un-completed mid-run.

No existing tests were modified or removed.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mscbpwfy-f785a4`<!-- vibe-worker-issue-3636 -->