### PR TITLE
Wire up memory.maxAnalysisMemoryMb; remove memory.proactiveGc (#3505 slice E) (Issue #3565)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
-  "version": "6.2.10",
+  "version": "6.2.11",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",

--- a/docs/DISCOVERY_ARCHITECTURE.md
+++ b/docs/DISCOVERY_ARCHITECTURE.md
@@ -696,6 +696,34 @@ Configuration lives on `memory` in `NeatOptions`:
 - `memory.nativeBudgetBytes` — the host's off-heap RSS budget, reused as the
   cancellation trigger alongside V8 CRITICAL pressure.
 
+#### Seeding the budget from the runner (Issue #3565)
+
+Leaving `maxAnalysisMemoryMb` at its `0` default means production runs with no
+Rust-side brake at all, which is exactly the failure #3432 shipped it for. The
+external Discovery runner already computes a host-derived budget, so
+`createNeatConfig` reads it from the environment automatically — the
+`workerThreadCap` pattern of `DISCOVERY_WORKER_ENVELOPE_MB`
+(`src/config/AnalysisMemoryBudgetEnv.ts`):
+
+| Variable                              | Maps to                      | Behaviour                                                            |
+| ------------------------------------- | ---------------------------- | -------------------------------------------------------------------- |
+| `DISCOVERY_ANALYSIS_MEMORY_BUDGET_MB` | `memory.maxAnalysisMemoryMb` | Positive integer MB. Unset ⇒ budget stays off (behaviour unchanged). |
+
+An explicitly supplied `memory.maxAnalysisMemoryMb` always wins — including an
+explicit `0`, which is a deliberate "send no budget". A value that is present
+but not a positive integer is ignored **loudly**: it warns and falls back to the
+default rather than applying a nonsensical budget or crashing startup.
+
+```mermaid
+flowchart LR
+    RUN["Discovery runner<br/>exports DISCOVERY_ANALYSIS_MEMORY_BUDGET_MB"] --> RES["resolveAnalysisMemoryBudgetEnvMb()"]
+    RES -->|positive int| MERGE["mergeAnalysisMemoryBudgetDefault()"]
+    RES -->|invalid| WARN["warn + fall back to default"]
+    OPT["memory.maxAnalysisMemoryMb option"] -->|wins| MERGE
+    MERGE --> CFG["config.memory.maxAnalysisMemoryMb"]
+    CFG --> FFI["analyze_parallel({ maxAnalysisMemoryMb })"]
+```
+
 The cancellation flag inside NEAT-AI-Discovery is process-wide, which is what
 makes the interrupt possible: the evolve loop signals it from the host isolate
 while the analysis blocks a different thread of the same process.

--- a/docs/archive/pr-summaries/pr-summary-3565.md
+++ b/docs/archive/pr-summaries/pr-summary-3565.md
@@ -1,0 +1,68 @@
+# Wire up `memory.maxAnalysisMemoryMb`; remove `memory.proactiveGc` (#3565)
+
+## Summary
+
+Slice E (#3523) of the #3505 option-removal audit flagged both `memory` fields
+as inert defaults. This PR carries out the decision recorded on the issue:
+
+- **`memory.maxAnalysisMemoryMb` — wired up.** It is the only in-flight brake on
+  `analyze_parallel` growing RSS until the host OOMs (the FFI call is blocking,
+  so no JS timer or heap sample runs while Rust allocates), yet its `0` default
+  meant no Rust-side budget was ever sent. `createNeatConfig` now seeds it from
+  `DISCOVERY_ANALYSIS_MEMORY_BUDGET_MB`, mirroring the `workerThreadCap` /
+  `DISCOVERY_WORKER_ENVELOPE_MB` precedent. An explicitly supplied option always
+  wins (including an explicit `0`); an invalid value is ignored **loudly** —
+  warn and fall back to the default — and with the variable unset behaviour is
+  unchanged. stSoftwareAU/GRQ#3881 exports the runner-side value.
+- **`memory.proactiveGc` — removed.** `attemptProactiveGc()` is a no-op unless
+  the runtime was started with `--v8-flags=--expose-gc`, which no launcher
+  passes. The option, its default, its parser entry, the `MemoryMonitor`
+  critical-response gate, `attemptProactiveGc()` itself, and the `attemptGc`
+  plumbing through `releaseRecordingRetainers()` are all gone.
+
+Closes #3565.
+
+## Evidence
+
+Backend/config change — no web interface to screenshot. Verified by the tests
+below and a clean `./quality.sh` run.
+
+```mermaid
+flowchart LR
+    RUN["Discovery runner<br/>DISCOVERY_ANALYSIS_MEMORY_BUDGET_MB"] --> RES["resolveAnalysisMemoryBudgetEnvMb()"]
+    RES -->|positive int| MERGE["mergeAnalysisMemoryBudgetDefault()"]
+    RES -->|invalid| WARN["warn + fall back to default"]
+    OPT["memory.maxAnalysisMemoryMb option"] -->|wins| MERGE
+    MERGE --> CFG["config.memory.maxAnalysisMemoryMb"]
+    CFG --> FFI["analyze_parallel({ maxAnalysisMemoryMb })"]
+```
+
+## Test Plan
+
+New — `test/config/AnalysisMemoryBudgetEnv.ts`:
+
+- `resolveAnalysisMemoryBudgetEnvMb` — unset, positive integer, whitespace-only
+  (unconfigured, no warning), and invalid (`0`, negative, non-numeric,
+  fractional, `Infinity`) values each warn once and fall back.
+- `mergeAnalysisMemoryBudgetDefault` — env seeds an unset budget, leaves other
+  overrides intact, and never overrides an explicit option (including `0`).
+- End-to-end through `createNeatConfig`, run in a **child process** so the
+  environment stays hermetic (`deno test --parallel` shares one process
+  environment across files): env `4096` → `memory.maxAnalysisMemoryMb === 4096`,
+  explicit `512` wins over the env value, and env unset → `0`.
+
+Modified (documented business-logic change — `memory.proactiveGc` no longer
+exists):
+
+- `test/NEAT/MemoryMonitor.ts` — removed the three `proactiveGc` /
+  `attemptProactiveGc` tests along with the API they covered.
+- `test/config/parsers/RuntimeParsers.ts` — the defaults assertion now checks
+  `maxAnalysisMemoryMb` instead of the removed `proactiveGc`.
+
+## Docs
+
+- `docs/DISCOVERY_ARCHITECTURE.md` — new "Seeding the budget from the runner"
+  section documenting the env variable, precedence, and loud-fallback rule.
+- `docs/troubleshooting/MEMORY.md` — dropped the `memory.proactiveGc` mention.
+- `scripts/lib/optionAuditRollup.ts` — `maxAnalysisMemoryMb` is now `IN USE`;
+  the `proactiveGc` entry is gone with the field.

--- a/docs/archive/pr-summaries/pr-summary-3565.md
+++ b/docs/archive/pr-summaries/pr-summary-3565.md
@@ -13,7 +13,7 @@ as inert defaults. This PR carries out the decision recorded on the issue:
   `DISCOVERY_WORKER_ENVELOPE_MB` precedent. An explicitly supplied option always
   wins (including an explicit `0`); an invalid value is ignored **loudly** —
   warn and fall back to the default — and with the variable unset behaviour is
-  unchanged. stSoftwareAU/GRQ#3881 exports the runner-side value.
+  unchanged. The downstream production repo exports the runner-side value.
 - **`memory.proactiveGc` — removed.** `attemptProactiveGc()` is a no-op unless
   the runtime was started with `--v8-flags=--expose-gc`, which no launcher
   passes. The option, its default, its parser entry, the `MemoryMonitor`

--- a/docs/troubleshooting/MEMORY.md
+++ b/docs/troubleshooting/MEMORY.md
@@ -289,9 +289,7 @@ record-phase leftovers — the per-chunk cache release of #2642 applied to the
 boundary. State analysis still consumes is preserved
 (`recordedNeuronTotalAbsError` for focus ranking, `parquetFilePath`,
 `combinedRustAnalysis`, `creature`), so there is no use-after-free and no change
-to recorded output. When `memory.proactiveGc` is enabled a best-effort
-`globalThis.gc?.()` runs after the references are dropped, but correctness never
-depends on GC running.
+to recorded output.
 
 #### Off-heap (RSS / native budget) awareness (Issue #3025)
 

--- a/scripts/lib/optionAuditRollup.ts
+++ b/scripts/lib/optionAuditRollup.ts
@@ -298,12 +298,12 @@ const SLICE_E: RollupEntry[] = [
     fieldOverrides: {
       enabled: { verdict: "IN USE" },
       nativeBudgetBytes: { verdict: "IN USE" },
-      proactiveGc: { verdict: "QUALIFIES", issue: 3565 },
-      maxAnalysisMemoryMb: { verdict: "QUALIFIES", issue: 3565 },
+      maxAnalysisMemoryMb: { verdict: "IN USE" },
     },
     note:
       "The downstream production consumer sets `enabled` + `nativeBudgetBytes`; " +
-      "seven defaults are live.",
+      "seven defaults are live. #3565 removed `proactiveGc` and wired " +
+      "`maxAnalysisMemoryMb` to the runner's `DISCOVERY_ANALYSIS_MEMORY_BUDGET_MB`.",
   }),
   inUse("workerThreadCap", "E", {
     interfaces: ["src/config/WorkerThreadCapConfig.ts::WorkerThreadCapConfig"],

--- a/src/NEAT/MemoryMonitor.ts
+++ b/src/NEAT/MemoryMonitor.ts
@@ -380,23 +380,6 @@ function broadcastWorkerCacheCaps(
 }
 
 /**
- * Attempt a proactive garbage collection if the runtime exposes it. Issue #2381.
- *
- * Only effective when the V8 `--expose-gc` flag is set. Safe to call
- * unconditionally — the call is a no-op otherwise.
- */
-export function attemptProactiveGc(): boolean {
-  const gc = (globalThis as { gc?: () => void }).gc;
-  if (typeof gc !== "function") return false;
-  try {
-    gc();
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-/**
  * Provider function for heap memory usage — injectable for testing.
  */
 export type MemoryUsageProvider = () => MemoryUsageSample;
@@ -545,7 +528,6 @@ export function formatMemorySnapshot(snapshot: MemorySnapshot): string {
  *   `criticalBackoffWindowMs`, the critical response is suppressed for
  *   `criticalBackoffCooldownMs` so we stop thrashing when caches are not the
  *   true retainer.
- * - Optional proactive GC (`proactiveGc`) invoked on critical pressure.
  *
  * @param config - Memory monitoring configuration with thresholds
  * @param logger - Logger instance for diagnostics
@@ -621,7 +603,6 @@ export function checkMemoryAndEvict(
         _backoffNotified = false;
 
         applyCriticalResponse(logger, sink);
-        if (config.proactiveGc) attemptProactiveGc();
         evicted = true;
 
         _recentCriticalTimestamps.push(nowMs);

--- a/src/architecture/ErrorGuidedStructuralEvolution/DataRecorder.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DataRecorder.ts
@@ -384,9 +384,7 @@ export class DataRecorder {
       // the heap sample the guard reads — the #2642 chunk-cache release applied
       // to the record→analysis handoff — without touching analysis-needed
       // state or recorded output.
-      discoverStructure.releaseRecordingRetainers({
-        attemptGc: this.config.memory.proactiveGc,
-      });
+      discoverStructure.releaseRecordingRetainers();
 
       // Issue #2594/#3025/#3296: Heap-aware extension boundary — degrade, don't
       // abort. Before extending the timeout for analysis, sample the heap. If

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructureRecording.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructureRecording.ts
@@ -26,7 +26,6 @@ import {
   observeRustTrainingRecord as observeRustTrainingRecordImpl,
 } from "@architecture/ErrorGuidedStructuralEvolution/RustFlushDiagnostics.ts";
 import { taskDescriptorToRustWire } from "@costs/TaskDescriptorRustWire.ts";
-import { attemptProactiveGc } from "@neat/MemoryMonitor.ts";
 import { getLogger } from "@utils/Logger.ts";
 import { appendAll } from "@utils/ArrayAppend.ts";
 import { isReleased } from "@utils/ReleasableRef.ts";
@@ -549,14 +548,12 @@ export class DiscoverStructureRecording extends DiscoverStructureBase {
    * deliberately preserved: `recordedNeuronTotalAbsError` (focus ranking),
    * `parquetFilePath`, `combinedRustAnalysis`, and `creature`.
    *
-   * @param options.attemptGc request a proactive `globalThis.gc?.()` after
-   *   dropping the references. Only effective under
-   *   `--v8-flags=--expose-gc`; correctness never depends on GC running.
    * @returns counts of what was released, for observability and tests.
    */
-  public releaseRecordingRetainers(
-    options?: Readonly<{ attemptGc?: boolean }>,
-  ): { releasedIndexEntries: number; releasedAccumulatedSamples: number } {
+  public releaseRecordingRetainers(): {
+    releasedIndexEntries: number;
+    releasedAccumulatedSamples: number;
+  } {
     let releasedIndexEntries = 0;
     for (const key of Object.keys(this.selectedIndices)) {
       releasedIndexEntries += this.selectedIndices[key]?.length ?? 0;
@@ -570,11 +567,6 @@ export class DiscoverStructureRecording extends DiscoverStructureBase {
     this.rustAccumulatedNeuronData = [];
     this.rustAccumulatedEstimatedBytes = 0;
     this.rustBinaryFilePaths = new Set();
-
-    if (options?.attemptGc) {
-      // Best-effort; a no-op unless the runtime was started with --expose-gc.
-      attemptProactiveGc();
-    }
 
     if (
       this.loggingEnabled &&

--- a/src/config/AnalysisMemoryBudgetEnv.ts
+++ b/src/config/AnalysisMemoryBudgetEnv.ts
@@ -1,0 +1,91 @@
+/**
+ * Discovery analysis memory budget → `memory.maxAnalysisMemoryMb` wiring
+ * (Issue #3565).
+ *
+ * ## Why this exists
+ *
+ * `memory.maxAnalysisMemoryMb` (#3432) is the only in-flight brake on
+ * `analyze_parallel` growing the resident set until the host OOMs: the FFI call
+ * is blocking, so no JS timer or heap sample runs while Rust allocates. Its
+ * default is `0` ("send no budget"), and the production runner never set it —
+ * so Discovery analysis ran with no Rust-side allocator budget at all.
+ *
+ * The runner already computes the right number, so this module mirrors the
+ * {@link ./DiscoveryWorkerEnvelope.ts} precedent: the external runner exports
+ * the budget as {@link ANALYSIS_MEMORY_BUDGET_ENV} and `createNeatConfig`
+ * seeds `memory.maxAnalysisMemoryMb` from it **automatically** — no per-caller
+ * opt-in. An explicitly supplied option always wins, and with the variable
+ * unset behaviour is unchanged (the budget stays off).
+ *
+ * @module
+ */
+
+import type { EnvReader } from "@workers/WorkerHeapBudget.ts";
+import { getLogger, type Logger } from "@utils/Logger.ts";
+
+export type { EnvReader };
+
+/**
+ * Environment variable the external Discovery runner sets to the analysis-phase
+ * memory budget (MB) handed to Rust on every `analyze_parallel` call.
+ */
+export const ANALYSIS_MEMORY_BUDGET_ENV = "DISCOVERY_ANALYSIS_MEMORY_BUDGET_MB";
+
+/**
+ * Resolve the analysis memory budget (MB) exported by the Discovery runner.
+ *
+ * Returns `undefined` when the variable is unset or empty — every non-Discovery
+ * caller — so the option keeps its `0` default and no budget is sent. A value
+ * that is present but not a positive integer is **ignored loudly**: it warns and
+ * falls back to the default rather than crashing startup or silently applying a
+ * nonsensical budget. Reading is wrapped in `try/catch` so a missing
+ * `--allow-env` permission is treated as unconfigured.
+ *
+ * @param env - Environment reader (defaults to `Deno.env`).
+ * @param logger - Logger for the invalid-value warning (defaults to the global).
+ */
+export function resolveAnalysisMemoryBudgetEnvMb(
+  env: EnvReader = Deno.env,
+  logger: Logger = getLogger(),
+): number | undefined {
+  let raw: string | undefined;
+  try {
+    raw = env.get(ANALYSIS_MEMORY_BUDGET_ENV) ?? undefined;
+  } catch {
+    // No --allow-env (or reader threw): treat as unconfigured.
+    return undefined;
+  }
+  if (raw === undefined) return undefined;
+  const trimmed = raw.trim();
+  if (trimmed === "") return undefined;
+
+  const budget = Number(trimmed);
+  if (!Number.isSafeInteger(budget) || budget <= 0) {
+    logger.warn(
+      `[NEAT-AI] Ignoring ${ANALYSIS_MEMORY_BUDGET_ENV}="${raw}": ` +
+        `expected a positive integer of megabytes — no analysis memory ` +
+        `budget will be sent to Discovery.`,
+    );
+    return undefined;
+  }
+  return budget;
+}
+
+/**
+ * Merge the runner-exported budget under any explicit `memory` overrides.
+ *
+ * The explicit option always wins — including an explicit `0`, which is a
+ * deliberate "send no budget". Returns the user overrides unchanged when no
+ * budget is exported, so the parser's static defaults apply.
+ *
+ * @param userOverrides - Raw `memory` overrides from user options.
+ * @param envBudgetMb - Runner-exported budget, or `undefined` when unset.
+ */
+export function mergeAnalysisMemoryBudgetDefault(
+  userOverrides: Record<string, unknown> | undefined,
+  envBudgetMb: number | undefined,
+): Record<string, unknown> | undefined {
+  if (envBudgetMb === undefined) return userOverrides;
+  if (userOverrides?.maxAnalysisMemoryMb !== undefined) return userOverrides;
+  return { maxAnalysisMemoryMb: envBudgetMb, ...userOverrides };
+}

--- a/src/config/MemoryConfig.ts
+++ b/src/config/MemoryConfig.ts
@@ -101,15 +101,6 @@ export interface MemoryConfig {
   criticalBackoffCooldownMs?: number;
 
   /**
-   * Whether to attempt proactive GC (`globalThis.gc?.()`) on critical
-   * pressure when available. Issue #2381.
-   *
-   * Only effective when the runtime was started with `--v8-flags=--expose-gc`.
-   * Defaults to false (so production behaviour is unchanged unless opted in).
-   */
-  proactiveGc?: boolean;
-
-  /**
    * Off-heap (native/Rust) resident-set budget in bytes. Issue #3025.
    *
    * The discovery worker runs on a small default V8 heap (~269 MB), so after
@@ -168,7 +159,6 @@ export const DEFAULT_MEMORY_CONFIG: RequiredMemoryConfig = {
   criticalBackoffBurst: 5,
   criticalBackoffWindowMs: 10_000,
   criticalBackoffCooldownMs: 60_000,
-  proactiveGc: false,
   nativeBudgetBytes: 0,
   maxAnalysisMemoryMb: 0,
 };

--- a/src/config/NeatConfig.ts
+++ b/src/config/NeatConfig.ts
@@ -77,6 +77,12 @@ import {
   resolveDiscoveryWorkerThreadCap,
 } from "@config/DiscoveryWorkerEnvelope.ts";
 
+// Automatic Discovery analysis budget → memory.maxAnalysisMemoryMb wiring.
+import {
+  mergeAnalysisMemoryBudgetDefault,
+  resolveAnalysisMemoryBudgetEnvMb,
+} from "@config/AnalysisMemoryBudgetEnv.ts";
+
 /**
  * Default cost of growth value used when not specified in options.
  */
@@ -642,8 +648,14 @@ export function createNeatConfig(options: NeatOptionsInput): NeatConfig {
       opts.wasmCache as Record<string, unknown> | undefined,
       populationSize,
     ),
+    // Issue #3565: seed the analysis memory budget from the Discovery runner's
+    // exported value when the caller did not set it explicitly, so the Rust-side
+    // OOM brake is live in production instead of dormant.
     memory: parseMemoryConfig(
-      opts.memory as Record<string, unknown> | undefined,
+      mergeAnalysisMemoryBudgetDefault(
+        opts.memory as Record<string, unknown> | undefined,
+        resolveAnalysisMemoryBudgetEnvMb(),
+      ),
     ),
     workerThreadCap,
     quantumStep: parseQuantumStep(

--- a/src/config/parsers/RuntimeParsers.ts
+++ b/src/config/parsers/RuntimeParsers.ts
@@ -120,9 +120,6 @@ export function parseMemoryConfig(
       d.criticalBackoffCooldownMs,
       { integer: true, min: 0 },
     ),
-    proactiveGc: overrides?.proactiveGc !== undefined
-      ? Boolean(overrides.proactiveGc)
-      : d.proactiveGc,
     nativeBudgetBytes: parseNumber(
       "Memory nativeBudgetBytes",
       overrides?.nativeBudgetBytes,

--- a/test/NEAT/MemoryMonitor.ts
+++ b/test/NEAT/MemoryMonitor.ts
@@ -2,7 +2,6 @@ import { assertEquals, assertStrictEquals } from "@std/assert";
 import {
   applyCriticalResponse,
   applyWarningResponse,
-  attemptProactiveGc,
   captureMemorySnapshot,
   checkMemoryAndEvict,
   defaultMemoryUsageProvider,
@@ -634,73 +633,6 @@ Deno.test(
     }
   },
 );
-
-Deno.test("checkMemoryAndEvict proactiveGc invokes globalThis.gc when present", () => {
-  resetMemoryPressureLogCountersForTests();
-  const originalCap = getMaxCachedWasmCreatureActivations();
-  const globalAny = globalThis as { gc?: () => void };
-  const originalGc = globalAny.gc;
-  try {
-    let gcCalls = 0;
-    globalAny.gc = () => {
-      gcCalls++;
-    };
-    const config: RequiredMemoryConfig = {
-      ...DEFAULT_MEMORY_CONFIG,
-      proactiveGc: true,
-      snapshotThreshold: 1.0,
-    };
-    const logger = createTestLogger();
-    setMaxCachedWasmCreatureActivations(100);
-    const result = checkMemoryAndEvict(
-      config,
-      logger,
-      fakeMemoryProvider(950, 1000),
-    );
-    assertStrictEquals(result.pressureLevel, "critical");
-    assertStrictEquals(gcCalls, 1);
-  } finally {
-    if (originalGc === undefined) {
-      delete (globalAny as { gc?: () => void }).gc;
-    } else {
-      globalAny.gc = originalGc;
-    }
-    setMaxCachedWasmCreatureActivations(originalCap);
-    resetMemoryPressureLogCountersForTests();
-  }
-});
-
-Deno.test("attemptProactiveGc returns false when gc is not exposed", () => {
-  const globalAny = globalThis as { gc?: () => void };
-  const originalGc = globalAny.gc;
-  try {
-    // Cannot delete non-configurable properties (e.g. when --expose-gc is set).
-    // Setting to undefined satisfies typeof check in attemptProactiveGc.
-    (globalAny as Record<string, unknown>).gc = undefined;
-    assertStrictEquals(attemptProactiveGc(), false);
-  } finally {
-    if (originalGc !== undefined) globalAny.gc = originalGc;
-  }
-});
-
-Deno.test("attemptProactiveGc returns true and invokes gc when exposed", () => {
-  const globalAny = globalThis as { gc?: () => void };
-  const originalGc = globalAny.gc;
-  try {
-    let called = false;
-    globalAny.gc = () => {
-      called = true;
-    };
-    assertStrictEquals(attemptProactiveGc(), true);
-    assertStrictEquals(called, true);
-  } finally {
-    if (originalGc === undefined) {
-      delete (globalAny as { gc?: () => void }).gc;
-    } else {
-      globalAny.gc = originalGc;
-    }
-  }
-});
 
 Deno.test(
   "resetMemoryPressureLogCountersForTests also clears snapshot and backoff state",

--- a/test/config/AnalysisMemoryBudgetEnv.ts
+++ b/test/config/AnalysisMemoryBudgetEnv.ts
@@ -1,0 +1,175 @@
+/**
+ * Tests for the Discovery analysis memory-budget env resolver (Issue #3565).
+ *
+ * These exercise the pure env → override mapping with an injected reader, so
+ * they are hermetic and never touch the real process environment.
+ */
+import { assert, assertEquals } from "@std/assert";
+import {
+  ANALYSIS_MEMORY_BUDGET_ENV,
+  mergeAnalysisMemoryBudgetDefault,
+  resolveAnalysisMemoryBudgetEnvMb,
+} from "@config/AnalysisMemoryBudgetEnv.ts";
+import { parseMemoryConfig } from "@config/parsers/RuntimeParsers.ts";
+import type { Logger } from "@utils/Logger.ts";
+
+/** Build an env getter from a plain record for hermetic tests. */
+function envFrom(
+  map: Record<string, string>,
+): { get(key: string): string | undefined } {
+  return { get: (k) => (k in map ? map[k] : undefined) };
+}
+
+/** Minimal recording logger capturing warnings. */
+function makeRecordingLogger(): { logger: Logger; warnings: string[] } {
+  const warnings: string[] = [];
+  const logger = {
+    debug: () => {},
+    info: () => {},
+    warn: (message: string) => warnings.push(message),
+    error: () => {},
+  } as unknown as Logger;
+  return { logger, warnings };
+}
+
+Deno.test("resolveAnalysisMemoryBudgetEnvMb: unset env yields no budget", () => {
+  assertEquals(resolveAnalysisMemoryBudgetEnvMb(envFrom({})), undefined);
+});
+
+Deno.test("resolveAnalysisMemoryBudgetEnvMb: positive integer is the budget", () => {
+  assertEquals(
+    resolveAnalysisMemoryBudgetEnvMb(
+      envFrom({ [ANALYSIS_MEMORY_BUDGET_ENV]: " 2048 " }),
+    ),
+    2048,
+  );
+});
+
+Deno.test("resolveAnalysisMemoryBudgetEnvMb: invalid values warn and fall back", () => {
+  for (const raw of ["0", "-512", "abc", "1024.5", "Infinity"]) {
+    const { logger, warnings } = makeRecordingLogger();
+    assertEquals(
+      resolveAnalysisMemoryBudgetEnvMb(
+        envFrom({ [ANALYSIS_MEMORY_BUDGET_ENV]: raw }),
+        logger,
+      ),
+      undefined,
+      `${raw} must not activate a budget`,
+    );
+    assertEquals(warnings.length, 1, `${raw} must warn loudly`);
+    assert(
+      warnings[0].includes(ANALYSIS_MEMORY_BUDGET_ENV),
+      "the warning names the offending variable",
+    );
+  }
+});
+
+Deno.test("resolveAnalysisMemoryBudgetEnvMb: empty value is unconfigured, not invalid", () => {
+  const { logger, warnings } = makeRecordingLogger();
+  assertEquals(
+    resolveAnalysisMemoryBudgetEnvMb(
+      envFrom({ [ANALYSIS_MEMORY_BUDGET_ENV]: "   " }),
+      logger,
+    ),
+    undefined,
+  );
+  assertEquals(warnings, []);
+});
+
+Deno.test("mergeAnalysisMemoryBudgetDefault: no env budget leaves overrides untouched", () => {
+  assertEquals(
+    mergeAnalysisMemoryBudgetDefault(undefined, undefined),
+    undefined,
+  );
+  const user = { maxAnalysisMemoryMb: 128 };
+  assertEquals(mergeAnalysisMemoryBudgetDefault(user, undefined), user);
+});
+
+Deno.test("mergeAnalysisMemoryBudgetDefault: env seeds the budget when unset", () => {
+  assertEquals(mergeAnalysisMemoryBudgetDefault(undefined, 4096), {
+    maxAnalysisMemoryMb: 4096,
+  });
+  assertEquals(
+    mergeAnalysisMemoryBudgetDefault({ enabled: false }, 4096),
+    { maxAnalysisMemoryMb: 4096, enabled: false },
+  );
+});
+
+Deno.test("mergeAnalysisMemoryBudgetDefault: explicit option wins over env", () => {
+  assertEquals(
+    mergeAnalysisMemoryBudgetDefault({ maxAnalysisMemoryMb: 512 }, 4096),
+    { maxAnalysisMemoryMb: 512 },
+  );
+  // An explicit 0 is a deliberate "no budget" and must not be re-seeded.
+  assertEquals(
+    mergeAnalysisMemoryBudgetDefault({ maxAnalysisMemoryMb: 0 }, 4096),
+    { maxAnalysisMemoryMb: 0 },
+  );
+});
+
+/**
+ * Run `createNeatConfig` in a child process so the environment stays hermetic:
+ * `deno test --parallel` shares one process environment across test files, so
+ * setting the variable in-process would leak into unrelated default assertions.
+ *
+ * @returns the `memory.maxAnalysisMemoryMb` values the child resolved.
+ */
+async function budgetsFromChild(
+  env: Record<string, string>,
+  optionsLiteral: string[],
+): Promise<number[]> {
+  const code = `import { createNeatConfig } from "@config/NeatConfig.ts";
+console.log(JSON.stringify([${
+    optionsLiteral.map((o) =>
+      `createNeatConfig(${o}).memory.maxAnalysisMemoryMb`
+    ).join(",")
+  }]));`;
+  // A cleared environment (plus the few variables Deno needs to find its cache)
+  // guarantees the "unset" case really is unset, whatever the parent carries.
+  const passThrough: Record<string, string> = {};
+  for (const key of ["PATH", "HOME", "DENO_DIR", "TMPDIR"]) {
+    const value = Deno.env.get(key);
+    if (value !== undefined) passThrough[key] = value;
+  }
+  const command = new Deno.Command(Deno.execPath(), {
+    args: ["eval", "--config", "./deno.json", code],
+    env: { ...passThrough, ...env },
+    clearEnv: true,
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const { code: status, stdout, stderr } = await command.output();
+  const out = new TextDecoder().decode(stdout).trim();
+  assertEquals(
+    status,
+    0,
+    `child failed: ${new TextDecoder().decode(stderr)}`,
+  );
+  return JSON.parse(out.split("\n").at(-1)!);
+}
+
+Deno.test("createNeatConfig: runner-exported budget seeds memory.maxAnalysisMemoryMb", async () => {
+  const [seeded, explicitWins] = await budgetsFromChild(
+    { [ANALYSIS_MEMORY_BUDGET_ENV]: "4096" },
+    ["{}", "{ memory: { maxAnalysisMemoryMb: 512 } }"],
+  );
+  assertEquals(seeded, 4096, "env budget reaches the parsed config");
+  assertEquals(explicitWins, 512, "an explicit option wins over the env value");
+});
+
+Deno.test("createNeatConfig: budget stays off when the runner exports nothing", async () => {
+  const [unset] = await budgetsFromChild({}, ["{}"]);
+  assertEquals(unset, 0, "behaviour is unchanged without the env variable");
+});
+
+Deno.test("env budget flows through parseMemoryConfig to the parsed config", () => {
+  const parsed = parseMemoryConfig(
+    mergeAnalysisMemoryBudgetDefault(
+      undefined,
+      resolveAnalysisMemoryBudgetEnvMb(
+        envFrom({ [ANALYSIS_MEMORY_BUDGET_ENV]: "3072" }),
+      ),
+    ),
+  );
+  assertEquals(parsed.maxAnalysisMemoryMb, 3072);
+});

--- a/test/config/parsers/RuntimeParsers.ts
+++ b/test/config/parsers/RuntimeParsers.ts
@@ -63,7 +63,10 @@ Deno.test("parseMemoryConfig - returns defaults when no overrides", () => {
   const cfg = parseMemoryConfig(undefined);
   assertEquals(cfg.enabled, DEFAULT_MEMORY_CONFIG.enabled);
   assertEquals(cfg.warningThreshold, DEFAULT_MEMORY_CONFIG.warningThreshold);
-  assertEquals(cfg.proactiveGc, DEFAULT_MEMORY_CONFIG.proactiveGc);
+  assertEquals(
+    cfg.maxAnalysisMemoryMb,
+    DEFAULT_MEMORY_CONFIG.maxAnalysisMemoryMb,
+  );
 });
 
 Deno.test("parseMemoryConfig - applies enabled override and thresholds", () => {


### PR DESCRIPTION
# Wire up `memory.maxAnalysisMemoryMb`; remove `memory.proactiveGc` (#3565)

## Summary

Slice E (#3523) of the #3505 option-removal audit flagged both `memory` fields
as inert defaults. This PR carries out the decision recorded on the issue:

- **`memory.maxAnalysisMemoryMb` — wired up.** It is the only in-flight brake on
  `analyze_parallel` growing RSS until the host OOMs (the FFI call is blocking,
  so no JS timer or heap sample runs while Rust allocates), yet its `0` default
  meant no Rust-side budget was ever sent. `createNeatConfig` now seeds it from
  `DISCOVERY_ANALYSIS_MEMORY_BUDGET_MB`, mirroring the `workerThreadCap` /
  `DISCOVERY_WORKER_ENVELOPE_MB` precedent. An explicitly supplied option always
  wins (including an explicit `0`); an invalid value is ignored **loudly** —
  warn and fall back to the default — and with the variable unset behaviour is
  unchanged. The downstream production repo exports the runner-side value.
- **`memory.proactiveGc` — removed.** `attemptProactiveGc()` is a no-op unless
  the runtime was started with `--v8-flags=--expose-gc`, which no launcher
  passes. The option, its default, its parser entry, the `MemoryMonitor`
  critical-response gate, `attemptProactiveGc()` itself, and the `attemptGc`
  plumbing through `releaseRecordingRetainers()` are all gone.

Closes #3565.

## Evidence

Backend/config change — no web interface to screenshot. Verified by the tests
below and a clean `./quality.sh` run.

```mermaid
flowchart LR
    RUN["Discovery runner<br/>DISCOVERY_ANALYSIS_MEMORY_BUDGET_MB"] --> RES["resolveAnalysisMemoryBudgetEnvMb()"]
    RES -->|positive int| MERGE["mergeAnalysisMemoryBudgetDefault()"]
    RES -->|invalid| WARN["warn + fall back to default"]
    OPT["memory.maxAnalysisMemoryMb option"] -->|wins| MERGE
    MERGE --> CFG["config.memory.maxAnalysisMemoryMb"]
    CFG --> FFI["analyze_parallel({ maxAnalysisMemoryMb })"]
```

## Test Plan

New — `test/config/AnalysisMemoryBudgetEnv.ts`:

- `resolveAnalysisMemoryBudgetEnvMb` — unset, positive integer, whitespace-only
  (unconfigured, no warning), and invalid (`0`, negative, non-numeric,
  fractional, `Infinity`) values each warn once and fall back.
- `mergeAnalysisMemoryBudgetDefault` — env seeds an unset budget, leaves other
  overrides intact, and never overrides an explicit option (including `0`).
- End-to-end through `createNeatConfig`, run in a **child process** so the
  environment stays hermetic (`deno test --parallel` shares one process
  environment across files): env `4096` → `memory.maxAnalysisMemoryMb === 4096`,
  explicit `512` wins over the env value, and env unset → `0`.

Modified (documented business-logic change — `memory.proactiveGc` no longer
exists):

- `test/NEAT/MemoryMonitor.ts` — removed the three `proactiveGc` /
  `attemptProactiveGc` tests along with the API they covered.
- `test/config/parsers/RuntimeParsers.ts` — the defaults assertion now checks
  `maxAnalysisMemoryMb` instead of the removed `proactiveGc`.

## Docs

- `docs/DISCOVERY_ARCHITECTURE.md` — new "Seeding the budget from the runner"
  section documenting the env variable, precedence, and loud-fallback rule.
- `docs/troubleshooting/MEMORY.md` — dropped the `memory.proactiveGc` mention.
- `scripts/lib/optionAuditRollup.ts` — `maxAnalysisMemoryMb` is now `IN USE`;
  the `proactiveGc` entry is gone with the field.



---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mse3qalr-c37dac`<!-- vibe-worker-issue-3565 -->