### PR TITLE
Validate input/output counts before the load-side allocation loop (Issue #3672)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -280,6 +280,19 @@ adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).
 
 ### Security
 
+- **Issue #3672 (CWE-1284, improper validation of a quantity used as a loop
+  bound):** `Creature.fromJSON` / `loadFrom` now validate the `input` and
+  `output` counts **before** the input-neuron allocation loop runs. `json.input`
+  bounded that loop straight from the file, and the `creatureValidate` check
+  that would have rejected a bad count ran only at the _end_ of the load — so
+  `"input": -1` looped forever (`while (i--)` tests before decrementing, so it
+  ran away from zero, allocating a `Neuron` and two Map entries per iteration
+  and never returning control to the caller), and `"input": 100000000` requested
+  a hundred million neurons before any check fired. Each count must now be an
+  integer in `[1, MAX_NEURON_COUNT]` (1,000,000 — the hidden/constant neuron id
+  floor in `NeuronId.ts`, above which input ids would collide) or loading throws
+  `ValidationError` (`reason: "OTHER"`). The loop itself is now an explicit
+  `for (let i = json.input - 1; i >= 0; i--)`.
 - **Issue #3671 (CWE-20, improper input validation):** `Creature.fromJSON` /
   `loadFrom` now validate a synapse's resolved `from` / `to` endpoint. When
   neither `fromUUID`/`toUUID` nor `fromId`/`toId` resolved, the loader fell

--- a/docs/api/CREATURE.md
+++ b/docs/api/CREATURE.md
@@ -103,6 +103,8 @@ new Creature(input: number, output: number, options?: {
 > fine: `exportJSON()` deliberately omits it and `CreatureUtil.makeUUID()` fills
 > it in later.
 
+<!-- -->
+
 > [!IMPORTANT]
 > **Issue #3672 — `input` and `output` are validated first.** The loader
 > pre-fills input neurons straight from `json.input`, one allocation per

--- a/docs/api/CREATURE.md
+++ b/docs/api/CREATURE.md
@@ -103,6 +103,17 @@ new Creature(input: number, output: number, options?: {
 > fine: `exportJSON()` deliberately omits it and `CreatureUtil.makeUUID()` fills
 > it in later.
 
+> [!IMPORTANT]
+> **Issue #3672 — `input` and `output` are validated first.** The loader
+> pre-fills input neurons straight from `json.input`, one allocation per
+> iteration, so that count is checked **before** anything is allocated rather
+> than by the structural pass at the end of the load. Both counts must be an
+> integer in `[1, 1_000_000]` — the ceiling is the hidden/constant neuron id
+> floor, above which input ids would collide — or the load throws
+> [`ValidationError`](ERRORS.md#-validationerror) with `reason: "OTHER"`.
+> Previously a negative count wedged the process in a non-terminating allocation
+> loop and a huge count exhausted memory.
+
 ### 💡 Example
 
 ```typescript

--- a/docs/archive/pr-summaries/pr-summary-3672.md
+++ b/docs/archive/pr-summaries/pr-summary-3672.md
@@ -1,0 +1,92 @@
+# Validate `input` / `output` before the load-side allocation loop (Issue #3672)
+
+## Summary
+
+`loadFrom` pre-filled input neurons straight from `json.input` — one `Neuron`
+plus two Map entries per iteration — before anything validated that count. The
+check that would have rejected a bad value (`creatureValidate`) ran only at the
+**end** of the load, so on the public `Creature.fromJSON` path an
+attacker-authored model file produced two denial-of-service outcomes:
+
+- **Negative → non-terminating loop.** `while (i--)` tests `i` before
+  decrementing, so `-1` is truthy, the body runs, and `i` walks away from zero.
+  The loop never reaches the falsy `0` and never returns control to the caller,
+  so even a timeout wrapper could not reclaim the thread.
+- **Large → memory exhaustion.** `"input": 100000000` requested a hundred
+  million neurons before any check fired.
+
+The fix hoists the existing predicate to the boundary. A new
+`src/creature/CreatureShapeValidation.ts` exports `MAX_NEURON_COUNT` and
+`assertValidCreatureShape(input, output, source)`; both counts must be an
+integer in `[1, MAX_NEURON_COUNT]` or the load throws `ValidationError`
+(`reason: "OTHER"`). It is called at the top of `loadFrom` — before any
+allocation, covering callers that reach `loadFrom` directly — and in `fromJSON`
+before the lazily-initialised constructor stores the unchecked value. The loop
+itself is now an explicit `for (let i = json.input - 1; i >= 0; i--)`, removing
+the decrement-away-from-zero trap for future callers.
+
+`MAX_NEURON_COUNT` is 1,000,000: an input neuron's id **is** its array index and
+hidden/constant ids are allocated from 1,000,000 upwards
+(`src/architecture/NeuronId.ts`), so a larger count would collide with the
+hidden id space regardless of memory. `Number.isInteger` alone still admits
+`1e8`, so the ceiling carries as much weight as the sign check.
+
+Closes #3672.
+
+## Evidence
+
+Backend library change — no web interface to screenshot.
+
+**Pre-fix reproduction.**
+`Creature.fromJSON({ input: -1, output: 1, neurons: [],
+synapses: [] })` printed
+the "loading" line and never returned; the probe had to be killed by `gtimeout`
+after 20s. Post-fix the same payload throws immediately:
+
+```text
+ValidationError: Invalid creature 'input' count (source=fromJSON): expected an
+integer in [1, 1000000], got -1
+```
+
+Load-path ordering, before and after:
+
+```mermaid
+flowchart TD
+    subgraph before["Before — validation ran last"]
+        B1[json.input from file] --> B2["while (i--) allocate Neuron"]
+        B2 -->|"input = -1"| B3[["never terminates"]]
+        B2 -->|"input = 1e8"| B4[["OOM"]]
+        B2 -.->|only if the loop ends| B5[creatureValidate rejects]
+    end
+    subgraph after["After — validated at the boundary"]
+        A1[json.input from file] --> A2{"integer in [1, MAX_NEURON_COUNT]?"}
+        A2 -->|no| A3[[ValidationError, nothing allocated]]
+        A2 -->|yes| A4["for (i = input - 1; i >= 0; i--)"]
+        A4 --> A5[creatureValidate as before]
+    end
+```
+
+Test run for the new suite:
+
+```text
+ok | 24 passed | 0 failed (58ms)
+```
+
+Full `./quality.sh` passes (format, lint, type-check, discovery, WASM sync, and
+the complete test suite).
+
+## Test Plan
+
+New `test/creature/CreatureLoadShapeValidation.ts` — 24 cases, all calling the
+real load path:
+
+- `fromJSON` rejects each hostile `input` **and** `output` value with a
+  `ValidationError` naming the offending field: negative, large negative, zero,
+  fractional, numeric string, `NaN`, `Infinity`, `undefined`,
+  `MAX_NEURON_COUNT + 1`, and `100_000_000`. The negative cases are the
+  regression test — without the fix they do not fail, they hang.
+- `loadFrom` rejects a hostile shape on the direct load path.
+- `fromPersistedJSON` rejects a hostile shape.
+- `MAX_NEURON_COUNT` stays at or below the hidden neuron id floor.
+- A valid creature still round-trips through `exportJSON` → `fromJSON` with
+  `input`, `output`, neuron count and synapse count preserved.

--- a/src/creature/CreatureSerialization.ts
+++ b/src/creature/CreatureSerialization.ts
@@ -37,6 +37,7 @@ import {
 } from "@blackbox/MemeticWireData.ts";
 import { convertMemeticExportToWireJson } from "@creature/MemeticWireExport.ts";
 import { assertValidCreatureUuid } from "@creature/CreatureUuidValidation.ts";
+import { assertValidCreatureShape } from "@creature/CreatureShapeValidation.ts";
 import { getLogger } from "@utils/Logger.ts";
 import { isRecord } from "@utils/TypeGuards.ts";
 import {
@@ -478,6 +479,10 @@ export function loadFrom(
   const sourceTag = source ?? "loadFrom";
   const throwOnRecurrent: ThrowOnRecurrent = options?.throwOnRecurrent ??
     "forwardOnly";
+  // Issue #3672: `json.input` bounds the input-neuron allocation loop below,
+  // so it must be checked before that loop rather than by the `creatureValidate`
+  // pass at the end of this function.
+  assertValidCreatureShape(json.input, json.output, sourceTag);
   // Issue #3670: the uuid arrives from untrusted JSON and is later used as a
   // filesystem path component (discovery temp dirs, trace stores) — validate
   // it once here so every downstream sink is covered.
@@ -513,8 +518,9 @@ export function loadFrom(
   const uuidToIndex = new Map<string, number>();
   const numericIdToIndex = new Map<number, number>();
 
-  let i = json.input;
-  while (i--) {
+  // Issue #3672: an explicit bound, not `while (i--)` — that shape decrements
+  // away from zero and never terminates for a negative count.
+  for (let i = json.input - 1; i >= 0; i--) {
     const neuronId = inputNeuronId(i);
     numericIdToIndex.set(neuronId, i);
     uuidToIndex.set(`input-${i}`, i);
@@ -873,6 +879,11 @@ export function fromJSON(
   if (rawVersion && rawVersion.startsWith("0.")) {
     json = upgradeOne(json);
   }
+
+  // Issue #3672: the lazy constructor stores `input`/`output` unchecked, so
+  // reject a hostile shape before it is stored — `loadFrom` re-checks for
+  // callers that reach it directly.
+  assertValidCreatureShape(json.input, json.output, sourceTag);
 
   const creature = new CreatureClass(json.input, json.output, {
     lazyInitialization: true,

--- a/src/creature/CreatureShapeValidation.ts
+++ b/src/creature/CreatureShapeValidation.ts
@@ -1,0 +1,85 @@
+/**
+ * Creature input/output shape validation at the deserialisation boundary
+ * (Issue #3672).
+ *
+ * `loadFrom` pre-fills the input neurons straight from `json.input`, one
+ * allocation per iteration, before any structural validation runs. The
+ * `creatureValidate` check that rejects a bad count fires only at the end of
+ * the load, so an untrusted model file could park the process there forever:
+ * a negative count decremented away from zero and never terminated, and a
+ * count of `1e8` requested a hundred million neurons. Validating the shape
+ * first — before the loop, and before the lazily-initialised constructor
+ * stores the value unchecked — closes both.
+ *
+ * `Number.isInteger` alone still admits `1e8`, so the ceiling matters as much
+ * as the sign check.
+ *
+ * @module CreatureShapeValidation
+ */
+
+import { ValidationError } from "@errors/ValidationError.ts";
+
+/**
+ * Upper bound on the input or output neuron count accepted from JSON.
+ *
+ * Pinned to the hidden/constant neuron id floor in
+ * `@architecture/NeuronId.ts`: an input neuron's id *is* its array index, and
+ * hidden ids are allocated from 1,000,000 upwards, so any larger count would
+ * collide with the hidden id space regardless of memory. No real topology
+ * comes close — the largest creature the suite builds has thousands of
+ * neurons, not millions.
+ */
+export const MAX_NEURON_COUNT = 1_000_000;
+
+/**
+ * Assert that the `input` and `output` counts read from untrusted JSON are
+ * usable as loop and allocation bounds.
+ *
+ * Fails closed: the same predicate {@link creatureValidate} applies at the end
+ * of a load, hoisted to run before anything is allocated.
+ *
+ * @param input The raw `input` count from the JSON payload.
+ * @param output The raw `output` count from the JSON payload.
+ * @param source Tag describing the calling site (e.g. `"fromJSON"`), included
+ *   in the error so production logs identify the upstream pipeline.
+ * @throws {ValidationError} When either count is not an integer in
+ *   `[1, MAX_NEURON_COUNT]`.
+ */
+export function assertValidCreatureShape(
+  input: unknown,
+  output: unknown,
+  source: string,
+): void {
+  assertCount(input, "input", source);
+  assertCount(output, "output", source);
+}
+
+function assertCount(
+  value: unknown,
+  field: "input" | "output",
+  source: string,
+): void {
+  if (
+    typeof value !== "number" || !Number.isInteger(value) ||
+    value < 1 || value > MAX_NEURON_COUNT
+  ) {
+    throw new ValidationError(
+      `Invalid creature '${field}' count (source=${source}): expected an ` +
+        `integer in [1, ${MAX_NEURON_COUNT}], got ${describe(value)}`,
+      "OTHER",
+    );
+  }
+}
+
+/** Longest rendering of a rejected value included in an error message. */
+const MAX_REPORTED_LENGTH = 64;
+
+/** Render an untrusted value for an error message without leaking a payload. */
+function describe(value: unknown): string {
+  const text = typeof value === "string"
+    ? `string ${JSON.stringify(value)}`
+    : String(value);
+  return text.length > MAX_REPORTED_LENGTH
+    ? `${text.slice(0, MAX_REPORTED_LENGTH)}…`
+    : text;
+}

--- a/test/creature/CreatureLoadShapeValidation.ts
+++ b/test/creature/CreatureLoadShapeValidation.ts
@@ -1,0 +1,98 @@
+/**
+ * Issue #3672: `json.input` from untrusted model JSON drove the input-neuron
+ * allocation loop in `loadFrom` before any validation ran — a negative count
+ * looped forever (`while (i--)` decrements away from zero) and a huge count
+ * exhausted memory. These tests pin the boundary check that now runs first.
+ *
+ * Note: without the fix the negative cases never return, so this suite hangs
+ * rather than fails.
+ */
+
+import { assert, assertEquals, assertThrows } from "@std/assert";
+import { Creature } from "@creature";
+import { fromJSON, loadFrom } from "@creature/CreatureSerialization.ts";
+import { MAX_NEURON_COUNT } from "@creature/CreatureShapeValidation.ts";
+import type {
+  CreatureExport,
+  CreatureInternal,
+} from "@architecture/CreatureInterfaces.ts";
+import { ValidationError } from "@errors/ValidationError.ts";
+
+/** Minimal model JSON with an arbitrary (possibly hostile) input/output shape. */
+function shapedJson(input: unknown, output: unknown): CreatureExport {
+  return { input, output, neurons: [], synapses: [] } as unknown as
+    & CreatureExport
+    & CreatureInternal;
+}
+
+const REJECTED_INPUTS: [string, unknown][] = [
+  ["negative", -1],
+  ["large negative", -1_000_000],
+  ["zero", 0],
+  ["fractional", 1.5],
+  ["numeric string", "2"],
+  ["NaN", Number.NaN],
+  ["Infinity", Number.POSITIVE_INFINITY],
+  ["undefined", undefined],
+  ["above the ceiling", MAX_NEURON_COUNT + 1],
+  ["one hundred million", 100_000_000],
+];
+
+for (const [label, value] of REJECTED_INPUTS) {
+  Deno.test(`fromJSON - rejects ${label} input before allocating`, () => {
+    const error = assertThrows(
+      () => Creature.fromJSON(shapedJson(value, 1)),
+      ValidationError,
+    );
+    assert(
+      error.message.includes("input"),
+      `message should name the offending field: ${error.message}`,
+    );
+  });
+
+  Deno.test(`fromJSON - rejects ${label} output before allocating`, () => {
+    const error = assertThrows(
+      () => Creature.fromJSON(shapedJson(1, value)),
+      ValidationError,
+    );
+    assert(
+      error.message.includes("output"),
+      `message should name the offending field: ${error.message}`,
+    );
+  });
+}
+
+Deno.test("loadFrom - rejects a hostile shape on the direct load path", () => {
+  const creature = new Creature(2, 1, { lazyInitialization: true });
+  assertThrows(
+    () => loadFrom(creature, shapedJson(-1, 1), false),
+    ValidationError,
+  );
+});
+
+Deno.test("fromPersistedJSON - rejects a hostile shape", () => {
+  assertThrows(
+    () => Creature.fromPersistedJSON(shapedJson(-5, 1)),
+    ValidationError,
+  );
+});
+
+Deno.test("MAX_NEURON_COUNT - stays below the hidden neuron id floor", () => {
+  // Input neuron ids are their array index; hidden/constant ids start at
+  // 1,000,000 (see NeuronId.ts), so a larger ceiling would collide.
+  assert(Number.isInteger(MAX_NEURON_COUNT));
+  assert(MAX_NEURON_COUNT > 0);
+  assert(MAX_NEURON_COUNT <= 1_000_000);
+});
+
+Deno.test("fromJSON - a valid creature still round-trips", () => {
+  const original = new Creature(3, 2, { layers: [{ count: 2 }] });
+  const exported = original.exportJSON();
+
+  const loaded = fromJSON(exported, false, Creature);
+
+  assertEquals(loaded.input, 3);
+  assertEquals(loaded.output, 2);
+  assertEquals(loaded.neurons.length, original.neurons.length);
+  assertEquals(loaded.synapses.length, original.synapses.length);
+});


### PR DESCRIPTION
# Validate `input` / `output` before the load-side allocation loop (Issue #3672)

## Summary

`loadFrom` pre-filled input neurons straight from `json.input` — one `Neuron`
plus two Map entries per iteration — before anything validated that count. The
check that would have rejected a bad value (`creatureValidate`) ran only at the
**end** of the load, so on the public `Creature.fromJSON` path an
attacker-authored model file produced two denial-of-service outcomes:

- **Negative → non-terminating loop.** `while (i--)` tests `i` before
  decrementing, so `-1` is truthy, the body runs, and `i` walks away from zero.
  The loop never reaches the falsy `0` and never returns control to the caller,
  so even a timeout wrapper could not reclaim the thread.
- **Large → memory exhaustion.** `"input": 100000000` requested a hundred
  million neurons before any check fired.

The fix hoists the existing predicate to the boundary. A new
`src/creature/CreatureShapeValidation.ts` exports `MAX_NEURON_COUNT` and
`assertValidCreatureShape(input, output, source)`; both counts must be an
integer in `[1, MAX_NEURON_COUNT]` or the load throws `ValidationError`
(`reason: "OTHER"`). It is called at the top of `loadFrom` — before any
allocation, covering callers that reach `loadFrom` directly — and in `fromJSON`
before the lazily-initialised constructor stores the unchecked value. The loop
itself is now an explicit `for (let i = json.input - 1; i >= 0; i--)`, removing
the decrement-away-from-zero trap for future callers.

`MAX_NEURON_COUNT` is 1,000,000: an input neuron's id **is** its array index and
hidden/constant ids are allocated from 1,000,000 upwards
(`src/architecture/NeuronId.ts`), so a larger count would collide with the
hidden id space regardless of memory. `Number.isInteger` alone still admits
`1e8`, so the ceiling carries as much weight as the sign check.

Closes #3672.

## Evidence

Backend library change — no web interface to screenshot.

**Pre-fix reproduction.**
`Creature.fromJSON({ input: -1, output: 1, neurons: [],
synapses: [] })` printed
the "loading" line and never returned; the probe had to be killed by `gtimeout`
after 20s. Post-fix the same payload throws immediately:

```text
ValidationError: Invalid creature 'input' count (source=fromJSON): expected an
integer in [1, 1000000], got -1
```

Load-path ordering, before and after:

```mermaid
flowchart TD
    subgraph before["Before — validation ran last"]
        B1[json.input from file] --> B2["while (i--) allocate Neuron"]
        B2 -->|"input = -1"| B3[["never terminates"]]
        B2 -->|"input = 1e8"| B4[["OOM"]]
        B2 -.->|only if the loop ends| B5[creatureValidate rejects]
    end
    subgraph after["After — validated at the boundary"]
        A1[json.input from file] --> A2{"integer in [1, MAX_NEURON_COUNT]?"}
        A2 -->|no| A3[[ValidationError, nothing allocated]]
        A2 -->|yes| A4["for (i = input - 1; i >= 0; i--)"]
        A4 --> A5[creatureValidate as before]
    end
```

Test run for the new suite:

```text
ok | 24 passed | 0 failed (58ms)
```

Full `./quality.sh` passes (format, lint, type-check, discovery, WASM sync, and
the complete test suite).

## Test Plan

New `test/creature/CreatureLoadShapeValidation.ts` — 24 cases, all calling the
real load path:

- `fromJSON` rejects each hostile `input` **and** `output` value with a
  `ValidationError` naming the offending field: negative, large negative, zero,
  fractional, numeric string, `NaN`, `Infinity`, `undefined`,
  `MAX_NEURON_COUNT + 1`, and `100_000_000`. The negative cases are the
  regression test — without the fix they do not fail, they hang.
- `loadFrom` rejects a hostile shape on the direct load path.
- `fromPersistedJSON` rejects a hostile shape.
- `MAX_NEURON_COUNT` stays at or below the hidden neuron id floor.
- A valid creature still round-trips through `exportJSON` → `fromJSON` with
  `input`, `output`, neuron count and synapse count preserved.



## Milestone
This PR is part of the **Scan 20260807** milestone and targets the `milestone/scan-20260807` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-msj62ozq-b97f0a`<!-- vibe-worker-issue-3672 -->