### PR TITLE
Packaging: Include LICENSE in the JSR publish set and declare an SPDX licence (#3674)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,10 @@ adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- **Issue #3674:** `deno.json` now declares the `Apache-2.0` SPDX identifier and
+  lists `LICENSE` in `publish.include`, so the published package carries its
+  licence text and metadata explicitly instead of relying on whatever
+  `deno publish` auto-includes.
 - **Issue #3427:** The `requestedOptions` echo (Issue #3422) no longer records
   non-serialisable options with a `"[function]"` / `"[unserialisable]"` marker —
   such entries are now dropped entirely, since the markers carry no tuning value

--- a/deno.json
+++ b/deno.json
@@ -2,6 +2,7 @@
   "name": "@stsoftware/neat-ai",
   "exports": "./mod.ts",
   "version": "6.2.11",
+  "license": "Apache-2.0",
   "neatCore": {
     "repo": "stSoftwareAU/NEAT-AI-core",
     "ref": "Develop",
@@ -11,6 +12,7 @@
   "publish": {
     "include": [
       "README.md",
+      "LICENSE",
       "mod.ts",
       "src/**",
       "wasm_activation/pkg/**"

--- a/docs/archive/pr-summaries/pr-summary-3674.md
+++ b/docs/archive/pr-summaries/pr-summary-3674.md
@@ -1,0 +1,57 @@
+# Include LICENSE in the JSR publish set and declare an SPDX licence
+
+## Summary
+
+`deno.json` declared no `license` field, and its `publish.include` allowlist did
+not list `LICENSE`, so the published `@stsoftware/neat-ai` artefact carried its
+licence only by whatever `deno publish` happened to auto-include, with no SPDX
+identifier for consumers or SBOM / licence-compliance tooling to read.
+
+Two additive manifest changes fix that:
+
+- `"license": "Apache-2.0"` — the SPDX identifier, matching the Apache Licence
+  2.0 text in `LICENSE` and the licence stated in `README.md`.
+- `"LICENSE"` added to `publish.include` — the licence text is now shipped
+  because the allowlist says so, satisfying Apache-2.0 §4.1 explicitly rather
+  than implicitly.
+
+Neither change alters code or the publish flow. Closes #3674.
+
+## Evidence
+
+Backend/packaging change only — no web interface to screenshot. Verified via the
+new tests, which fail against the unfixed manifest and pass after it:
+
+```text
+$ deno test --allow-read --allow-run test/scripts/PublishLicenceMetadata.ts
+# before the fix
+deno.json declares the Apache-2.0 SPDX identifier (Issue #3674) ... FAILED
+  Values are not equal: undefined vs "Apache-2.0"
+publish.include lists LICENSE explicitly (Issue #3674) ... FAILED
+  found: ["README.md","mod.ts","src/**","wasm_activation/pkg/**"]
+FAILED | 2 passed | 2 failed
+
+# after the fix
+ok | 4 passed | 0 failed (425ms)
+```
+
+`deno publish --dry-run --allow-dirty` lists `LICENSE (11.09KB)` in the
+published file set, which the fourth test asserts on directly.
+
+## Test Plan
+
+New file `test/scripts/PublishLicenceMetadata.ts`:
+
+- `deno.json declares the Apache-2.0 SPDX identifier` — parses the committed
+  manifest and asserts `license === "Apache-2.0"` (regression test for the
+  missing field).
+- `the declared SPDX identifier matches the LICENSE file` — asserts the root
+  `LICENSE` really is the Apache Licence 2.0 text, so the identifier is
+  truthful.
+- `publish.include lists LICENSE explicitly` — asserts the allowlist carries
+  `LICENSE` (regression test for the missing entry).
+- `deno publish ships the LICENSE file` — runs `deno publish --dry-run` and
+  asserts `LICENSE` appears in the published file set, so the outcome is
+  verified rather than just the manifest text.
+
+`./quality.sh` was run to completion over the full suite.

--- a/test/scripts/PublishLicenceMetadata.ts
+++ b/test/scripts/PublishLicenceMetadata.ts
@@ -1,0 +1,67 @@
+import { assert, assertEquals } from "@std/assert";
+import { fromFileUrl, join } from "@std/path";
+
+/**
+ * Issue #3674 — the published `@stsoftware/neat-ai` artefact must carry its
+ * licence explicitly rather than by whatever `deno publish` auto-includes.
+ *
+ * Apache-2.0 §4.1 requires redistributions to carry a copy of the licence, and
+ * SBOM / licence-compliance tooling reads the manifest's SPDX identifier first.
+ * These are "what" tests: they assert on the manifest's declared licence
+ * metadata and on the file set `deno publish` actually produces.
+ */
+
+const REPO_ROOT = fromFileUrl(new URL("../../", import.meta.url));
+const DENO_JSON = join(REPO_ROOT, "deno.json");
+const LICENCE_FILE = join(REPO_ROOT, "LICENSE");
+
+Deno.test("deno.json declares the Apache-2.0 SPDX identifier (Issue #3674)", async () => {
+  const json = JSON.parse(await Deno.readTextFile(DENO_JSON));
+  assertEquals(
+    json.license,
+    "Apache-2.0",
+    'deno.json must declare "license": "Apache-2.0" — consumers and SBOM ' +
+      "tooling read the manifest's SPDX identifier first",
+  );
+});
+
+Deno.test("the declared SPDX identifier matches the LICENSE file (Issue #3674)", async () => {
+  const licence = await Deno.readTextFile(LICENCE_FILE);
+  assert(
+    licence.includes("Apache License") && licence.includes("Version 2.0"),
+    "LICENSE at the repository root must be the Apache Licence 2.0 text so " +
+      "the declared SPDX identifier is truthful",
+  );
+});
+
+Deno.test("publish.include lists LICENSE explicitly (Issue #3674)", async () => {
+  const json = JSON.parse(await Deno.readTextFile(DENO_JSON));
+  const include: string[] = json.publish?.include ?? [];
+  assert(
+    include.includes("LICENSE"),
+    "deno.json publish.include is an explicit allowlist, so LICENSE must be " +
+      `listed in it — found: ${JSON.stringify(include)}`,
+  );
+});
+
+Deno.test({
+  name: "deno publish ships the LICENSE file (Issue #3674)",
+  permissions: { run: true, read: true },
+  fn: async () => {
+    const command = new Deno.Command("deno", {
+      args: ["publish", "--dry-run", "--allow-dirty"],
+      stdout: "piped",
+      stderr: "piped",
+      cwd: REPO_ROOT,
+    });
+    const output = await command.output();
+    const combined = new TextDecoder().decode(output.stdout) +
+      new TextDecoder().decode(output.stderr);
+
+    assert(
+      /\/LICENSE\b/.test(combined),
+      "deno publish must include LICENSE — Apache-2.0 §4.1 requires " +
+        "redistributions to carry a copy of the licence",
+    );
+  },
+});


### PR DESCRIPTION
# Include LICENSE in the JSR publish set and declare an SPDX licence

## Summary

`deno.json` declared no `license` field, and its `publish.include` allowlist did
not list `LICENSE`, so the published `@stsoftware/neat-ai` artefact carried its
licence only by whatever `deno publish` happened to auto-include, with no SPDX
identifier for consumers or SBOM / licence-compliance tooling to read.

Two additive manifest changes fix that:

- `"license": "Apache-2.0"` — the SPDX identifier, matching the Apache Licence
  2.0 text in `LICENSE` and the licence stated in `README.md`.
- `"LICENSE"` added to `publish.include` — the licence text is now shipped
  because the allowlist says so, satisfying Apache-2.0 §4.1 explicitly rather
  than implicitly.

Neither change alters code or the publish flow. Closes #3674.

## Evidence

Backend/packaging change only — no web interface to screenshot. Verified via the
new tests, which fail against the unfixed manifest and pass after it:

```text
$ deno test --allow-read --allow-run test/scripts/PublishLicenceMetadata.ts
# before the fix
deno.json declares the Apache-2.0 SPDX identifier (Issue #3674) ... FAILED
  Values are not equal: undefined vs "Apache-2.0"
publish.include lists LICENSE explicitly (Issue #3674) ... FAILED
  found: ["README.md","mod.ts","src/**","wasm_activation/pkg/**"]
FAILED | 2 passed | 2 failed

# after the fix
ok | 4 passed | 0 failed (425ms)
```

`deno publish --dry-run --allow-dirty` lists `LICENSE (11.09KB)` in the
published file set, which the fourth test asserts on directly.

## Test Plan

New file `test/scripts/PublishLicenceMetadata.ts`:

- `deno.json declares the Apache-2.0 SPDX identifier` — parses the committed
  manifest and asserts `license === "Apache-2.0"` (regression test for the
  missing field).
- `the declared SPDX identifier matches the LICENSE file` — asserts the root
  `LICENSE` really is the Apache Licence 2.0 text, so the identifier is
  truthful.
- `publish.include lists LICENSE explicitly` — asserts the allowlist carries
  `LICENSE` (regression test for the missing entry).
- `deno publish ships the LICENSE file` — runs `deno publish --dry-run` and
  asserts `LICENSE` appears in the published file set, so the outcome is
  verified rather than just the manifest text.

`./quality.sh` was run to completion over the full suite.



## Milestone
This PR is part of the **Scan 20260807** milestone and targets the `milestone/scan-20260807` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-msj7fndf-db7e09`<!-- vibe-worker-issue-3674 -->