### PR TITLE
Sandbox the CycloneDX SBOM generator outside the JSR OIDC job (Issue #3668)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,9 @@ jobs:
     permissions:
       contents: read
       id-token: write # OIDC for JSR (provenance + tokenless publish)
+    # Consumed by the `sbom` job, which cannot see this job's step outputs.
+    outputs:
+      publish: ${{ steps.needs_publish.outputs.publish }}
     steps:
       # `persist-credentials: false` (Issue #3355) — the default `true`
       # writes the workflow `GITHUB_TOKEN` into `.git/config` as an auth
@@ -114,20 +117,73 @@ jobs:
             --allow-net=rekor.sigstore.dev,jsr.io \
             scripts/verify_provenance.ts publish-output.log
 
-      # Issue #3008 (SCR-SBOM): emit a machine-readable Software Bill of
-      # Materials for the published version. Deno has no first-class SBOM
-      # emitter, so generate a CycloneDX document over the committed deno.lock
-      # (-t deno) — the same resolved tree that ships. Downstream consumers use
-      # this to answer "did the version I depend on include the compromised
-      # package?" without re-resolving the dependency graph.
+  # Issue #3008 (SCR-SBOM): emit a machine-readable Software Bill of Materials
+  # for the published version. Deno has no first-class SBOM emitter, so
+  # generate a CycloneDX document over the committed deno.lock (-t deno) — the
+  # same resolved tree that ships. Downstream consumers use this to answer "did
+  # the version I depend on include the compromised package?" without
+  # re-resolving the dependency graph.
+  #
+  # Issue #3668: this runs in its OWN job, deliberately. `permissions` is
+  # job-scoped, so while the SBOM step lived in `publish` the JSR OIDC
+  # credential (ACTIONS_ID_TOKEN_REQUEST_URL / _TOKEN) was still mintable from
+  # its environment — a hijacked release of the third-party generator could
+  # have minted a `jsr.io`-audience token and tokenlessly published a
+  # trojanised @stsoftware/neat-ai carrying valid Sigstore provenance. Splitting
+  # the job removes the credential from the blast radius entirely; `contents:
+  # read` is all an SBOM build needs.
+  sbom:
+    name: Generate CycloneDX SBOM
+    needs: publish
+    # Same release gate as the publish step, hoisted to the job: the SBOM is a
+    # per-release artefact and every push to Develop runs this workflow.
+    if: needs.publish.outputs.publish == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      # actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+
+      # verify-wasm: "false" — this job only reads deno.lock; it never loads
+      # the WASM bundle, and the publish job has already verified the pin.
+      - name: Setup Deno
+        uses: ./.github/actions/setup-neat
+        with:
+          verify-wasm: "false"
+
+      # Issue #3668: pinned and sandboxed, not `-A npm:@cyclonedx/cdxgen`.
+      #
+      # The pin makes every upgrade a reviewable diff instead of a silent
+      # `latest` resolution from the npm registry on each run. Renovate does not
+      # manage specifiers inside a `run:` block, so bump this by hand.
+      #
+      # The permission set is the minimum a `-t deno` run needs, verified
+      # locally: read (the repo plus cdxgen's own files in DENO_DIR), write
+      # scoped to the output file, env (cdxgen and its dependency tree read
+      # dozens of variables) and sys (homedir/uid/userInfo probes). Crucially
+      # there is no --allow-net, --allow-run or --allow-ffi, so a hijacked
+      # release has no route off the runner and cannot tamper with the source
+      # tree. A missing permission fails loud with Deno's NotCapable error
+      # rather than degrading the SBOM silently (Issue #3234).
+      #
+      # `--no-lock` keeps the module loader from writing its own resolution of
+      # the generator into the committed deno.lock. Lockfile writes bypass
+      # --allow-write, and cdxgen reads deno.lock as its input: without this the
+      # generator's ~190 npm dependencies end up inside the SBOM describing the
+      # published package (308 components instead of 120, measured locally).
       - name: Generate CycloneDX SBOM
-        if: steps.needs_publish.outputs.publish == 'true'
-        run: deno run -A npm:@cyclonedx/cdxgen -t deno -o sbom.cdx.json .
+        run: |
+          set -Eeuo pipefail
+          deno run --no-lock --allow-read --allow-write=sbom.cdx.json --allow-env --allow-sys \
+            npm:@cyclonedx/cdxgen@12.8.2 -t deno -o sbom.cdx.json .
 
       # Pinned per github-actions-audit (SCR-ACTIONS-PIN): 40-char commit SHA,
       # not a moving tag. Same release as coverage.yaml's upload-artifact.
       - name: Upload SBOM
-        if: steps.needs_publish.outputs.publish == 'true'
         # actions/upload-artifact@v7.0.1 — Node 24 runtime (Issue #2767)
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:

--- a/docs/archive/pr-summaries/pr-summary-3668.md
+++ b/docs/archive/pr-summaries/pr-summary-3668.md
@@ -1,0 +1,160 @@
+# Harden the CycloneDX SBOM step against package hijack (Issue #3668)
+
+## Summary
+
+`.github/workflows/publish.yml` ran an **unpinned** third-party npm package with
+Deno's **all-permissions** flag inside the job that holds the JSR OIDC
+publishing credential:
+
+```yaml
+- name: Generate CycloneDX SBOM
+  if: steps.needs_publish.outputs.publish == 'true'
+  run: deno run -A npm:@cyclonedx/cdxgen -t deno -o sbom.cdx.json .
+```
+
+Four properties combined into a package-hijack path. The bare specifier resolved
+`latest` from the npm registry on every run (no `deno.lock` entry, and
+`bump-deps.sh`'s quarantine only covers declared `deno.json` `imports`); `-A`
+granted filesystem, network, environment, subprocess and FFI access; and
+`permissions:` is **job-scoped**, so `ACTIONS_ID_TOKEN_REQUEST_URL` /
+`ACTIONS_ID_TOKEN_REQUEST_TOKEN` were still live in that step's environment. A
+compromised upstream release — no repository access required — could have minted
+a fresh `jsr.io`-audience token and tokenlessly published a trojanised
+`@stsoftware/neat-ai` carrying **valid** Sigstore provenance, because the
+legitimate pipeline minted it.
+
+Two of the issue's three suggested fixes are applied; each breaks the chain on
+its own.
+
+1. **SBOM generation moved to its own `sbom` job** (`needs: publish`,
+   `permissions: contents: read`, no `id-token` grant), mirroring the split
+   already used in `pages.yml`. The `publish` job now exposes the release gate
+   as a job output so the new job reuses the same signal
+   (`needs.publish.outputs.publish == 'true'`).
+2. **The generator is pinned and sandboxed**:
+   `deno run --no-lock --allow-read --allow-write=sbom.cdx.json --allow-env --allow-sys npm:@cyclonedx/cdxgen@12.8.2`.
+   No `--allow-net`, no `--allow-run`, no `--allow-ffi` — a hijacked release has
+   no route off the runner and cannot rewrite source files that later CI steps
+   execute. A missing permission fails loud with Deno's `NotCapable` error
+   rather than degrading the SBOM silently (Issue #3234).
+
+Scoping the write permission surfaced a **latent correctness bug in the SBOM
+itself**. Deno's module loader writes its resolution of the generator into
+`deno.lock`, and that write bypasses `--allow-write`; cdxgen then reads
+`deno.lock` as its input. Every SBOM published so far therefore described the
+generator's own dependency tree as well as the package's — measured locally,
+**308 components with the polluted lockfile versus 120 with a clean one**
+(`@appthreat/atom-common` and friends were in the artefact; they are not
+dependencies of `@stsoftware/neat-ai`). `--no-lock` fixes it at the same call
+site.
+
+The issue's third suggestion — `step-security/harden-runner` egress filtering —
+is **not** adopted here. With SBOM generation moved out of the credential-
+bearing job and network access removed from the generator, the remaining benefit
+is marginal, while adding an always-on third-party network agent to the
+OIDC-bearing publish job introduces exactly the class of dependency this change
+removes. Repo-wide egress filtering is a separate policy decision, not a
+property of this call site.
+
+`renovate.json` is deliberately untouched: the sibling quarantine finding is
+tracked as stSoftwareAU/NEAT-AI#3675. Renovate does not parse specifiers inside
+a `run:` block, so the cdxgen pin is bumped by hand — which is the point, since
+the bump is now a reviewable diff.
+
+Closes #3668.
+
+## Evidence
+
+Backend/CI-only change — no web interface to screenshot.
+
+Blast radius before and after (the OIDC credential is the shaded surface):
+
+```mermaid
+flowchart TB
+    subgraph before["Before — one job, id-token: write"]
+        direction TB
+        B1[checkout] --> B2[deno publish<br/>OIDC mints Sigstore provenance]
+        B2 --> B3[verify provenance<br/>scoped --allow-read/--allow-net]
+        B3 --> B4["deno run -A npm:@cyclonedx/cdxgen<br/>unpinned · all permissions<br/>OIDC still mintable"]
+        B4 --> B5[upload SBOM]
+    end
+    subgraph after["After — split jobs"]
+        direction TB
+        subgraph pub["job: publish (contents: read, id-token: write)"]
+            A1[checkout] --> A2[deno publish] --> A3[verify provenance]
+        end
+        subgraph sb["job: sbom (contents: read only)"]
+            A4[checkout] --> A5["deno run --no-lock --allow-read<br/>--allow-write=sbom.cdx.json<br/>--allow-env --allow-sys<br/>npm:@cyclonedx/cdxgen@12.8.2"]
+            A5 --> A6[upload SBOM]
+        end
+        pub -->|"needs.publish.outputs.publish == 'true'"| sb
+    end
+```
+
+The permission set was derived empirically, not guessed: the narrowed command
+was run locally against this repository until it completed, with no network or
+subprocess access granted. It emits a valid CycloneDX 1.7 document — and, with
+`--no-lock`, one that finally describes only the published tree.
+
+```text
+$ deno run --no-prompt --no-lock --allow-read --allow-write=…/clean.cdx.json \
+    --allow-env --allow-sys npm:@cyclonedx/cdxgen@12.8.2 -t deno -o …/clean.cdx.json .
+components: 120   (cspell*, stsoftware__tags, std__*, …)
+generator's own deps present: []      # git status: deno.lock unchanged
+
+# without --no-lock, for comparison:
+components: 308   (includes @appthreat/atom-common and the rest of cdxgen's tree)
+```
+
+Intermediate runs confirmed the flags are genuinely required (each omission
+fails loud rather than silently producing a thinner SBOM):
+
+- without `--allow-read` on `DENO_DIR`: `NotCapable … lic-mapping.json`
+- without `--allow-sys`: `NotCapable: Requires sys access to "homedir"` /
+  `"uid"`
+- without `--allow-env`:
+  `NotCapable: Requires env access to "YARGS_MIN_NODE_VERSION"`
+
+`--allow-env` stays unscoped because cdxgen and its dependency tree read dozens
+of variables and the list changes between releases; the new job carries no
+secrets, so there is nothing in that environment worth reading, and without
+`--allow-net`/`--allow-run` there is nowhere to send it.
+
+`actionlint .github/workflows/publish.yml` passes with no findings.
+
+## Test Plan
+
+New — `test/ci/SbomStepLeastPrivilege.ts` (every one of them failed against the
+unfixed workflow; all pass now):
+
+- `the SBOM generator runs outside the JSR OIDC job` — the job containing the
+  cdxgen step must not grant `id-token`.
+- `the SBOM job requests only contents: read` — explicit least-privilege
+  `permissions:` block, nothing beyond `contents`.
+- `the cdxgen specifier is version-pinned` — rejects a bare
+  `npm:@cyclonedx/cdxgen` that resolves `latest`.
+- `the cdxgen invocation does not use --allow-all`.
+- `the cdxgen invocation grants no network, subprocess or FFI access`.
+- `the cdxgen invocation does not rewrite the committed lockfile` — requires
+  `--no-lock`, the fix for the SBOM pollution described above.
+- `the cdxgen invocation scopes its write access to the SBOM file`.
+
+Modified (documented, nothing removed):
+
+- `test/ci/SbomPublishWorkflow.ts` — the release-gate test previously required
+  the gate on each step's `if:`. Moving the steps into a dedicated job hoists
+  that gate to the job, so the test now evaluates the **effective** condition
+  (job `if:` combined with step `if:`) and accepts either
+  `steps.needs_publish.outputs.publish` or `needs.publish.outputs.publish`. The
+  requirement it encodes — the SBOM is emitted only for a new release version —
+  is unchanged, and the other three tests in the file are untouched.
+- `test/ci/SetupNeatCompositeAction.ts` — added the new `sbom` job to
+  `CALL_SITES` with `verifyWasm: false`, so the job is held to the same shared
+  preamble rules as every other job (checkout before the composite action, no
+  inlined `setup-deno`/`build.sh`).
+
+Existing gates re-run green over the new job: `WorkflowJobTimeoutMinutes`
+(`timeout-minutes: 15`), `WorkflowPersistCredentialsFalse`
+(`persist-credentials: false`), `WorkflowActionPinning` (40-char SHA pins),
+`ProvenancePublishWorkflow` and `PublishProvenanceGate` (the `publish` job keeps
+`contents: read` + `id-token: write` and its provenance gate).

--- a/test/ci/SbomPublishWorkflow.ts
+++ b/test/ci/SbomPublishWorkflow.ts
@@ -29,6 +29,7 @@ interface Step {
 }
 
 interface Job {
+  if?: string;
   steps?: Step[];
 }
 
@@ -41,25 +42,47 @@ async function readWorkflow(): Promise<Workflow> {
   return parse(text) as Workflow;
 }
 
-function allSteps(wf: Workflow): Step[] {
-  const steps: Step[] = [];
+/** A step paired with the `if:` of the job that contains it. */
+interface OwnedStep {
+  step: Step;
+  jobIf: string;
+}
+
+function allSteps(wf: Workflow): OwnedStep[] {
+  const steps: OwnedStep[] = [];
   for (const job of Object.values(wf.jobs ?? {})) {
-    for (const step of job.steps ?? []) steps.push(step);
+    for (const step of job.steps ?? []) {
+      steps.push({ step, jobIf: job.if ?? "" });
+    }
   }
   return steps;
 }
 
-function sbomGenerationStep(wf: Workflow): Step | undefined {
+function sbomGenerationStep(wf: Workflow): OwnedStep | undefined {
   return allSteps(wf).find(
-    (s) => typeof s.run === "string" && /cdxgen/.test(s.run),
+    ({ step }) => typeof step.run === "string" && /cdxgen/.test(step.run),
   );
 }
 
-function sbomUploadStep(wf: Workflow): Step | undefined {
+function sbomUploadStep(wf: Workflow): OwnedStep | undefined {
   return allSteps(wf).find(
-    (s) =>
-      typeof s.uses === "string" && /actions\/upload-artifact/.test(s.uses),
+    ({ step }) =>
+      typeof step.uses === "string" &&
+      /actions\/upload-artifact/.test(step.uses),
   );
+}
+
+/**
+ * The condition that actually decides whether a step runs: its own `if:` plus
+ * the `if:` of its job. Issue #3668 moved the SBOM steps into a dedicated job
+ * with no `id-token` grant, so the release gate is now expressed once on the
+ * job (`needs.publish.outputs.publish`) instead of on each step
+ * (`steps.needs_publish.outputs.publish`). Either placement satisfies the
+ * requirement this test encodes — that the SBOM is emitted only for a new
+ * release version.
+ */
+function effectiveCondition({ step, jobIf }: OwnedStep): string {
+  return [jobIf, step.if ?? ""].filter((c) => c !== "").join(" && ");
 }
 
 Deno.test("publish.yml generates a CycloneDX SBOM from the lockfile (Issue #3008)", async () => {
@@ -70,7 +93,7 @@ Deno.test("publish.yml generates a CycloneDX SBOM from the lockfile (Issue #3008
     "publish.yml must run a CycloneDX generator (e.g. npm:@cyclonedx/cdxgen) " +
       "to produce an SBOM for the published version",
   );
-  const run = step!.run ?? "";
+  const run = step!.step.run ?? "";
   // Deno has no first-class SBOM emitter, so the generator must target Deno so
   // it reads the resolved deno.lock rather than guessing the ecosystem.
   assert(
@@ -87,7 +110,7 @@ Deno.test("publish.yml writes a recognisable SBOM filename (Issue #3008)", async
   assert(gen !== undefined, "no SBOM generation step found");
   assert(upload !== undefined, "no SBOM upload step found");
 
-  const genRun = gen!.run ?? "";
+  const genRun = gen!.step.run ?? "";
   // CycloneDX SBOMs are conventionally named *.cdx.json (or sbom*.json).
   assert(
     /(sbom[^\s]*\.(json|xml)|[^\s]*\.cdx\.json)/.test(genRun),
@@ -95,7 +118,7 @@ Deno.test("publish.yml writes a recognisable SBOM filename (Issue #3008)", async
       "(e.g. sbom.cdx.json) so consumers can find it",
   );
 
-  const path = String(upload!.with?.["path"] ?? "");
+  const path = String(upload!.step.with?.["path"] ?? "");
   assert(
     /(sbom|\.cdx\.json)/.test(path),
     "the upload-artifact step must upload the generated SBOM file via its " +
@@ -111,7 +134,7 @@ Deno.test("publish.yml uploads the SBOM as a build artefact (Issue #3008)", asyn
     "publish.yml must upload the generated SBOM via actions/upload-artifact " +
       "so downstream consumers can retrieve the bill of materials",
   );
-  const name = String(upload!.with?.["name"] ?? "");
+  const name = String(upload!.step.with?.["name"] ?? "");
   assert(
     name.trim().length > 0,
     "the upload-artifact step must set a non-empty artefact `name`",
@@ -126,16 +149,18 @@ Deno.test("publish.yml only emits the SBOM when a new version is published (Issu
 
   // Every push to Develop runs this workflow, but the version only changes on a
   // release commit. The SBOM is a per-release artefact, so both steps must be
-  // gated on the same needs_publish signal that gates the JSR publish step.
+  // gated on the same needs_publish signal that gates the JSR publish step —
+  // either directly on the step, or on the job that contains it.
   for (
-    const [label, step] of [["generation", gen!], ["upload", upload!]] as const
+    const [label, owned] of [["generation", gen!], ["upload", upload!]] as const
   ) {
-    const cond = step.if ?? "";
+    const cond = effectiveCondition(owned);
     assert(
-      /needs_publish\.outputs\.publish\s*==\s*'true'/.test(cond),
-      `the SBOM ${label} step must be gated on ` +
-        "steps.needs_publish.outputs.publish == 'true' so it only runs for a " +
-        `new release version, got if: '${cond}'`,
+      /(steps\.needs_publish|needs\.publish)\.outputs\.publish\s*==\s*'true'/
+        .test(cond),
+      `the SBOM ${label} step must be gated on the publish signal ` +
+        "(steps.needs_publish.outputs.publish or needs.publish.outputs.publish " +
+        `== 'true') so it only runs for a new release version, got: '${cond}'`,
     );
   }
 });

--- a/test/ci/SbomStepLeastPrivilege.ts
+++ b/test/ci/SbomStepLeastPrivilege.ts
@@ -1,0 +1,196 @@
+/**
+ * Issue #3668 — the CycloneDX SBOM generator was an unpinned third-party npm
+ * package executed with Deno's all-permissions flag (`-A`) inside the job that
+ * holds the JSR OIDC publishing credential:
+ *
+ * ```yaml
+ * run: deno run -A npm:@cyclonedx/cdxgen -t deno -o sbom.cdx.json .
+ * ```
+ *
+ * Four properties combined into a package-hijack path. The specifier resolved
+ * `latest` fresh from the npm registry on every run, no quarantine covered an
+ * inline workflow specifier, `-A` granted filesystem, network, environment,
+ * subprocess and FFI access, and `permissions: id-token: write` is job-scoped —
+ * so `ACTIONS_ID_TOKEN_REQUEST_URL` / `ACTIONS_ID_TOKEN_REQUEST_TOKEN` were
+ * still live in the environment of that step. Anyone who compromised the
+ * upstream package could mint a fresh `jsr.io`-audience token and tokenlessly
+ * publish a trojanised `@stsoftware/neat-ai` — carrying valid Sigstore
+ * provenance, because the legitimate pipeline minted it.
+ *
+ * The fix removes the credential from the blast radius (SBOM generation moved
+ * to its own job with no `id-token` grant) and constrains the invocation
+ * itself: a pinned version and an explicit permission set with no network, no
+ * subprocess and no FFI, so the generator cannot reach the outside world even
+ * if it is hijacked.
+ *
+ * These are "what" tests: they parse the committed workflow YAML and assert on
+ * the resulting configuration, not on how any value happens to be written.
+ */
+
+import { assert } from "@std/assert";
+import { fromFileUrl, join } from "@std/path";
+import { parse } from "@std/yaml";
+
+const REPO_ROOT = fromFileUrl(new URL("../../", import.meta.url));
+const PUBLISH_WORKFLOW = join(REPO_ROOT, ".github/workflows/publish.yml");
+
+interface Step {
+  name?: string;
+  uses?: string;
+  run?: string;
+  if?: string;
+  with?: Record<string, unknown>;
+}
+
+interface Job {
+  if?: string;
+  needs?: string | string[];
+  permissions?: Record<string, string>;
+  outputs?: Record<string, string>;
+  steps?: Step[];
+}
+
+interface Workflow {
+  jobs?: Record<string, Job>;
+}
+
+async function readWorkflow(): Promise<Workflow> {
+  return parse(await Deno.readTextFile(PUBLISH_WORKFLOW)) as Workflow;
+}
+
+/** The job id + step that invokes the CycloneDX generator. */
+function findGenerator(
+  wf: Workflow,
+): { jobId: string; job: Job; step: Step } | undefined {
+  for (const [jobId, job] of Object.entries(wf.jobs ?? {})) {
+    for (const step of job.steps ?? []) {
+      if (typeof step.run === "string" && /cdxgen/.test(step.run)) {
+        return { jobId, job, step };
+      }
+    }
+  }
+  return undefined;
+}
+
+async function generator(): Promise<{ jobId: string; job: Job; run: string }> {
+  const found = findGenerator(await readWorkflow());
+  assert(
+    found !== undefined,
+    "publish.yml must run a CycloneDX generator to produce the SBOM",
+  );
+  return { jobId: found.jobId, job: found.job, run: found.step.run ?? "" };
+}
+
+/** Permission flags granted to the `deno run` that invokes the generator. */
+function grantedFlags(run: string): string[] {
+  return run.match(/--allow-[a-z-]+(?:=[^\s\\]*)?/g) ?? [];
+}
+
+Deno.test("the SBOM generator runs outside the JSR OIDC job (Issue #3668)", async () => {
+  const { jobId, job } = await generator();
+  const idToken = job.permissions?.["id-token"];
+  assert(
+    idToken === undefined || idToken === "none",
+    `job "${jobId}" generates the SBOM with a third-party package but also ` +
+      `grants id-token: ${idToken}. The OIDC credential is job-scoped, so it ` +
+      "stays mintable for every later step — a hijacked generator could " +
+      "tokenlessly publish to JSR. Generate the SBOM in a job with no " +
+      "id-token grant.",
+  );
+});
+
+Deno.test("the SBOM job requests only contents: read (Issue #3668)", async () => {
+  const { jobId, job } = await generator();
+  const perms = job.permissions;
+  assert(
+    perms !== undefined,
+    `job "${jobId}" must declare an explicit least-privilege \`permissions:\` ` +
+      "block rather than inheriting the workflow or repository default",
+  );
+  const granted = Object.entries(perms!)
+    .filter(([, level]) => level !== "none")
+    .map(([scope]) => scope)
+    .sort();
+  assert(
+    granted.length === 1 && granted[0] === "contents",
+    `job "${jobId}" needs nothing beyond \`contents: read\` to build and ` +
+      `upload an SBOM, but grants: ${granted.join(", ") || "(nothing)"}`,
+  );
+});
+
+Deno.test("the cdxgen specifier is version-pinned (Issue #3668)", async () => {
+  const { run } = await generator();
+  const specifiers = run.match(/npm:@cyclonedx\/cdxgen[^\s\\]*/g) ?? [];
+  assert(specifiers.length > 0, "no npm:@cyclonedx/cdxgen specifier found");
+  for (const specifier of specifiers) {
+    assert(
+      /^npm:@cyclonedx\/cdxgen@\d+\.\d+\.\d+$/.test(specifier),
+      `'${specifier}' resolves \`latest\` from the npm registry on every run, ` +
+        "so a malicious release executes with no review. Pin an exact " +
+        "version (npm:@cyclonedx/cdxgen@x.y.z) so a bump is a reviewable diff.",
+    );
+  }
+});
+
+Deno.test("the cdxgen invocation does not use --allow-all (Issue #3668)", async () => {
+  const { run } = await generator();
+  assert(
+    !/(^|\s)(-A|--allow-all)(\s|$)/.test(run),
+    "the SBOM generator must not run with `-A` / `--allow-all`; grant only " +
+      "the permissions it needs so a hijacked release cannot reach the " +
+      "network, spawn processes, or load native code",
+  );
+});
+
+Deno.test("the cdxgen invocation grants no network, subprocess or FFI access (Issue #3668)", async () => {
+  const { run } = await generator();
+  const flags = grantedFlags(run);
+  // The SBOM is built from the committed deno.lock, so the generator needs no
+  // egress at all — and without egress, subprocess/FFI escapes are the only
+  // remaining way out of the sandbox.
+  for (const forbidden of ["--allow-net", "--allow-run", "--allow-ffi"]) {
+    const granted = flags.filter((f) => f.split("=")[0] === forbidden);
+    assert(
+      granted.length === 0,
+      `the SBOM generator must not be granted ${forbidden} (got ` +
+        `'${granted.join(", ")}'): it reads the committed deno.lock, so it ` +
+        "needs no egress, and either flag re-opens the exfiltration path",
+    );
+  }
+});
+
+Deno.test("the cdxgen invocation does not rewrite the committed lockfile (Issue #3668)", async () => {
+  const { run } = await generator();
+  // Deno's module loader writes its own resolution of the generator into
+  // deno.lock, and that write bypasses --allow-write. cdxgen reads deno.lock as
+  // its input, so without --no-lock the generator's own dependency tree lands
+  // inside the SBOM that describes the published package.
+  assert(
+    /(^|\s)--no-lock(\s|$)/.test(run),
+    "the SBOM generator must run with --no-lock so resolving it does not " +
+      "mutate the committed deno.lock — the same lockfile it reads to " +
+      "enumerate the published dependency tree",
+  );
+});
+
+Deno.test("the cdxgen invocation scopes its write access to the SBOM file (Issue #3668)", async () => {
+  const { run } = await generator();
+  const writes = grantedFlags(run).filter((f) =>
+    f.split("=")[0] === "--allow-write"
+  );
+  assert(
+    writes.length === 1,
+    `expected exactly one --allow-write flag, got '${writes.join(", ")}'`,
+  );
+  const [, value] = writes[0].split("=");
+  assert(
+    value !== undefined && value.trim().length > 0,
+    "--allow-write must be scoped to the SBOM output path, not granted " +
+      "repository-wide — otherwise a hijacked generator can rewrite source " +
+      "files that later CI jobs execute",
+  );
+  assert(
+    /sbom/i.test(value),
+    `--allow-write must name the SBOM output file, got '${value}'`,
+  );
+});

--- a/test/ci/SetupNeatCompositeAction.ts
+++ b/test/ci/SetupNeatCompositeAction.ts
@@ -108,6 +108,13 @@ const CALL_SITES: { workflow: string; job: string; verifyWasm: boolean }[] = [
     job: "publish",
     verifyWasm: true,
   },
+  // Issue #3668 split SBOM generation out of the OIDC-bearing publish job. It
+  // only reads deno.lock, so it opts out of the WASM sync.
+  {
+    workflow: ".github/workflows/publish.yml",
+    job: "sbom",
+    verifyWasm: false,
+  },
 ];
 
 async function readJob(workflow: string, jobId: string): Promise<Job> {


### PR DESCRIPTION
# Harden the CycloneDX SBOM step against package hijack (Issue #3668)

## Summary

`.github/workflows/publish.yml` ran an **unpinned** third-party npm package with
Deno's **all-permissions** flag inside the job that holds the JSR OIDC
publishing credential:

***REDACTED***
- name: Generate CycloneDX SBOM
  if: steps.needs_publish.outputs.publish == 'true'
  run: deno run -A npm:@cyclonedx/cdxgen -t deno -o sbom.cdx.json .
```

Four properties combined into a package-hijack path. The bare specifier resolved
`latest` from the npm registry on every run (no `deno.lock` entry, and
`bump-deps.sh`'s quarantine only covers declared `deno.json` `imports`); `-A`
granted filesystem, network, environment, subprocess and FFI access; and
`permissions:` is **job-scoped**, so `ACTIONS_ID_TOKEN_REQUEST_URL` /
`ACTIONS_ID_TOKEN_REQUEST_TOKEN` were still live in that step's environment. A
compromised upstream release — no repository access required — could have minted
a fresh `jsr.io`-audience token and tokenlessly published a trojanised
`@stsoftware/neat-ai` carrying **valid** Sigstore provenance, because the
legitimate pipeline minted it.

Two of the issue's three suggested fixes are applied; each breaks the chain on
its own.

1. **SBOM generation moved to its own `sbom` job** (`needs: publish`,
   `permissions: contents: read`, no `id-token` grant), mirroring the split
   already used in `pages.yml`. The `publish` job now exposes the release gate
   as a job output so the new job reuses the same signal
   (`needs.publish.outputs.publish == 'true'`).
2. **The generator is pinned and sandboxed**:
   `deno run --no-lock --allow-read --allow-write=sbom.cdx.json --allow-env --allow-sys npm:@cyclonedx/cdxgen@12.8.2`.
   No `--allow-net`, no `--allow-run`, no `--allow-ffi` — a hijacked release has
   no route off the runner and cannot rewrite source files that later CI steps
   execute. A missing permission fails loud with Deno's `NotCapable` error
   rather than degrading the SBOM silently (Issue #3234).

Scoping the write permission surfaced a **latent correctness bug in the SBOM
itself**. Deno's module loader writes its resolution of the generator into
`deno.lock`, and that write bypasses `--allow-write`; cdxgen then reads
`deno.lock` as its input. Every SBOM published so far therefore described the
generator's own dependency tree as well as the package's — measured locally,
**308 components with the polluted lockfile versus 120 with a clean one**
(`@appthreat/atom-common` and friends were in the artefact; they are not
dependencies of `@stsoftware/neat-ai`). `--no-lock` fixes it at the same call
site.

The issue's third suggestion — `step-security/harden-runner` egress filtering —
is **not** adopted here. With SBOM generation moved out of the credential-
bearing job and network access removed from the generator, the remaining benefit
is marginal, while adding an always-on third-party network agent to the
OIDC-bearing publish job introduces exactly the class of dependency this change
removes. Repo-wide egress filtering is a separate policy decision, not a
property of this call site.

`renovate.json` is deliberately untouched: the sibling quarantine finding is
tracked as stSoftwareAU/NEAT-AI#3675. Renovate does not parse specifiers inside
a `run:` block, so the cdxgen pin is bumped by hand — which is the point, since
the bump is now a reviewable diff.

Closes #3668.

## Evidence

Backend/CI-only change — no web interface to screenshot.

Blast radius before and after (the OIDC credential is the shaded surface):

```mermaid
flowchart TB
    subgraph before["Before — one job, id-token: ***REDACTED***
        direction TB
        B1[checkout] --> B2[deno publish<br/>OIDC mints Sigstore provenance]
        B2 --> B3[verify provenance<br/>scoped --allow-read/--allow-net]
        B3 --> B4["deno run -A npm:@cyclonedx/cdxgen<br/>unpinned · all permissions<br/>OIDC still mintable"]
        B4 --> B5[upload SBOM]
    end
    subgraph after["After — split jobs"]
        direction TB
        subgraph pub["job: publish (contents: read, id-token: ***REDACTED***
            A1[checkout] --> A2[deno publish] --> A3[verify provenance]
        end
        subgraph sb["job: sbom (contents: read only)"]
            A4[checkout] --> A5["deno run --no-lock --allow-read<br/>--allow-write=sbom.cdx.json<br/>--allow-env --allow-sys<br/>npm:@cyclonedx/cdxgen@12.8.2"]
            A5 --> A6[upload SBOM]
        end
        pub -->|"needs.publish.outputs.publish == 'true'"| sb
    end
```

The permission set was derived empirically, not guessed: the narrowed command
was run locally against this repository until it completed, with no network or
subprocess access granted. It emits a valid CycloneDX 1.7 document — and, with
`--no-lock`, one that finally describes only the published tree.

```text
$ deno run --no-prompt --no-lock --allow-read --allow-write=…/clean.cdx.json \
    --allow-env --allow-sys npm:@cyclonedx/cdxgen@12.8.2 -t deno -o …/clean.cdx.json .
components: 120   (cspell*, stsoftware__tags, std__*, …)
generator's own deps present: []      # git status: deno.lock unchanged

# without --no-lock, for comparison:
components: 308   (includes @appthreat/atom-common and the rest of cdxgen's tree)
```

Intermediate runs confirmed the flags are genuinely required (each omission
fails loud rather than silently producing a thinner SBOM):

- without `--allow-read` on `DENO_DIR`: `NotCapable … lic-mapping.json`
- without `--allow-sys`: `NotCapable: Requires sys access to "homedir"` /
  `"uid"`
- without `--allow-env`:
  `NotCapable: Requires env access to "YARGS_MIN_NODE_VERSION"`

`--allow-env` stays unscoped because cdxgen and its dependency tree read dozens
of variables and the list changes between releases; the new job carries no
secrets, so there is nothing in that environment worth reading, and without
`--allow-net`/`--allow-run` there is nowhere to send it.

`actionlint .github/workflows/publish.yml` passes with no findings.

## Test Plan

New — `test/ci/SbomStepLeastPrivilege.ts` (every one of them failed against the
unfixed workflow; all pass now):

- `the SBOM generator runs outside the JSR OIDC job` — the job containing the
  cdxgen step must not grant `id-token`.
- `the SBOM job requests only contents: read` — explicit least-privilege
  `permissions:` block, nothing beyond `contents`.
- `the cdxgen specifier is version-pinned` — rejects a bare
  `npm:@cyclonedx/cdxgen` that resolves `latest`.
- `the cdxgen invocation does not use --allow-all`.
- `the cdxgen invocation grants no network, subprocess or FFI access`.
- `the cdxgen invocation does not rewrite the committed lockfile` — requires
  `--no-lock`, the fix for the SBOM pollution described above.
- `the cdxgen invocation scopes its write access to the SBOM file`.

Modified (documented, nothing removed):

- `test/ci/SbomPublishWorkflow.ts` — the release-gate test previously required
  the gate on each step's `if:`. Moving the steps into a dedicated job hoists
  that gate to the job, so the test now evaluates the **effective** condition
  (job `if:` combined with step `if:`) and accepts either
  `steps.needs_publish.outputs.publish` or `needs.publish.outputs.publish`. The
  requirement it encodes — the SBOM is emitted only for a new release version —
  is unchanged, and the other three tests in the file are untouched.
- `test/ci/SetupNeatCompositeAction.ts` — added the new `sbom` job to
  `CALL_SITES` with `verifyWasm: false`, so the job is held to the same shared
  preamble rules as every other job (checkout before the composite action, no
  inlined `setup-deno`/`build.sh`).

Existing gates re-run green over the new job: `WorkflowJobTimeoutMinutes`
(`timeout-minutes: 15`), `WorkflowPersistCredentialsFalse`
(`persist-credentials: ***REDACTED*** `WorkflowActionPinning` (40-char SHA pins),
`ProvenancePublishWorkflow` and `PublishProvenanceGate` (the `publish` job keeps
`contents: read` + `id-token: ***REDACTED*** and its provenance gate).



## Milestone
This PR is part of the **Scan 20260807** milestone and targets the `milestone/scan-20260807` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-msilqnke-76ee26`<!-- vibe-worker-issue-3668 -->