### PR TITLE
Remove `parallelEvaluation.maxConcurrentEvaluations` — inert default, superseded by the #2245 worker-pool split (#3505 slice E) (Issue #3566)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -246,6 +246,16 @@ adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).
   `LARGE_NETWORK_PRESET` block that advertised "adapt mutation to stability",
   and the documentation and troubleshooting advice describing it as a working
   lever are all gone.
+- **Issue #3566:** Removed `parallelEvaluation.maxConcurrentEvaluations` (#3505
+  audit, slice E). It defaulted to `0`, and `0` made the only branch reading it
+  a no-op, so evaluation already ran on every supplied worker — the removal is
+  **behaviour-preserving**. Its purpose (reserving workers for training and
+  discovery) was superseded by the #2245 fast/heavy worker-pool split, which
+  hands evaluation only fast-pool workers; size the heavy pool with
+  `heavyTaskWorkerCount` instead. **Breaking for embedders that set it:**
+  passing `parallelEvaluation.maxConcurrentEvaluations` is now a `deno check`
+  error. `parallelEvaluation.topologyGrouping` and the parent
+  `parallelEvaluation` key are untouched.
 
 ## [5.2.0] - 2026-05-30
 

--- a/bench/ParallelEvaluation.ts
+++ b/bench/ParallelEvaluation.ts
@@ -85,7 +85,6 @@ Deno.bench({
   baseline: true,
   async fn() {
     const evalConfig: RequiredParallelEvaluationConfig = {
-      maxConcurrentEvaluations: 0,
       topologyGrouping: false,
     };
     const fitness = new Fitness(workers, 0.0001, false, evalConfig);
@@ -99,7 +98,6 @@ Deno.bench({
   group: "100 creatures, 5 topologies",
   async fn() {
     const evalConfig: RequiredParallelEvaluationConfig = {
-      maxConcurrentEvaluations: 0,
       topologyGrouping: true,
     };
     const fitness = new Fitness(workers, 0.0001, false, evalConfig);
@@ -114,7 +112,6 @@ Deno.bench({
   baseline: true,
   async fn() {
     const evalConfig: RequiredParallelEvaluationConfig = {
-      maxConcurrentEvaluations: 0,
       topologyGrouping: false,
     };
     const fitness = new Fitness(workers, 0.0001, false, evalConfig);
@@ -128,7 +125,6 @@ Deno.bench({
   group: "500 creatures, 10 topologies",
   async fn() {
     const evalConfig: RequiredParallelEvaluationConfig = {
-      maxConcurrentEvaluations: 0,
       topologyGrouping: true,
     };
     const fitness = new Fitness(workers, 0.0001, false, evalConfig);

--- a/bench/ScorerBatchThroughput.ts
+++ b/bench/ScorerBatchThroughput.ts
@@ -122,7 +122,6 @@ async function runOnce(
 ): Promise<BenchResult> {
   const config: RequiredParallelEvaluationConfig = {
     topologyGrouping: mode === "batch",
-    maxConcurrentEvaluations: 0,
   };
 
   // Use a small worker pool so scheduling matters; values mirror a typical

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "6.2.8",
+  "version": "6.2.9",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/api/CONFIGURATION.md
+++ b/docs/api/CONFIGURATION.md
@@ -258,10 +258,9 @@ convergence progress. Defaults via `DEFAULT_ADAPTIVE_POPULATION_CONFIG`.
 
 ### `parallelEvaluation` — ParallelEvaluationConfig
 
-Issue #1862: controls topology-aware grouping and concurrency limits for
-population fitness evaluation. Topology grouping clusters same-structure
-creatures to maximise WASM (WebAssembly) cache hits. Defaults via
-`DEFAULT_PARALLEL_EVALUATION_CONFIG`.
+Issue #1862: controls topology-aware grouping for population fitness evaluation.
+Topology grouping clusters same-structure creatures to maximise WASM
+(WebAssembly) cache hits. Defaults via `DEFAULT_PARALLEL_EVALUATION_CONFIG`.
 
 ### `dataFuzzing` — DataFuzzingConfig
 

--- a/docs/archive/pr-summaries/pr-summary-3566.md
+++ b/docs/archive/pr-summaries/pr-summary-3566.md
@@ -1,0 +1,115 @@
+# Remove `parallelEvaluation.maxConcurrentEvaluations` (Issue #3566)
+
+## Summary
+
+Removed the `parallelEvaluation.maxConcurrentEvaluations` option — slice E of
+the #3505 option-removal audit, following the #3502 / #3562 removal pattern.
+Closes #3566.
+
+The field defaulted to `0`, and with `0` the only branch that read it took the
+un-sliced `allWorkers` path, so it never changed behaviour in any run. Its
+original purpose (#1862 — reserve workers for training and discovery while
+evaluation runs) was superseded by the #2245 fast/heavy worker-pool split:
+evaluation now receives only fast-pool workers, which never run discovery or
+training. Callers who genuinely want to reserve capacity size the heavy pool
+with `heavyTaskWorkerCount`. The same #2245 change removed the sibling
+`busyWorkerWaitMs` for exactly this reason.
+
+`parallelEvaluation.topologyGrouping` and the parent `parallelEvaluation` key
+are untouched — `topologyGrouping` defaults to `true` and drives
+`EvaluationScheduling` on every generation.
+
+**Breaking for embedders that set it:** passing
+`parallelEvaluation.maxConcurrentEvaluations` is now a `deno check` error. No
+consumer sets it (verified in the issue's cross-repo sweep — zero camelCase,
+env-var, and code-search hits in both downstream repos), so the runtime
+behaviour of every existing configuration is unchanged.
+
+### Removal surface
+
+| Area         | Change                                                                                                        |
+| ------------ | ------------------------------------------------------------------------------------------------------------- |
+| Option       | `src/config/ParallelEvaluationConfig.ts` — interface field and `DEFAULT_PARALLEL_EVALUATION_CONFIG` entry     |
+| Parsing      | `src/config/parsers/RuntimeParsers.ts` — the `parseParallelEvaluation` `parseNumber` block                    |
+| Plumbing     | `src/architecture/Fitness.ts` — the `maxConcurrent` ternary; `activeWorkers` collapses into `allWorkers`      |
+| Bench        | `bench/ParallelEvaluation.ts` (4 lines), `bench/ScorerBatchThroughput.ts` (1 line) — all inert `: 0` literals |
+| Tests        | Config, parser, and Fitness suites (see Test Plan)                                                            |
+| Docs         | `docs/config/WORKERS.md`, `docs/comparison/FUTURE_WORK.md`, `docs/api/CONFIGURATION.md`, `CHANGELOG.md`       |
+| Option audit | `scripts/lib/optionAuditRollup.ts` — the stale `QUALIFIES` field override on the `parallelEvaluation` entry   |
+
+## Evidence
+
+Backend/library change with no web interface — no screenshot applies. The
+evidence is the quality gate and the behaviour-equivalence argument below.
+
+### Why the removal is behaviour-preserving
+
+```mermaid
+flowchart LR
+    subgraph Before["Before (#1862)"]
+        A1[fast pool + idle heavy assistants] --> B1{maxConcurrent > 0?}
+        B1 -- "no — always, default 0" --> C1[allWorkers]
+        B1 -. "never taken" .-> D1[allWorkers.slice 0, n]
+        C1 --> E1[work-stealing queue]
+    end
+    subgraph After["After (#3566)"]
+        A2[fast pool + idle heavy assistants] --> C2[allWorkers] --> E2[work-stealing queue]
+    end
+```
+
+The dead branch is the whole change: with the default of `0` the ternary always
+resolved to `allWorkers`, which is now the only expression.
+
+### Quality gate
+
+`./quality.sh < /dev/null` passes cleanly:
+
+```
+ok | 8136 passed (5 steps) | 0 failed | 4 ignored (5m8s)
+```
+
+## Test Plan
+
+**Added regression guards** (both fail if the option is reintroduced):
+
+- `test/config/ParallelEvaluationConfig.ts::ParallelEvaluationConfig -
+  maxConcurrentEvaluations is gone (Issue #3566)`
+  — asserts the key is absent from `DEFAULT_PARALLEL_EVALUATION_CONFIG` and that
+  an override naming it is not carried into the parsed config.
+- `test/config/parsers/RuntimeParsers.ts::parseParallelEvaluation - drops
+  removed maxConcurrentEvaluations (#3566)`
+  — asserts `parseParallelEvaluation` does not parse the key back in.
+
+**Rewritten:**
+
+- `test/architecture/BatchCreatureEvaluation.ts` —
+  `Fitness -
+  maxConcurrentEvaluations 0 uses all workers` renamed to
+  `Fitness - every
+  supplied worker is available for evaluation`; it covered
+  the surviving behaviour already, so its assertions are unchanged.
+- `test/config/ParallelEvaluationConfig.ts` — the default, override, partial
+  merge, and frozen-config tests now exercise `topologyGrouping`. The
+  CLI-coercion and `>= 0` validation tests went with the only numeric field.
+
+**Removed (documented business-logic change — the behaviour they asserted no
+longer exists; each file records why in its header comment):**
+
+- `test/architecture/BatchCreatureEvaluation.ts::Fitness -
+  maxConcurrentEvaluations limits active workers`
+- `test/architecture/FitnessBusyWorkerWait.ts::Fitness maxConcurrentEvaluations
+  still caps fast-pool worker usage`
+- `test/architecture/FitnessDynamicPool.ts::Fitness.calculate with additional
+  workers respects maxConcurrentEvaluations`
+
+**Unchanged and still passing** (inert `maxConcurrentEvaluations: 0` literals
+dropped from their fixtures): `FitnessScorerTelemetry.ts`,
+`FitnessTopologyGrouping.ts`, `test/scripts/OptionAuditRollup.ts` — the last of
+which mechanically re-reconciles the audit roll-up against the live config
+surface, so a stale roll-up entry would fail CI.
+
+## Security self-check
+
+No new input handling, no new dependency, no new endpoint or privileged
+operation. The change deletes a configuration field and one branch; the
+validation removed with it (`min: 0`) guarded only that deleted field.

--- a/docs/comparison/FUTURE_WORK.md
+++ b/docs/comparison/FUTURE_WORK.md
@@ -109,8 +109,8 @@ mini-batch gradient descent.
 **What we have**:
 
 - ✅ **Parallel batch creature evaluation** (`ParallelEvaluationConfig`):
-  topology-aware grouping maximises WASM compilation cache hits, with
-  configurable concurrency via `maxConcurrentEvaluations`.
+  topology-aware grouping maximises WASM compilation cache hits, spread across
+  every worker in the fast pool.
 - **Batch discovery validation** (`BatchDiscoveryValidator`): validates multiple
   candidates per call with type-based grouping, result caching, and early-exit.
 - **Mini-batch gradient descent**: configurable batch sizes for backpropagation.

--- a/docs/config/WORKERS.md
+++ b/docs/config/WORKERS.md
@@ -13,20 +13,19 @@ const config = createNeatConfig({
   threads: 8,
   heavyTaskWorkerCount: 2,
   workerThreadCap: { maxMemoryMB: 8192, estimatedMemoryPerWorkerMB: 2048 },
-  parallelEvaluation: { topologyGrouping: true, maxConcurrentEvaluations: 0 },
+  parallelEvaluation: { topologyGrouping: true },
 });
 ```
 
 ## 📊 Quick reference
 
-| Option                                        | Type      | Default                                                          | Description                                       |
-| --------------------------------------------- | --------- | ---------------------------------------------------------------- | ------------------------------------------------- |
-| `threads`                                     | `integer` | `navigator.hardwareConcurrency + heavyTaskWorkerCount` (default) | Worker threads (min: 1)                           |
-| `heavyTaskWorkerCount`                        | `integer` | `2`                                                              | Workers dedicated to discovery/training (min: 1)  |
-| `workerThreadCap.maxMemoryMB`                 | `integer` | `0` (disabled)                                                   | Total memory budget for workers (MB)              |
-| `workerThreadCap.estimatedMemoryPerWorkerMB`  | `integer` | `2048`                                                           | Estimated memory per worker (MB)                  |
-| `parallelEvaluation.topologyGrouping`         | `boolean` | `true`                                                           | Group same-topology creatures for WASM cache hits |
-| `parallelEvaluation.maxConcurrentEvaluations` | `integer` | `0` (all)                                                        | Max workers for evaluation                        |
+| Option                                       | Type      | Default                                                          | Description                                       |
+| -------------------------------------------- | --------- | ---------------------------------------------------------------- | ------------------------------------------------- |
+| `threads`                                    | `integer` | `navigator.hardwareConcurrency + heavyTaskWorkerCount` (default) | Worker threads (min: 1)                           |
+| `heavyTaskWorkerCount`                       | `integer` | `2`                                                              | Workers dedicated to discovery/training (min: 1)  |
+| `workerThreadCap.maxMemoryMB`                | `integer` | `0` (disabled)                                                   | Total memory budget for workers (MB)              |
+| `workerThreadCap.estimatedMemoryPerWorkerMB` | `integer` | `2048`                                                           | Estimated memory per worker (MB)                  |
+| `parallelEvaluation.topologyGrouping`        | `boolean` | `true`                                                           | Group same-topology creatures for WASM cache hits |
 
 ## 🧮 Sizing the pool
 
@@ -102,21 +101,22 @@ Pass as `parallelEvaluation` in options.
 const config = createNeatConfig({
   parallelEvaluation: {
     topologyGrouping: true, // default
-    maxConcurrentEvaluations: 4, // cap at 4 workers for evaluation
   },
 });
 ```
 
-| Option                     | Type      | Default   | Description                                                     |
-| -------------------------- | --------- | --------- | --------------------------------------------------------------- |
-| `topologyGrouping`         | `boolean` | `true`    | Group creatures by topology hash to improve WASM cache hit rate |
-| `maxConcurrentEvaluations` | `integer` | `0` (all) | Maximum workers for evaluation — 0 means use all available      |
+| Option             | Type      | Default | Description                                                     |
+| ------------------ | --------- | ------- | --------------------------------------------------------------- |
+| `topologyGrouping` | `boolean` | `true`  | Group creatures by topology hash to improve WASM cache hit rate |
 
 > [!TIP]
 > Keep `topologyGrouping` enabled unless you have a specific reason to disable
 > it. Topology grouping improves WASM cache utilisation by batching same-shape
-> creatures together. Set `maxConcurrentEvaluations` when you need to reserve
-> workers for concurrent training or discovery tasks.
+> creatures together. Every worker handed to evaluation participates — to
+> reserve capacity for concurrent training or discovery, size the heavy pool
+> with `heavyTaskWorkerCount` rather than capping evaluation. (Issue #3566
+> removed the inert `maxConcurrentEvaluations` cap, which defaulted to "no
+> cap".)
 
 ## ✅ Validation rules
 

--- a/scripts/lib/optionAuditRollup.ts
+++ b/scripts/lib/optionAuditRollup.ts
@@ -314,9 +314,9 @@ const SLICE_E: RollupEntry[] = [
     interfaces: [
       "src/config/ParallelEvaluationConfig.ts::ParallelEvaluationConfig",
     ],
-    fieldOverrides: {
-      maxConcurrentEvaluations: { verdict: "QUALIFIES", issue: 3566 },
-    },
+    note:
+      "`maxConcurrentEvaluations` was the one QUALIFIES field; #3566 removed " +
+      "it, leaving `topologyGrouping` as the load-bearing default.",
   }),
   keep("wasmCache", "E", {
     interfaces: ["src/config/WasmCacheConfig.ts::WasmCacheConfig"],

--- a/src/architecture/Fitness.ts
+++ b/src/architecture/Fitness.ts
@@ -29,14 +29,17 @@ import { BUILT_IN_COST_NAMES, type BuiltInCostName } from "@costs";
  * with identical UUIDs are evaluated once and the score is copied to all
  * duplicates.
  *
- * Issue #1862: Supports topology-aware grouping and configurable concurrency.
- * When topology grouping is enabled, creatures with identical network structure
- * are adjacent in the evaluation queue, maximising WASM compilation cache hits.
- * The maxConcurrentEvaluations setting caps how many workers participate.
+ * Issue #1862: Supports topology-aware grouping. When topology grouping is
+ * enabled, creatures with identical network structure are adjacent in the
+ * evaluation queue, maximising WASM compilation cache hits.
  *
  * Issue #2245: Receives only fast-pool workers that are dedicated to
  * evaluation. This eliminates the need for reactive `isRunningLongTask()`
  * filtering since fast-pool workers never run discovery or training.
+ *
+ * Issue #3566: Every supplied worker participates. The `maxConcurrentEvaluations`
+ * cap was removed — it defaulted to "no cap", and the fast/heavy pool split
+ * already reserves capacity for training and discovery.
  */
 export class Fitness {
   private workers: WorkerHandler[];
@@ -161,7 +164,7 @@ export class Fitness {
    * Issue #1289: Distributes evaluations across the worker pool using a
    * work-stealing pattern for parallel execution.
    * Issue #1862: Optionally groups creatures by topology hash for better
-   * WASM cache utilisation, and caps concurrent evaluations.
+   * WASM cache utilisation.
    *
    * @param population - Array of creatures to evaluate
    * @param additionalWorkers - Issue #2313: Extra workers (e.g. idle heavy-pool
@@ -381,18 +384,13 @@ export class Fitness {
 
     // Issue #2313: Combine dedicated fast-pool workers with any idle
     // heavy-pool workers temporarily assisting this evaluation.
+    // Issue #2245: Every worker here is dedicated to evaluation, so no
+    // isRunningLongTask() filtering or busy-worker fallback is needed.
+    // Issue #3566: All of them evaluate — the removed maxConcurrentEvaluations
+    // cap defaulted to 0 (no cap), so this was already the only behaviour.
     const allWorkers = additionalWorkers && additionalWorkers.length > 0
       ? [...this.workers, ...additionalWorkers]
       : this.workers;
-
-    // Issue #1862: Cap the number of concurrent workers if configured.
-    // Issue #2245: Workers are now guaranteed to be from the fast pool
-    // (dedicated to evaluation), so no isRunningLongTask() filtering
-    // or busy-worker fallback is needed.
-    const maxConcurrent = this.evalConfig.maxConcurrentEvaluations;
-    const activeWorkers = maxConcurrent > 0
-      ? allWorkers.slice(0, maxConcurrent)
-      : allWorkers;
 
     const processNext = async (worker: WorkerHandler): Promise<void> => {
       if (front >= queue.length) return;
@@ -459,7 +457,7 @@ export class Fitness {
     };
 
     // Start all active workers processing the queue concurrently
-    await Promise.all(activeWorkers.map((worker) => processNext(worker)));
+    await Promise.all(allWorkers.map((worker) => processNext(worker)));
 
     // Issue #2424: Publish scorer telemetry for throughput metrics assembly.
     this.lastScorerMs = scorerMsAccum;

--- a/src/config/ParallelEvaluationConfig.ts
+++ b/src/config/ParallelEvaluationConfig.ts
@@ -10,15 +10,15 @@
  * by topology hash so same-topology creatures cluster together and
  * naturally flow to the same worker via the work-stealing pattern.
  *
- * `maxConcurrentEvaluations` allows capping the number of workers
- * used for evaluation independently from the total thread count,
- * which is useful when other tasks (training, discovery) need
- * workers concurrently.
- *
  * Issue #2245: The `busyWorkerWaitMs` option was removed because fitness
  * evaluation now receives only fast-pool workers that are dedicated to
  * evaluation and never run discovery or training. The reactive
  * `isRunningLongTask()` filtering is no longer needed.
+ *
+ * Issue #3566: `maxConcurrentEvaluations` was removed for the same reason —
+ * it defaulted to 0 (use every worker), so its branch never fired, and the
+ * fast/heavy pool split already reserves capacity for training and discovery.
+ * Size the heavy pool with `heavyTaskWorkerCount` instead.
  */
 
 /**
@@ -27,17 +27,6 @@
  * All fields are optional; defaults are applied in `createNeatConfig()`.
  */
 export interface ParallelEvaluationConfig {
-  /**
-   * Maximum number of concurrent creature evaluations.
-   *
-   * Caps how many workers participate in fitness evaluation.
-   * When 0 (default), all available workers are used.
-   *
-   * Useful when other tasks (training, discovery) need workers
-   * concurrently and you want to reserve capacity for them.
-   */
-  maxConcurrentEvaluations?: number;
-
   /**
    * Whether to group creatures by topology hash before evaluation.
    *
@@ -61,11 +50,9 @@ export type RequiredParallelEvaluationConfig = Required<
 /**
  * Default values for parallel evaluation configuration.
  *
- * `maxConcurrentEvaluations` defaults to 0 (use all workers).
  * `topologyGrouping` defaults to true for optimal WASM cache utilisation.
  */
 export const DEFAULT_PARALLEL_EVALUATION_CONFIG:
   RequiredParallelEvaluationConfig = {
-    maxConcurrentEvaluations: 0,
     topologyGrouping: true,
   };

--- a/src/config/parsers/RuntimeParsers.ts
+++ b/src/config/parsers/RuntimeParsers.ts
@@ -144,12 +144,6 @@ export function parseParallelEvaluation(
 ): RequiredParallelEvaluationConfig {
   const d = DEFAULT_PARALLEL_EVALUATION_CONFIG;
   return {
-    maxConcurrentEvaluations: parseNumber(
-      "Parallel evaluation maxConcurrentEvaluations",
-      overrides?.maxConcurrentEvaluations,
-      d.maxConcurrentEvaluations,
-      { integer: true, min: 0 },
-    ),
     topologyGrouping: typeof overrides?.topologyGrouping === "boolean"
       ? overrides.topologyGrouping
       : d.topologyGrouping,

--- a/test/architecture/BatchCreatureEvaluation.ts
+++ b/test/architecture/BatchCreatureEvaluation.ts
@@ -258,56 +258,13 @@ Deno.test("Fitness - topology grouping disabled preserves original order", async
   );
 });
 
-Deno.test("Fitness - maxConcurrentEvaluations limits active workers", async () => {
-  const workers: MockWorkerHandler[] = [];
-  for (let i = 0; i < 4; i++) {
-    workers.push(new MockWorkerHandler());
-  }
-
-  const evalConfig: RequiredParallelEvaluationConfig = {
-    maxConcurrentEvaluations: 2,
-    topologyGrouping: false,
-  };
-
-  const fitness = new Fitness(
-    workers.map((w) => w as unknown as WorkerHandler),
-    0.0001,
-    false,
-    evalConfig,
-  );
-
-  const population = createSameTopologyCreatures(8);
-
-  await fitness.calculate(population);
-
-  // All creatures should have scores
-  for (const creature of population) {
-    assert(creature.score !== undefined, "All creatures should have scores");
-  }
-
-  // Total evaluations should match
-  const totalEvaluations = workers.reduce(
-    (sum, w) => sum + w.evaluateCallCount,
-    0,
-  );
-  assertEquals(totalEvaluations, 8, "Total evaluations should equal 8");
-
-  // Only 2 of 4 workers should have been used (capped at 2)
-  const workersUsed = workers.filter((w) => w.evaluateCallCount > 0).length;
-  assert(
-    workersUsed <= 2,
-    `Only ${evalConfig.maxConcurrentEvaluations} workers should be used, but ${workersUsed} were used`,
-  );
-});
-
-Deno.test("Fitness - maxConcurrentEvaluations 0 uses all workers", async () => {
+Deno.test("Fitness - every supplied worker is available for evaluation", async () => {
   const workers: MockWorkerHandler[] = [];
   for (let i = 0; i < 3; i++) {
     workers.push(new MockWorkerHandler());
   }
 
   const evalConfig: RequiredParallelEvaluationConfig = {
-    maxConcurrentEvaluations: 0,
     topologyGrouping: true,
   };
 
@@ -334,7 +291,7 @@ Deno.test("Fitness - maxConcurrentEvaluations 0 uses all workers", async () => {
   );
   assertEquals(totalEvaluations, 9, "Total evaluations should equal 9");
 
-  // With 0 (all workers), at least 2 workers should be used
+  // Issue #3566: every supplied worker participates — no cap exists.
   const workersUsed = workers.filter((w) => w.evaluateCallCount > 0).length;
   assert(
     workersUsed >= 2,
@@ -346,7 +303,6 @@ Deno.test("Fitness - batch evaluation produces identical results to sequential",
   // Evaluate with topology grouping enabled
   const worker1 = new MockWorkerHandler();
   const evalConfigGrouped: RequiredParallelEvaluationConfig = {
-    maxConcurrentEvaluations: 0,
     topologyGrouping: true,
   };
   const fitnessGrouped = new Fitness(
@@ -359,7 +315,6 @@ Deno.test("Fitness - batch evaluation produces identical results to sequential",
   // Evaluate without topology grouping
   const worker2 = new MockWorkerHandler();
   const evalConfigUngrouped: RequiredParallelEvaluationConfig = {
-    maxConcurrentEvaluations: 0,
     topologyGrouping: false,
   };
   const fitnessUngrouped = new Fitness(
@@ -416,7 +371,6 @@ Deno.test("Fitness - topology grouping with deduplication", async () => {
   const worker2 = new MockWorkerHandler();
 
   const evalConfig: RequiredParallelEvaluationConfig = {
-    maxConcurrentEvaluations: 0,
     topologyGrouping: true,
   };
 
@@ -496,6 +450,5 @@ Deno.test("Fitness - topology grouping with deduplication", async () => {
 });
 
 Deno.test("Fitness - default config has expected values", () => {
-  assertEquals(DEFAULT_PARALLEL_EVALUATION_CONFIG.maxConcurrentEvaluations, 0);
   assertEquals(DEFAULT_PARALLEL_EVALUATION_CONFIG.topologyGrouping, true);
 });

--- a/test/architecture/FitnessBusyWorkerWait.ts
+++ b/test/architecture/FitnessBusyWorkerWait.ts
@@ -12,12 +12,17 @@
  * Fitness works correctly with its dedicated fast-pool workers without
  * any busy-worker filtering or waiting.
  *
+ * BUSINESS LOGIC CHANGE (Issue #3566): the `maxConcurrentEvaluations` cap that
+ * one test here exercised has been removed — it defaulted to 0 (no cap), so no
+ * consumer ever narrowed the pool. That test went with the option; the
+ * remaining tests cover the surviving all-workers-participate behaviour.
+ *
  * Verifies:
  * - Fitness evaluates all creatures using fast-pool workers
  * - Evaluation completes without any busy-worker polling
  * - Multiple fast-pool workers share the evaluation load
  */
-import { assert, assertEquals, assertGreater } from "@std/assert";
+import { assert, assertEquals } from "@std/assert";
 import { Creature } from "@creature";
 import type { CreatureExport } from "@architecture/CreatureInterfaces.ts";
 import { Fitness } from "@architecture/Fitness.ts";
@@ -150,45 +155,5 @@ Deno.test(
         "Creature score should be finite",
       );
     }
-  },
-);
-
-Deno.test(
-  "Fitness maxConcurrentEvaluations still caps fast-pool worker usage",
-  async () => {
-    const worker1 = new MockWorker();
-    const worker2 = new MockWorker();
-    const worker3 = new MockWorker();
-
-    // Cap to 2 workers even though 3 are available
-    const fitness = new Fitness(
-      [worker1, worker2, worker3] as unknown[] as WorkerHandler[],
-      0.0001,
-      false,
-      {
-        maxConcurrentEvaluations: 2,
-        topologyGrouping: false,
-      },
-    );
-
-    const population = [
-      makeCreature(0.1),
-      makeCreature(0.2),
-      makeCreature(0.3),
-    ];
-
-    await fitness.calculate(population);
-
-    const usedEvaluations = worker1.evaluationCount + worker2.evaluationCount;
-    assertGreater(
-      usedEvaluations,
-      0,
-      "Capped workers should have evaluated creatures",
-    );
-    assertEquals(
-      worker3.evaluationCount,
-      0,
-      "Worker beyond maxConcurrentEvaluations should not be used",
-    );
   },
 );

--- a/test/architecture/FitnessDynamicPool.ts
+++ b/test/architecture/FitnessDynamicPool.ts
@@ -7,6 +7,11 @@
  * verifies that `additionalWorkers` passed to `Fitness.calculate()`
  * participate in creature evaluation alongside the regular fast-pool
  * workers.
+ *
+ * BUSINESS LOGIC CHANGE (Issue #3566): a test here asserted that
+ * `maxConcurrentEvaluations: 2` excluded the assisting heavy worker. The
+ * option has been removed — it defaulted to 0 (no cap) and no consumer set
+ * it — so that test went with it; every supplied worker now participates.
  */
 import { assertEquals, assertGreater } from "@std/assert";
 import { Creature } from "@creature";
@@ -156,57 +161,6 @@ Deno.test(
       fastWorker.evaluationCount,
       2,
       "All creatures should be evaluated by the fast worker",
-    );
-  },
-);
-
-Deno.test(
-  "Fitness.calculate with additional workers respects maxConcurrentEvaluations",
-  async () => {
-    const fastWorker1 = new MockWorker("fast-1");
-    const fastWorker2 = new MockWorker("fast-2");
-    const heavyWorker = new MockWorker("heavy-idle");
-
-    // Limit to 2 concurrent workers
-    const fitness = new Fitness(
-      [fastWorker1, fastWorker2] as unknown[] as WorkerHandler[],
-      0.0001,
-      false,
-      {
-        maxConcurrentEvaluations: 2,
-        topologyGrouping: false,
-      },
-    );
-
-    const population = [
-      makeCreature(0.1),
-      makeCreature(0.2),
-      makeCreature(0.3),
-      makeCreature(0.4),
-    ];
-
-    // Even though we pass a heavy worker, the cap should limit to 2 workers
-    await fitness.calculate(
-      population,
-      [heavyWorker] as unknown[] as WorkerHandler[],
-    );
-
-    const totalEvaluations = fastWorker1.evaluationCount +
-      fastWorker2.evaluationCount +
-      heavyWorker.evaluationCount;
-
-    assertEquals(
-      totalEvaluations,
-      4,
-      "All 4 creatures should be evaluated",
-    );
-
-    // With maxConcurrent=2, only the first 2 workers from the combined
-    // list (fast1, fast2) should participate — heavy worker should not.
-    assertEquals(
-      heavyWorker.evaluationCount,
-      0,
-      "Heavy worker should be excluded when maxConcurrentEvaluations caps at 2",
     );
   },
 );

--- a/test/architecture/FitnessScorerTelemetry.ts
+++ b/test/architecture/FitnessScorerTelemetry.ts
@@ -64,7 +64,6 @@ function makeCreature(bias: number): Creature {
 
 const EVAL_CONFIG: RequiredParallelEvaluationConfig = {
   topologyGrouping: false,
-  maxConcurrentEvaluations: 0,
 };
 
 Deno.test("Fitness scorer telemetry - counts unique scored creatures", async () => {

--- a/test/architecture/FitnessTopologyGrouping.ts
+++ b/test/architecture/FitnessTopologyGrouping.ts
@@ -80,7 +80,6 @@ Deno.test("Fitness topology grouping - creatures grouped by topology hash", asyn
 
   const evalConfig: RequiredParallelEvaluationConfig = {
     topologyGrouping: true,
-    maxConcurrentEvaluations: 0,
   };
 
   const fitness = new Fitness(
@@ -157,7 +156,6 @@ Deno.test("Fitness topology grouping disabled - all creatures still evaluated", 
 
   const evalConfig: RequiredParallelEvaluationConfig = {
     topologyGrouping: false,
-    maxConcurrentEvaluations: 0,
   };
 
   const fitness = new Fitness(
@@ -192,7 +190,6 @@ Deno.test("Fitness topology grouping - preserves correctness of scores", async (
 
   const evalConfig: RequiredParallelEvaluationConfig = {
     topologyGrouping: true,
-    maxConcurrentEvaluations: 0,
   };
 
   const fitness = new Fitness(

--- a/test/config/ParallelEvaluationConfig.ts
+++ b/test/config/ParallelEvaluationConfig.ts
@@ -3,70 +3,42 @@
  *
  * Verifies that the ParallelEvaluationConfig is properly parsed,
  * defaults are applied, and CLI coercion works correctly.
+ *
+ * Issue #3566: `maxConcurrentEvaluations` was removed — it defaulted to 0,
+ * which made the only branch reading it a no-op, and the #2245 fast/heavy
+ * worker-pool split already reserves workers for training and discovery.
  */
-import { assertEquals, assertThrows } from "@std/assert";
+import { assert, assertEquals, assertThrows } from "@std/assert";
 import { createNeatConfig } from "@config/NeatConfig.ts";
 import { DEFAULT_PARALLEL_EVALUATION_CONFIG } from "@config/ParallelEvaluationConfig.ts";
 
 Deno.test("ParallelEvaluationConfig - default values are sensible", () => {
-  assertEquals(
-    DEFAULT_PARALLEL_EVALUATION_CONFIG.maxConcurrentEvaluations,
-    0,
-  );
   assertEquals(DEFAULT_PARALLEL_EVALUATION_CONFIG.topologyGrouping, true);
 });
 
 Deno.test("ParallelEvaluationConfig - defaults applied when not set", () => {
   const config = createNeatConfig({});
-  assertEquals(config.parallelEvaluation.maxConcurrentEvaluations, 0);
   assertEquals(config.parallelEvaluation.topologyGrouping, true);
 });
 
 Deno.test("ParallelEvaluationConfig - custom values override defaults", () => {
   const config = createNeatConfig({
-    parallelEvaluation: {
-      maxConcurrentEvaluations: 4,
-      topologyGrouping: false,
-    },
+    parallelEvaluation: { topologyGrouping: false },
   });
-  assertEquals(config.parallelEvaluation.maxConcurrentEvaluations, 4);
   assertEquals(config.parallelEvaluation.topologyGrouping, false);
 });
 
 Deno.test("ParallelEvaluationConfig - partial overrides merge with defaults", () => {
-  const config = createNeatConfig({
-    parallelEvaluation: { maxConcurrentEvaluations: 2 },
-  });
-  assertEquals(config.parallelEvaluation.maxConcurrentEvaluations, 2);
+  const config = createNeatConfig({ parallelEvaluation: {} });
   assertEquals(
     config.parallelEvaluation.topologyGrouping,
     DEFAULT_PARALLEL_EVALUATION_CONFIG.topologyGrouping,
   );
 });
 
-Deno.test("ParallelEvaluationConfig - string values coerced from CLI", () => {
-  const config = createNeatConfig({
-    parallelEvaluation: {
-      maxConcurrentEvaluations: "3" as unknown as number,
-    },
-  });
-  assertEquals(config.parallelEvaluation.maxConcurrentEvaluations, 3);
-});
-
-Deno.test("ParallelEvaluationConfig - maxConcurrentEvaluations must be >= 0", () => {
-  assertThrows(
-    () =>
-      createNeatConfig({
-        parallelEvaluation: { maxConcurrentEvaluations: -1 },
-      }),
-    Error,
-    "maxConcurrentEvaluations",
-  );
-});
-
 Deno.test("ParallelEvaluationConfig - config frozen after creation", () => {
   const config = createNeatConfig({
-    parallelEvaluation: { maxConcurrentEvaluations: 2 },
+    parallelEvaluation: { topologyGrouping: false },
   });
   assertThrows(
     () => {
@@ -82,4 +54,21 @@ Deno.test("ParallelEvaluationConfig - topology grouping can be disabled", () => 
     parallelEvaluation: { topologyGrouping: false },
   });
   assertEquals(config.parallelEvaluation.topologyGrouping, false);
+});
+
+Deno.test("ParallelEvaluationConfig - maxConcurrentEvaluations is gone (Issue #3566)", () => {
+  assert(
+    !("maxConcurrentEvaluations" in DEFAULT_PARALLEL_EVALUATION_CONFIG),
+    "the removed option must not reappear in the defaults",
+  );
+  const config = createNeatConfig({
+    parallelEvaluation: {
+      maxConcurrentEvaluations: 2,
+    } as unknown as Record<string, unknown>,
+  });
+  assert(
+    !("maxConcurrentEvaluations" in config.parallelEvaluation),
+    "an unknown override must not be carried into the parsed config",
+  );
+  assertEquals(config.parallelEvaluation.topologyGrouping, true);
 });

--- a/test/config/parsers/RuntimeParsers.ts
+++ b/test/config/parsers/RuntimeParsers.ts
@@ -5,7 +5,7 @@
  * rejection for the runtime/system limit parsers.
  */
 
-import { assertEquals, assertThrows } from "@std/assert";
+import { assert, assertEquals, assertThrows } from "@std/assert";
 import { ConfigurationError } from "@errors/ConfigurationError.ts";
 import { DEFAULT_MEMORY_CONFIG } from "@config/MemoryConfig.ts";
 import { DEFAULT_PARALLEL_EVALUATION_CONFIG } from "@config/ParallelEvaluationConfig.ts";
@@ -105,10 +105,6 @@ Deno.test("parseMemoryConfig - rejects negative nativeBudgetBytes (#3025)", () =
 Deno.test("parseParallelEvaluation - returns defaults when no overrides", () => {
   const cfg = parseParallelEvaluation(undefined);
   assertEquals(
-    cfg.maxConcurrentEvaluations,
-    DEFAULT_PARALLEL_EVALUATION_CONFIG.maxConcurrentEvaluations,
-  );
-  assertEquals(
     cfg.topologyGrouping,
     DEFAULT_PARALLEL_EVALUATION_CONFIG.topologyGrouping,
   );
@@ -116,19 +112,18 @@ Deno.test("parseParallelEvaluation - returns defaults when no overrides", () => 
 
 Deno.test("parseParallelEvaluation - applies overrides", () => {
   const cfg = parseParallelEvaluation({
-    maxConcurrentEvaluations: 4,
     topologyGrouping: !DEFAULT_PARALLEL_EVALUATION_CONFIG.topologyGrouping,
   });
-  assertEquals(cfg.maxConcurrentEvaluations, 4);
   assertEquals(
     cfg.topologyGrouping,
     !DEFAULT_PARALLEL_EVALUATION_CONFIG.topologyGrouping,
   );
 });
 
-Deno.test("parseParallelEvaluation - rejects negative maxConcurrentEvaluations", () => {
-  assertThrows(
-    () => parseParallelEvaluation({ maxConcurrentEvaluations: -1 }),
-    ConfigurationError,
+Deno.test("parseParallelEvaluation - drops removed maxConcurrentEvaluations (#3566)", () => {
+  const cfg = parseParallelEvaluation({ maxConcurrentEvaluations: 4 });
+  assert(
+    !("maxConcurrentEvaluations" in cfg),
+    "the removed option must not be parsed back into the config",
   );
 });


### PR DESCRIPTION
# Remove `parallelEvaluation.maxConcurrentEvaluations` (Issue #3566)

## Summary

Removed the `parallelEvaluation.maxConcurrentEvaluations` option — slice E of
the #3505 option-removal audit, following the #3502 / #3562 removal pattern.
Closes #3566.

The field defaulted to `0`, and with `0` the only branch that read it took the
un-sliced `allWorkers` path, so it never changed behaviour in any run. Its
original purpose (#1862 — reserve workers for training and discovery while
evaluation runs) was superseded by the #2245 fast/heavy worker-pool split:
evaluation now receives only fast-pool workers, which never run discovery or
training. Callers who genuinely want to reserve capacity size the heavy pool
with `heavyTaskWorkerCount`. The same #2245 change removed the sibling
`busyWorkerWaitMs` for exactly this reason.

`parallelEvaluation.topologyGrouping` and the parent `parallelEvaluation` key
are untouched — `topologyGrouping` defaults to `true` and drives
`EvaluationScheduling` on every generation.

**Breaking for embedders that set it:** passing
`parallelEvaluation.maxConcurrentEvaluations` is now a `deno check` error. No
consumer sets it (verified in the issue's cross-repo sweep — zero camelCase,
env-var, and code-search hits in both downstream repos), so the runtime
behaviour of every existing configuration is unchanged.

### Removal surface

| Area         | Change                                                                                                        |
| ------------ | ------------------------------------------------------------------------------------------------------------- |
| Option       | `src/config/ParallelEvaluationConfig.ts` — interface field and `DEFAULT_PARALLEL_EVALUATION_CONFIG` entry     |
| Parsing      | `src/config/parsers/RuntimeParsers.ts` — the `parseParallelEvaluation` `parseNumber` block                    |
| Plumbing     | `src/architecture/Fitness.ts` — the `maxConcurrent` ternary; `activeWorkers` collapses into `allWorkers`      |
| Bench        | `bench/ParallelEvaluation.ts` (4 lines), `bench/ScorerBatchThroughput.ts` (1 line) — all inert `: 0` literals |
| Tests        | Config, parser, and Fitness suites (see Test Plan)                                                            |
| Docs         | `docs/config/WORKERS.md`, `docs/comparison/FUTURE_WORK.md`, `docs/api/CONFIGURATION.md`, `CHANGELOG.md`       |
| Option audit | `scripts/lib/optionAuditRollup.ts` — the stale `QUALIFIES` field override on the `parallelEvaluation` entry   |

## Evidence

Backend/library change with no web interface — no screenshot applies. The
evidence is the quality gate and the behaviour-equivalence argument below.

### Why the removal is behaviour-preserving

```mermaid
flowchart LR
    subgraph Before["Before (#1862)"]
        A1[fast pool + idle heavy assistants] --> B1{maxConcurrent > 0?}
        B1 -- "no — always, default 0" --> C1[allWorkers]
        B1 -. "never taken" .-> D1[allWorkers.slice 0, n]
        C1 --> E1[work-stealing queue]
    end
    subgraph After["After (#3566)"]
        A2[fast pool + idle heavy assistants] --> C2[allWorkers] --> E2[work-stealing queue]
    end
```

The dead branch is the whole change: with the default of `0` the ternary always
resolved to `allWorkers`, which is now the only expression.

### Quality gate

`./quality.sh < /dev/null` passes cleanly:

```
ok | 8136 passed (5 steps) | 0 failed | 4 ignored (5m8s)
```

## Test Plan

**Added regression guards** (both fail if the option is reintroduced):

- `test/config/ParallelEvaluationConfig.ts::ParallelEvaluationConfig -
  maxConcurrentEvaluations is gone (Issue #3566)`
  — asserts the key is absent from `DEFAULT_PARALLEL_EVALUATION_CONFIG` and that
  an override naming it is not carried into the parsed config.
- `test/config/parsers/RuntimeParsers.ts::parseParallelEvaluation - drops
  removed maxConcurrentEvaluations (#3566)`
  — asserts `parseParallelEvaluation` does not parse the key back in.

**Rewritten:**

- `test/architecture/BatchCreatureEvaluation.ts` —
  `Fitness -
  maxConcurrentEvaluations 0 uses all workers` renamed to
  `Fitness - every
  supplied worker is available for evaluation`; it covered
  the surviving behaviour already, so its assertions are unchanged.
- `test/config/ParallelEvaluationConfig.ts` — the default, override, partial
  merge, and frozen-config tests now exercise `topologyGrouping`. The
  CLI-coercion and `>= 0` validation tests went with the only numeric field.

**Removed (documented business-logic change — the behaviour they asserted no
longer exists; each file records why in its header comment):**

- `test/architecture/BatchCreatureEvaluation.ts::Fitness -
  maxConcurrentEvaluations limits active workers`
- `test/architecture/FitnessBusyWorkerWait.ts::Fitness maxConcurrentEvaluations
  still caps fast-pool worker usage`
- `test/architecture/FitnessDynamicPool.ts::Fitness.calculate with additional
  workers respects maxConcurrentEvaluations`

**Unchanged and still passing** (inert `maxConcurrentEvaluations: 0` literals
dropped from their fixtures): `FitnessScorerTelemetry.ts`,
`FitnessTopologyGrouping.ts`, `test/scripts/OptionAuditRollup.ts` — the last of
which mechanically re-reconciles the audit roll-up against the live config
surface, so a stale roll-up entry would fail CI.

## Security self-check

No new input handling, no new dependency, no new endpoint or privileged
operation. The change deletes a configuration field and one branch; the
validation removed with it (`min: 0`) guarded only that deleted field.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-msdui154-04b522`<!-- vibe-worker-issue-3566 -->