### PR TITLE
🟡 `build.sh` and `scripts/**` execute in the JSR `id-token: write` job but sit outside the CODEOWNERS review gate (.github/CODEOWNERS:16-20) (Issue #3669)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,3 +18,19 @@
 
 # The CODEOWNERS file itself, so ownership rules cannot be quietly changed.
 /.github/CODEOWNERS  @stSoftwareAU/developers
+
+# Repository code the privileged jobs EXECUTE (Issue #3669). Owning the
+# workflow files alone stopped one line short of the credential: the composite
+# action `.github/actions/setup-neat` does nothing but `run: ./build.sh
+# --verify-only`, and `scripts/verify_provenance.ts` is the provenance gate
+# itself — both run inside publish.yml's `id-token: write` job, where the JSR
+# OIDC credential is mintable by every step. `deno.json` carries the `version`
+# that gates publishing, the `neatCore.assetSha256` integrity pin, and the
+# `tasks` bodies CI executes.
+#
+# `test/ci/CodeownersPrivilegedJobCoverage.ts` derives this requirement from
+# the workflows, so a new script added to a privileged job fails CI until it is
+# covered here.
+/build.sh            @stSoftwareAU/developers
+/scripts/            @stSoftwareAU/developers
+/deno.json           @stSoftwareAU/developers

--- a/docs/REPO_GOVERNANCE.md
+++ b/docs/REPO_GOVERNANCE.md
@@ -56,6 +56,42 @@ automated worker account, so it is not used as a human code owner.)
 > unenforced. `test/ci/CodeownersWorkflowsCoverage.ts` guards against that
 > regression.
 
+## Ownership must reach the code the workflow runs (Issue #3669)
+
+Owning the workflow files alone left the gate one line short of the credential.
+`permissions:` is **job-scoped**, so every step in `publish.yml`'s `publish` job
+can mint the JSR OIDC token — including the steps that execute repository code:
+
+| Executed by the `id-token: write` job | Reached via                                                    |
+| ------------------------------------- | -------------------------------------------------------------- |
+| `build.sh`                            | `.github/actions/setup-neat` → `run: ./build.sh --verify-only` |
+| `scripts/verify_provenance.ts`        | the provenance gate step in `publish.yml`                      |
+| `deno.json`                           | the version check that decides whether to publish              |
+
+The composite action was owned; the script it runs was not — so editing
+`build.sh` achieved what editing the owned `action.yml` would, without tripping
+the rule. Worse, `scripts/verify_provenance.ts` **is** the control that turns a
+bad publish red, so an unreviewed edit could disable the check that would report
+it. `.github/CODEOWNERS` therefore also owns `/build.sh`, `/scripts/` and
+`/deno.json`.
+
+```mermaid
+flowchart LR
+    W[".github/workflows/publish.yml<br/>job: publish<br/>id-token: write"] --> A[".github/actions/setup-neat"]
+    A --> B["build.sh"]
+    W --> V["scripts/verify_provenance.ts"]
+    W --> D["deno.json"]
+    B & V & D --> T{"Covered by<br/>CODEOWNERS?"}
+    T -- "before #3669: No" --> X["Unreviewed edit runs<br/>beside the JSR OIDC token"]
+    T -- "now: Yes" --> O["Code-owner review required"]
+```
+
+`test/ci/CodeownersPrivilegedJobCoverage.ts` derives this requirement from the
+workflows rather than from a hand-written list: it parses every job granting
+`id-token: write`, follows local composite actions, collects each repository
+file the job executes, and asserts all of them resolve to an owner. Adding a new
+script to a privileged job fails that test until the gate is extended.
+
 ## Required branch-protection settings
 
 CODEOWNERS only _requests_ review; it is enforced **only** once branch

--- a/docs/archive/pr-summaries/pr-summary-3669.md
+++ b/docs/archive/pr-summaries/pr-summary-3669.md
@@ -2,15 +2,15 @@
 
 ## Summary
 
-`.github/CODEOWNERS` owned the workflow *files* but not the repository *code
-those workflows execute*, so the review gate stopped one line short of the
+`.github/CODEOWNERS` owned the workflow _files_ but not the repository _code
+those workflows execute_, so the review gate stopped one line short of the
 privileged credential. `publish.yml`'s `publish` job holds
 `permissions: id-token: write` — the JSR OIDC credential backing tokenless
 publishing of `@stsoftware/neat-ai` — and `permissions:` is job-scoped, so every
 step in that job can mint the token. Three repository paths ran inside it
 unowned:
 
-- `build.sh` — reached through the *owned* composite action
+- `build.sh` — reached through the _owned_ composite action
   `.github/actions/setup-neat`, whose only instruction is
   `run: ./build.sh --verify-only`. Editing `build.sh` achieved what editing the
   owned `action.yml` would, without triggering the rule.
@@ -19,14 +19,14 @@ unowned:
 - `deno.json` — carries the `version` that gates publishing, the
   `neatCore.assetSha256` integrity pin, and the `tasks` bodies CI executes.
 
-The fix adds `/build.sh`, `/scripts/` and `/deno.json` to
-`.github/CODEOWNERS`, and adds a test that derives the requirement from the
-workflows rather than from a hand-written list, so a new script added to a
-privileged job fails CI until the gate is extended to cover it.
+The fix adds `/build.sh`, `/scripts/` and `/deno.json` to `.github/CODEOWNERS`,
+and adds a test that derives the requirement from the workflows rather than from
+a hand-written list, so a new script added to a privileged job fails CI until
+the gate is extended to cover it.
 
 Closes #3669.
 
-**Still requires a human/admin action:** CODEOWNERS only *requests* review. The
+**Still requires a human/admin action:** CODEOWNERS only _requests_ review. The
 **"Require review from Code Owners"** branch-protection rule must be enabled on
 `Develop` or GitHub enforces nothing — see
 [`docs/REPO_GOVERNANCE.md`](../../REPO_GOVERNANCE.md#required-branch-protection-settings)
@@ -34,9 +34,8 @@ for the `gh api` invocation. This is a server-side setting invisible to a static
 checkout, so no test can assert it.
 
 The issue's "defence in depth" suggestion — moving the SBOM step out of the
-`id-token: write` job — was already delivered by Issue #3668
-(`publish.yml`'s `sbom` job, `contents: read` only), so nothing was changed
-there.
+`id-token: write` job — was already delivered by Issue #3668 (`publish.yml`'s
+`sbom` job, `contents: read` only), so nothing was changed there.
 
 ## Evidence
 
@@ -91,9 +90,9 @@ counts only when it resolves to a file in the checkout), and asserts:
 - `every file executed by an id-token: write job has a code owner` — the general
   case; it caught all three unowned paths without any of them being named in the
   test.
-- `the publish gate's own verifier is owned` — pins `scripts/verify_provenance.ts`
-  independently of discovery, so the gate cannot be edited in the same
-  unreviewed PR that trojanises the pipeline.
+- `the publish gate's own verifier is owned` — pins
+  `scripts/verify_provenance.ts` independently of discovery, so the gate cannot
+  be edited in the same unreviewed PR that trojanises the pipeline.
 - `a job holding the JSR OIDC credential exists and executes repository code` —
   fails loud if a restructure makes the discovery blind, rather than passing
   vacuously on an empty set (Issue #3234).

--- a/docs/archive/pr-summaries/pr-summary-3669.md
+++ b/docs/archive/pr-summaries/pr-summary-3669.md
@@ -1,0 +1,111 @@
+# Extend CODEOWNERS to the code the JSR OIDC job executes (Issue #3669)
+
+## Summary
+
+`.github/CODEOWNERS` owned the workflow *files* but not the repository *code
+those workflows execute*, so the review gate stopped one line short of the
+privileged credential. `publish.yml`'s `publish` job holds
+`permissions: id-token: write` — the JSR OIDC credential backing tokenless
+publishing of `@stsoftware/neat-ai` — and `permissions:` is job-scoped, so every
+step in that job can mint the token. Three repository paths ran inside it
+unowned:
+
+- `build.sh` — reached through the *owned* composite action
+  `.github/actions/setup-neat`, whose only instruction is
+  `run: ./build.sh --verify-only`. Editing `build.sh` achieved what editing the
+  owned `action.yml` would, without triggering the rule.
+- `scripts/verify_provenance.ts` — the provenance gate itself, so an unreviewed
+  edit could silently disable the control that turns a bad publish red.
+- `deno.json` — carries the `version` that gates publishing, the
+  `neatCore.assetSha256` integrity pin, and the `tasks` bodies CI executes.
+
+The fix adds `/build.sh`, `/scripts/` and `/deno.json` to
+`.github/CODEOWNERS`, and adds a test that derives the requirement from the
+workflows rather than from a hand-written list, so a new script added to a
+privileged job fails CI until the gate is extended to cover it.
+
+Closes #3669.
+
+**Still requires a human/admin action:** CODEOWNERS only *requests* review. The
+**"Require review from Code Owners"** branch-protection rule must be enabled on
+`Develop` or GitHub enforces nothing — see
+[`docs/REPO_GOVERNANCE.md`](../../REPO_GOVERNANCE.md#required-branch-protection-settings)
+for the `gh api` invocation. This is a server-side setting invisible to a static
+checkout, so no test can assert it.
+
+The issue's "defence in depth" suggestion — moving the SBOM step out of the
+`id-token: write` job — was already delivered by Issue #3668
+(`publish.yml`'s `sbom` job, `contents: read` only), so nothing was changed
+there.
+
+## Evidence
+
+Backend/CI governance change — no web interface to screenshot. Evidence is the
+test run below: the new tests fail against the unfixed `CODEOWNERS` and pass
+after it.
+
+Before (`CODEOWNERS` unchanged), the discovery names the exact gap from the
+issue:
+
+```text
+every file executed by an `id-token: write` job has a code owner (Issue #3669) ... FAILED
+error: AssertionError: these files run inside a job holding the JSR OIDC `id-token`,
+but no CODEOWNERS rule covers them, so they can be changed without the code-owner
+review the gate exists to force:
+  - build.sh — via .github/workflows/publish.yml (job: publish) → .github/actions/setup-neat/action.yml
+  - deno.json — via .github/workflows/publish.yml (job: publish)
+  - scripts/verify_provenance.ts — via .github/workflows/publish.yml (job: publish)
+the publish gate's own verifier is owned (Issue #3669) ... FAILED
+FAILED | 6 passed | 2 failed
+```
+
+After:
+
+```text
+running 3 tests from ./test/ci/CodeownersPrivilegedJobCoverage.ts
+a job holding the JSR OIDC credential exists and executes repository code (Issue #3669) ... ok
+every file executed by an `id-token: write` job has a code owner (Issue #3669) ... ok
+the publish gate's own verifier is owned (Issue #3669) ... ok
+running 5 tests from ./test/ci/CodeownersWorkflowsCoverage.ts
+... ok | 8 passed | 0 failed
+```
+
+```mermaid
+flowchart LR
+    W[".github/workflows/publish.yml<br/>job: publish<br/>id-token: write"] --> A[".github/actions/setup-neat<br/>(owned)"]
+    A --> B["build.sh"]
+    W --> V["scripts/verify_provenance.ts"]
+    W --> D["deno.json"]
+    B & V & D --> T{"Covered by<br/>CODEOWNERS?"}
+    T -- "before: No" --> X["Unreviewed edit runs beside<br/>the JSR OIDC credential"]
+    T -- "after: Yes" --> O["Code-owner review required"]
+```
+
+## Test Plan
+
+Added `test/ci/CodeownersPrivilegedJobCoverage.ts` — it parses every workflow
+job granting `id-token: write`, follows local `uses: ./…` composite actions into
+their own `run:` blocks, collects each repository file the job executes (a token
+counts only when it resolves to a file in the checkout), and asserts:
+
+- `every file executed by an id-token: write job has a code owner` — the general
+  case; it caught all three unowned paths without any of them being named in the
+  test.
+- `the publish gate's own verifier is owned` — pins `scripts/verify_provenance.ts`
+  independently of discovery, so the gate cannot be edited in the same
+  unreviewed PR that trojanises the pipeline.
+- `a job holding the JSR OIDC credential exists and executes repository code` —
+  fails loud if a restructure makes the discovery blind, rather than passing
+  vacuously on an empty set (Issue #3234).
+
+Supporting changes:
+
+- `test/ci/_codeowners.ts` (new) — the CODEOWNERS reader/parser/`ownersFor`
+  helpers, moved verbatim out of `test/ci/CodeownersWorkflowsCoverage.ts` so
+  both test files share them without one test file importing another (which
+  would register the same five tests twice).
+- `test/ci/CodeownersWorkflowsCoverage.ts` — imports those helpers instead of
+  defining them. **No test was removed, modified or disabled**; all five Issue
+  #3187 tests still run and pass.
+- `docs/REPO_GOVERNANCE.md` — new section documenting why ownership must reach
+  the executed code, with the path table and a Mermaid diagram.

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -516,6 +516,7 @@
     "traj",
     "trav",
     "trunc",
+    "trojanises",
     "tsmerge",
     "tunables",
     "twophase",

--- a/test/ci/CodeownersPrivilegedJobCoverage.ts
+++ b/test/ci/CodeownersPrivilegedJobCoverage.ts
@@ -1,0 +1,185 @@
+/**
+ * Issue #3669 — CODEOWNERS covered the workflow *files* but not the repository
+ * *code those workflows execute*, so ownership stopped one line short of the
+ * privileged credential.
+ *
+ * `publish.yml`'s `publish` job holds `permissions: id-token: write` — the JSR
+ * OIDC credential backing tokenless publishing of `@stsoftware/neat-ai`. That
+ * grant is job-scoped, so every step in the job can mint the token. Two of the
+ * things the job executes lived outside the gate: `./build.sh --verify-only`
+ * (reached through the owned composite action `.github/actions/setup-neat`,
+ * whose only instruction is to run the unowned script) and
+ * `scripts/verify_provenance.ts` — which is itself the provenance gate, so an
+ * unreviewed edit could disable the control that would report a bad publish.
+ *
+ * Rather than pin a hand-written list of paths, this test derives the
+ * requirement from the workflows themselves: for every job granting
+ * `id-token: write`, every repository file the job runs (directly, or through a
+ * local composite action) must resolve to a CODEOWNERS owner. A new script
+ * added to a privileged job therefore fails here until the gate is extended to
+ * cover it.
+ */
+
+import { assert } from "@std/assert";
+import { fromFileUrl, join } from "@std/path";
+import { parse } from "@std/yaml";
+import { ownersFor, parseCodeowners, readCodeowners } from "./_codeowners.ts";
+
+const REPO_ROOT = fromFileUrl(new URL("../../", import.meta.url));
+const WORKFLOWS_DIR = join(REPO_ROOT, ".github/workflows");
+
+interface Step {
+  uses?: string;
+  run?: string;
+}
+
+interface Job {
+  permissions?: Record<string, string>;
+  steps?: Step[];
+}
+
+interface Workflow {
+  jobs?: Record<string, Job>;
+}
+
+/** A repository file executed by a privileged job, with its provenance. */
+interface ExecutedPath {
+  /** Repo-relative path, e.g. `build.sh`. */
+  path: string;
+  /** Where it was found, e.g. `.github/workflows/publish.yml (job: publish)`. */
+  origin: string;
+}
+
+/** Characters that separate arguments in a shell `run:` block. */
+const TOKEN_SEPARATORS = /[\s;|&()<>"'`=,]+/;
+
+/**
+ * Repo-relative file paths named by a shell snippet.
+ *
+ * Deliberately conservative: a token counts only when it names a file that
+ * exists in the checkout, so command names, flags and expressions fall away.
+ */
+export function referencedFiles(run: string): string[] {
+  const found = new Set<string>();
+  for (const rawToken of run.split(TOKEN_SEPARATORS)) {
+    // Skip flags and anything holding a shell/Actions expression — those
+    // cannot be resolved statically.
+    if (rawToken.startsWith("-") || /[$\\{}]/.test(rawToken)) continue;
+    const token = rawToken.replace(/^\.\//, "").replace(/[.,:]+$/, "");
+    if (token === "" || token.startsWith("/")) continue;
+    if (!/^[A-Za-z0-9._][A-Za-z0-9._/-]*$/.test(token)) continue;
+    try {
+      if (Deno.statSync(join(REPO_ROOT, token)).isFile) found.add(token);
+    } catch {
+      // Not a file in the checkout (a command name, or an artefact produced at
+      // run time) — nothing to own.
+    }
+  }
+  return [...found];
+}
+
+/** The `action.yml` / `action.yaml` implementing a local `uses: ./…` step. */
+function localActionManifest(uses: string): string | null {
+  const dir = uses.replace(/^\.\//, "");
+  for (const name of ["action.yml", "action.yaml"]) {
+    const rel = join(dir, name);
+    try {
+      if (Deno.statSync(join(REPO_ROOT, rel)).isFile) return rel;
+    } catch {
+      // Try the other extension.
+    }
+  }
+  return null;
+}
+
+/** Files a step executes, following local composite actions one level deep. */
+function filesForStep(step: Step, origin: string): ExecutedPath[] {
+  if (typeof step.run === "string") {
+    return referencedFiles(step.run).map((path) => ({ path, origin }));
+  }
+  if (typeof step.uses === "string" && step.uses.startsWith("./")) {
+    const manifest = localActionManifest(step.uses);
+    if (manifest === null) return [];
+    const action = parse(
+      Deno.readTextFileSync(join(REPO_ROOT, manifest)),
+    ) as { runs?: { steps?: Step[] } };
+    const nested = (action.runs?.steps ?? []).flatMap((s) =>
+      filesForStep(s, `${origin} → ${manifest}`)
+    );
+    return [{ path: manifest, origin }, ...nested];
+  }
+  return [];
+}
+
+/** Every repository file executed by a job granting `id-token: write`. */
+export async function privilegedExecutedPaths(): Promise<ExecutedPath[]> {
+  const names: string[] = [];
+  for await (const entry of Deno.readDir(WORKFLOWS_DIR)) {
+    if (entry.isFile && /\.ya?ml$/.test(entry.name)) names.push(entry.name);
+  }
+  const sources = await Promise.all(
+    names.map((name) => Deno.readTextFile(join(WORKFLOWS_DIR, name))),
+  );
+
+  const executed = new Map<string, ExecutedPath>();
+  names.forEach((name, index) => {
+    const rel = join(".github/workflows", name);
+    const workflow = parse(sources[index]) as Workflow;
+    for (const [jobId, job] of Object.entries(workflow.jobs ?? {})) {
+      if (job.permissions?.["id-token"] !== "write") continue;
+      const origin = `${rel} (job: ${jobId})`;
+      for (const step of job.steps ?? []) {
+        // First origin wins — one entry per distinct file keeps the failure
+        // message readable.
+        for (const found of filesForStep(step, origin)) {
+          if (!executed.has(found.path)) executed.set(found.path, found);
+        }
+      }
+    }
+  });
+  return [...executed.values()];
+}
+
+Deno.test("a job holding the JSR OIDC credential exists and executes repository code (Issue #3669)", async () => {
+  const executed = await privilegedExecutedPaths();
+  assert(
+    executed.length > 0,
+    "no `id-token: write` job executing repository code was found — this test " +
+      "cannot protect what it cannot see. If the publish job was restructured, " +
+      "update the discovery in privilegedExecutedPaths().",
+  );
+});
+
+Deno.test("every file executed by an `id-token: write` job has a code owner (Issue #3669)", async () => {
+  const file = await readCodeowners();
+  assert(file !== null, "CODEOWNERS file is required");
+  const rules = parseCodeowners(file.source);
+
+  const unowned = (await privilegedExecutedPaths())
+    .filter(({ path }) => ownersFor(rules, path).length === 0);
+
+  assert(
+    unowned.length === 0,
+    "these files run inside a job holding the JSR OIDC `id-token`, but no " +
+      "CODEOWNERS rule covers them, so they can be changed without the " +
+      "code-owner review the gate exists to force:\n" +
+      unowned.map(({ path, origin }) => `  - ${path} — via ${origin}`)
+        .join("\n"),
+  );
+});
+
+Deno.test("the publish gate's own verifier is owned (Issue #3669)", async () => {
+  const file = await readCodeowners();
+  assert(file !== null, "CODEOWNERS file is required");
+  const rules = parseCodeowners(file.source);
+
+  // The provenance verifier is the control that turns a bad publish red. If it
+  // is editable in the same unreviewed PR that trojanises the pipeline, the
+  // gate defends nothing — so pin its ownership independently of discovery.
+  const owners = ownersFor(rules, "scripts/verify_provenance.ts");
+  assert(
+    owners.length > 0,
+    "`scripts/verify_provenance.ts` is the provenance gate for the JSR " +
+      "publish; it must require code-owner review",
+  );
+});

--- a/test/ci/CodeownersWorkflowsCoverage.ts
+++ b/test/ci/CodeownersWorkflowsCoverage.ts
@@ -22,81 +22,12 @@
  */
 
 import { assert } from "@std/assert";
-import { fromFileUrl, join } from "@std/path";
-
-const REPO_ROOT = fromFileUrl(new URL("../../", import.meta.url));
-
-/** Locations GitHub scans for a CODEOWNERS file, in precedence order. */
-const CODEOWNERS_LOCATIONS = [
-  "CODEOWNERS",
-  ".github/CODEOWNERS",
-  "docs/CODEOWNERS",
-];
-
-interface CodeownersRule {
-  pattern: string;
-  owners: string[];
-}
-
-/** Read the first CODEOWNERS file found, or null when none exists. */
-export async function readCodeowners(): Promise<
-  { path: string; source: string } | null
-> {
-  const reads = CODEOWNERS_LOCATIONS.map(async (rel) => {
-    try {
-      const source = await Deno.readTextFile(join(REPO_ROOT, rel));
-      return { path: rel, source };
-    } catch (err) {
-      if (err instanceof Deno.errors.NotFound) return null;
-      throw err;
-    }
-  });
-  // Precedence order: first existing location wins.
-  const results = await Promise.all(reads);
-  return results.find((r) => r !== null) ?? null;
-}
-
-/** Parse CODEOWNERS text into ordered { pattern, owners } rules. */
-export function parseCodeowners(source: string): CodeownersRule[] {
-  const rules: CodeownersRule[] = [];
-  for (const rawLine of source.split("\n")) {
-    const line = rawLine.replace(/#.*$/, "").trim();
-    if (line === "") continue;
-    const [pattern, ...owners] = line.split(/\s+/);
-    if (!pattern) continue;
-    rules.push({ pattern, owners });
-  }
-  return rules;
-}
-
-/** Convert a CODEOWNERS/gitignore-style pattern to an anchored RegExp. */
-function patternToRegExp(pattern: string): RegExp {
-  const anchoredToRoot = pattern.startsWith("/");
-  const core = pattern.replace(/^\/+/, "").replace(/\/+$/, "");
-
-  const escaped = core
-    .split("/")
-    .map((segment) =>
-      segment
-        .split("*")
-        .map((part) => part.replace(/[.+^${}()|[\]\\]/g, "\\$&"))
-        .join("[^/]*")
-    )
-    .join("/");
-
-  const prefix = anchoredToRoot ? "^/?" : "^(?:.*/)?";
-  // Match the file/dir itself and, for a directory pattern, everything beneath.
-  return new RegExp(prefix + escaped + "(?:/.*)?$");
-}
-
-/** Owners for a path using CODEOWNERS last-match-wins semantics. */
-export function ownersFor(rules: CodeownersRule[], path: string): string[] {
-  let owners: string[] = [];
-  for (const rule of rules) {
-    if (patternToRegExp(rule.pattern).test(path)) owners = rule.owners;
-  }
-  return owners;
-}
+import {
+  CODEOWNERS_LOCATIONS,
+  ownersFor,
+  parseCodeowners,
+  readCodeowners,
+} from "./_codeowners.ts";
 
 const OWNER_TOKEN = /^@[A-Za-z0-9-]+(?:\/[A-Za-z0-9._-]+)?$/;
 

--- a/test/ci/_codeowners.ts
+++ b/test/ci/_codeowners.ts
@@ -1,0 +1,84 @@
+/**
+ * Shared CODEOWNERS reader/parser for the governance tests (Issues #3187,
+ * #3669).
+ *
+ * Extracted so both `CodeownersWorkflowsCoverage.ts` and
+ * `CodeownersPrivilegedJobCoverage.ts` can resolve owners without one test file
+ * importing another (which would register the same tests twice).
+ */
+
+import { fromFileUrl, join } from "@std/path";
+
+const REPO_ROOT = fromFileUrl(new URL("../../", import.meta.url));
+
+/** Locations GitHub scans for a CODEOWNERS file, in precedence order. */
+export const CODEOWNERS_LOCATIONS = [
+  "CODEOWNERS",
+  ".github/CODEOWNERS",
+  "docs/CODEOWNERS",
+];
+
+export interface CodeownersRule {
+  pattern: string;
+  owners: string[];
+}
+
+/** Read the first CODEOWNERS file found, or null when none exists. */
+export async function readCodeowners(): Promise<
+  { path: string; source: string } | null
+> {
+  const reads = CODEOWNERS_LOCATIONS.map(async (rel) => {
+    try {
+      const source = await Deno.readTextFile(join(REPO_ROOT, rel));
+      return { path: rel, source };
+    } catch (err) {
+      if (err instanceof Deno.errors.NotFound) return null;
+      throw err;
+    }
+  });
+  // Precedence order: first existing location wins.
+  const results = await Promise.all(reads);
+  return results.find((r) => r !== null) ?? null;
+}
+
+/** Parse CODEOWNERS text into ordered { pattern, owners } rules. */
+export function parseCodeowners(source: string): CodeownersRule[] {
+  const rules: CodeownersRule[] = [];
+  for (const rawLine of source.split("\n")) {
+    const line = rawLine.replace(/#.*$/, "").trim();
+    if (line === "") continue;
+    const [pattern, ...owners] = line.split(/\s+/);
+    if (!pattern) continue;
+    rules.push({ pattern, owners });
+  }
+  return rules;
+}
+
+/** Convert a CODEOWNERS/gitignore-style pattern to an anchored RegExp. */
+function patternToRegExp(pattern: string): RegExp {
+  const anchoredToRoot = pattern.startsWith("/");
+  const core = pattern.replace(/^\/+/, "").replace(/\/+$/, "");
+
+  const escaped = core
+    .split("/")
+    .map((segment) =>
+      segment
+        .split("*")
+        .map((part) => part.replace(/[.+^${}()|[\]\\]/g, "\\$&"))
+        .join("[^/]*")
+    )
+    .join("/");
+
+  const prefix = anchoredToRoot ? "^/?" : "^(?:.*/)?";
+  // Match the file/dir itself and, for a directory pattern, everything beneath.
+  return new RegExp(prefix + escaped + "(?:/.*)?$");
+}
+
+/** Owners for a path using CODEOWNERS last-match-wins semantics. */
+export function ownersFor(rules: CodeownersRule[], path: string): string[] {
+  let owners: string[] = [];
+  for (const rule of rules) {
+    if (patternToRegExp(rule.pattern).test(path)) owners = rule.owners;
+  }
+  return owners;
+}


### PR DESCRIPTION
# Extend CODEOWNERS to the code the JSR OIDC job executes (Issue #3669)

## Summary

`.github/CODEOWNERS` owned the workflow *files* but not the repository *code
those workflows execute*, so the review gate stopped one line short of the
privileged credential. `publish.yml`'s `publish` job holds
`permissions: id-token: ***REDACTED*** — the JSR OIDC credential backing tokenless
publishing of `@stsoftware/neat-ai` — and `permissions:` is job-scoped, so every
step in that job can mint the token. Three repository paths ran inside it
unowned:

- `build.sh` — reached through the *owned* composite action
  `.github/actions/setup-neat`, whose only instruction is
  `run: ./build.sh --verify-only`. Editing `build.sh` achieved what editing the
  owned `action.yml` would, without triggering the rule.
- `scripts/verify_provenance.ts` — the provenance gate itself, so an unreviewed
  edit could silently disable the control that turns a bad publish red.
- `deno.json` — carries the `version` that gates publishing, the
  `neatCore.assetSha256` integrity pin, and the `tasks` bodies CI executes.

The fix adds `/build.sh`, `/scripts/` and `/deno.json` to
`.github/CODEOWNERS`, and adds a test that derives the requirement from the
workflows rather than from a hand-written list, so a new script added to a
privileged job fails CI until the gate is extended to cover it.

Closes #3669.

**Still requires a human/admin action:** CODEOWNERS only *requests* review. The
**"Require review from Code Owners"** branch-protection rule must be enabled on
`Develop` or GitHub enforces nothing — see
[`docs/REPO_GOVERNANCE.md`](../../REPO_GOVERNANCE.md#required-branch-protection-settings)
for the `gh api` invocation. This is a server-side setting invisible to a static
checkout, so no test can assert it.

The issue's "defence in depth" suggestion — moving the SBOM step out of the
`id-token: ***REDACTED*** job — was already delivered by Issue #3668
(`publish.yml`'s `sbom` job, `contents: read` only), so nothing was changed
there.

## Evidence

Backend/CI governance change — no web interface to screenshot. Evidence is the
test run below: the new tests fail against the unfixed `CODEOWNERS` and pass
after it.

Before (`CODEOWNERS` unchanged), the discovery names the exact gap from the
issue:

```text
every file executed by an `id-token: ***REDACTED*** job has a code owner (Issue #3669) ... FAILED
error: AssertionError: these files run inside a job holding the JSR OIDC `id-token`,
but no CODEOWNERS rule covers them, so they can be changed without the code-owner
review the gate exists to force:
  - build.sh — via .github/workflows/publish.yml (job: publish) → .github/actions/setup-neat/action.yml
  - deno.json — via .github/workflows/publish.yml (job: publish)
  - scripts/verify_provenance.ts — via .github/workflows/publish.yml (job: publish)
the publish gate's own verifier is owned (Issue #3669) ... FAILED
FAILED | 6 passed | 2 failed
```

After:

```text
running 3 tests from ./test/ci/CodeownersPrivilegedJobCoverage.ts
a job holding the JSR OIDC credential exists and executes repository code (Issue #3669) ... ok
every file executed by an `id-token: ***REDACTED*** job has a code owner (Issue #3669) ... ok
the publish gate's own verifier is owned (Issue #3669) ... ok
running 5 tests from ./test/ci/CodeownersWorkflowsCoverage.ts
... ok | 8 passed | 0 failed
```

```mermaid
flowchart LR
    W[".github/workflows/publish.yml<br/>job: publish<br/>id-token: ***REDACTED*** --> A[".github/actions/setup-neat<br/>(owned)"]
    A --> B["build.sh"]
    W --> V["scripts/verify_provenance.ts"]
    W --> D["deno.json"]
    B & V & D --> T{"Covered by<br/>CODEOWNERS?"}
    T -- "before: No" --> X["Unreviewed edit runs beside<br/>the JSR OIDC credential"]
    T -- "after: Yes" --> O["Code-owner review required"]
```

## Test Plan

Added `test/ci/CodeownersPrivilegedJobCoverage.ts` — it parses every workflow
job granting `id-token: ***REDACTED*** follows local `uses: ./…` composite actions into
their own `run:` blocks, collects each repository file the job executes (a token
counts only when it resolves to a file in the checkout), and asserts:

- `every file executed by an id-token: ***REDACTED*** job has a code owner` — the general
  case; it caught all three unowned paths without any of them being named in the
  test.
- `the publish gate's own verifier is owned` — pins `scripts/verify_provenance.ts`
  independently of discovery, so the gate cannot be edited in the same
  unreviewed PR that trojanises the pipeline.
- `a job holding the JSR OIDC credential exists and executes repository code` —
  fails loud if a restructure makes the discovery blind, rather than passing
  vacuously on an empty set (Issue #3234).

Supporting changes:

- `test/ci/_codeowners.ts` (new) — the CODEOWNERS reader/parser/`ownersFor`
  helpers, moved verbatim out of `test/ci/CodeownersWorkflowsCoverage.ts` so
  both test files share them without one test file importing another (which
  would register the same five tests twice).
- `test/ci/CodeownersWorkflowsCoverage.ts` — imports those helpers instead of
  defining them. **No test was removed, modified or disabled**; all five Issue
  #3187 tests still run and pass.
- `docs/REPO_GOVERNANCE.md` — new section documenting why ownership must reach
  the executed code, with the path table and a Mermaid diagram.



## Milestone
This PR is part of the **Scan 20260807** milestone and targets the `milestone/scan-20260807` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-msiolvoi-aa8981`<!-- vibe-worker-issue-3669 -->