### PR TITLE
Drive the Rust flush predicate through the public surface (Issue #3676)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-3676.md
+++ b/docs/archive/pr-summaries/pr-summary-3676.md
@@ -1,0 +1,97 @@
+# PR Summary — Issue #3676
+
+## Summary
+
+`test/ErrorGuidedStructuralEvolution/RustFlushPeakCopy.ts` arranged all three
+cases by casting `DiscoverStructure` to an ad-hoc shape and hand-writing five
+protected fields (`usingRustDualWrite`, `rustFlushBytesThreshold`,
+`rustAccumulatedEstimatedBytes`, `rustAccumulatedData`, `rustFlushRecords`)
+before asserting `shouldFlushRustChunk()`. That verified the predicate against
+state the implementation might never produce: a rename of the internal
+bookkeeping broke the tests with no behaviour change, and a drift in the real
+accumulation path would leave them green while the Issue #3402 peak-copy guard
+silently regressed.
+
+The tests are rewritten to drive the predicate the way production does
+(suggested fix (a) — the file is **not** deleted, so the #3402 behaviour keeps a
+direct behavioural net):
+
+- The byte threshold now comes from
+  `DiscoverStructureOptions.rustFlushBytesThreshold` and the record ceiling from
+  the constructor argument.
+- The byte accounting is produced by recording **real** samples through the
+  public `record()` path.
+- `usingRustDualWrite` is no longer poked — `initialize()` already sets it.
+- The flush itself is observed at the already-injected `recordDiscovery`
+  boundary stub.
+
+To let a test observe the flush decision without reaching into protected state,
+`DiscoverStructureRecording` gains a small public accessor,
+`getRustFlushByteState()`, returning the accumulated sample count, the
+accumulated estimate, the projected flush-time peak, and the configured
+threshold. `shouldFlushRustChunk()` now reads its projected peak from that same
+accessor, so there is one source of truth for the decision inputs.
+
+Closes #3676.
+
+## Evidence
+
+Backend-only change — no web interface to screenshot. Evidence is the test run
+plus a deliberate regression check.
+
+All four cases pass against the current implementation:
+
+```
+byte flush fires while the accumulator alone is still under the threshold ... ok
+byte flush holds off while the projected peak is under the threshold ... ok
+record-count ceiling still forces a flush regardless of bytes ... ok
+flush driven by the byte predicate hands the accumulated samples to the FFI boundary ... ok
+ok | 4 passed | 0 failed
+```
+
+Regression check — temporarily reverting `shouldFlushRustChunk()` to the
+pre-#3402 estimate-only comparison
+(`rustAccumulatedEstimatedBytes >= threshold`) fails the guard test, proving the
+new behaviour-based arrange still nets the peak-copy fix:
+
+```
+byte flush fires while the accumulator alone is still under the threshold ... FAILED
+error: AssertionError: accumulator 10300 should still be under 10000 when the flush fires
+FAILED | 3 passed | 1 failed
+```
+
+The implementation was restored immediately afterwards; the diff contains no
+such change.
+
+```mermaid
+flowchart LR
+    Opt["new DiscoverStructure(..., { rustFlushBytesThreshold })"] --> Init[initialize]
+    Init --> Rec["record(sample) — public path"]
+    Rec --> State["getRustFlushByteState()"]
+    State --> Pred{"shouldFlushRustChunk()<br/>projected peak ≥ threshold?"}
+    Pred -- "no" --> Rec
+    Pred -- "yes" --> Flush["flushRustChunk()"]
+    Flush --> Stub["recordDiscovery stub<br/>observes payload size"]
+```
+
+## Test Plan
+
+Rewritten in `test/ErrorGuidedStructuralEvolution/RustFlushPeakCopy.ts` (no test
+was dropped — each original case has a behaviour-based successor):
+
+- **byte flush fires while the accumulator alone is still under the threshold**
+  — records real samples one at a time until the predicate fires, then asserts
+  the projected peak has reached the configured threshold while the single-copy
+  accumulator is still below it. This is the #3402 guard: an estimate-only
+  predicate would still be accumulating at that point.
+- **byte flush holds off while the projected peak is under the threshold** —
+  records three samples under a large threshold and asserts no flush.
+- **record-count ceiling still forces a flush regardless of bytes** — configures
+  the ceiling via the constructor argument with an effectively infinite byte
+  threshold; false at two samples, true at three.
+- **flush driven by the byte predicate hands the accumulated samples to the FFI
+  boundary** (new end-to-end case) — mirrors the `DataRecorderRecording` call
+  site: the stub receives exactly the accumulated samples, the accumulator
+  resets to zero bytes, and the next chunk flushes at the same size.
+
+Full `./quality.sh` run passes.

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructureRecording.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoverStructureRecording.ts
@@ -217,9 +217,33 @@ export class DiscoverStructureRecording extends DiscoverStructureBase {
     // peak so it stays under `rustFlushBytesThreshold` instead of overshooting
     // it by the copy — the discovery heap retainer MemoryMonitor cannot free
     // (#2594).
-    const projectedPeakBytes = this.rustAccumulatedEstimatedBytes *
-      RUST_FLUSH_PEAK_COPY_MULTIPLIER;
-    return projectedPeakBytes >= this.rustFlushBytesThreshold;
+    const state = this.getRustFlushByteState();
+    return state.projectedPeakBytes >= state.bytesThreshold;
+  }
+
+  /**
+   * Snapshot of the byte accounting behind the flush decision (Issue #3402).
+   *
+   * `projectedPeakBytes` is the heap the flush is expected to peak at — the
+   * still-live accumulator plus the plain-object FFI payload copy
+   * `writeRustParquetChunk` builds alongside it — and is what
+   * {@link shouldFlushRustChunk} compares against `bytesThreshold`. Exposed so
+   * callers (and tests) can observe the decision inputs without reaching into
+   * the recorder's internal bookkeeping.
+   */
+  public getRustFlushByteState(): {
+    accumulatedSamples: number;
+    accumulatedEstimatedBytes: number;
+    projectedPeakBytes: number;
+    bytesThreshold: number;
+  } {
+    return {
+      accumulatedSamples: this.rustAccumulatedData.length,
+      accumulatedEstimatedBytes: this.rustAccumulatedEstimatedBytes,
+      projectedPeakBytes: this.rustAccumulatedEstimatedBytes *
+        RUST_FLUSH_PEAK_COPY_MULTIPLIER,
+      bytesThreshold: this.rustFlushBytesThreshold,
+    };
   }
 
   private getNextChunkDir(): string {

--- a/test/ErrorGuidedStructuralEvolution/RustFlushPeakCopy.ts
+++ b/test/ErrorGuidedStructuralEvolution/RustFlushPeakCopy.ts
@@ -7,17 +7,29 @@
  * `shouldFlushRustChunk` must decide against that projected peak so it stays
  * under `rustFlushBytesThreshold` rather than overshooting it by the copy — the
  * single-generation discovery heap retainer `MemoryMonitor` cannot free (#2594).
+ *
+ * Every case here drives the predicate the way production does (Issue #3676):
+ * the threshold is configured through `DiscoverStructureOptions`, the byte
+ * accounting is produced by recording real samples through the public
+ * `record()` path, and the flush itself is observed at the injected
+ * `recordDiscovery` boundary.
  */
 
-import { assertEquals } from "@std/assert";
+import { assert, assertEquals } from "@std/assert";
 import { DiscoverStructure } from "@architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
 import type { DiscoverStructureDeps } from "@architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
+import type { RustRecordInput } from "@architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts";
 import type { CreatureExport } from "@architecture/CreatureInterfaces.ts";
+import type { DataRecordInterface } from "@architecture/DataSet.ts";
 import { Creature } from "@creature";
 import { IDENTITY } from "@methods/activations/types/IDENTITY.ts";
 import { CreatureUtil } from "@architecture/CreatureUtils.ts";
-import { RUST_FLUSH_PEAK_COPY_MULTIPLIER } from "@architecture/ErrorGuidedStructuralEvolution/constants.ts";
 import { initWasmForTests } from "../_initWasm.ts";
+
+/** Record-count ceiling high enough that only the byte rule can fire. */
+const NO_RECORD_CEILING = 1_000_000;
+/** Safety cap so a broken predicate fails the test instead of looping. */
+const MAX_SAMPLES = 500;
 
 function makeTestCreature(): Creature {
   const json: CreatureExport = {
@@ -38,74 +50,163 @@ function makeTestCreature(): Creature {
   return creature;
 }
 
-function buildStructure(): DiscoverStructure {
+function makeSample(index: number): DataRecordInterface {
+  return {
+    input: Float32Array.from([index / 100, (index + 1) / 100]),
+    output: Float32Array.from([index / 100]),
+  };
+}
+
+/**
+ * Build a structure through the supported surface: the byte threshold and the
+ * record ceiling are constructor configuration, and the FFI boundary is the
+ * injected `recordDiscovery` stub whose payload sizes are captured.
+ */
+function buildStructure(
+  bytesThreshold: number,
+  flushRecords: number = NO_RECORD_CEILING,
+): { structure: DiscoverStructure; flushedSampleCounts: number[] } {
+  const flushedSampleCounts: number[] = [];
   const deps: Partial<DiscoverStructureDeps> = {
     isRustDiscoveryEnabled: () => true,
     isRustLibraryAvailable: () => true,
-    recordDiscovery: () => ({ success: true, file: "/tmp/ignored.parquet" }),
+    recordDiscovery: (input: RustRecordInput) => {
+      flushedSampleCounts.push(input.training_data.length);
+      return {
+        success: true,
+        file: `chunk-${flushedSampleCounts.length}.parquet`,
+      };
+    },
   };
-  const structure = new DiscoverStructure(makeTestCreature(), 600, 4096, deps);
+  const structure = new DiscoverStructure(
+    makeTestCreature(),
+    600,
+    flushRecords,
+    deps,
+    { rustFlushBytesThreshold: bytesThreshold },
+  );
   structure.initialize(new Map());
-  // Mark the Rust dual-write path active so `shouldFlushRustChunk` runs.
-  (structure as unknown as { usingRustDualWrite: boolean }).usingRustDualWrite =
-    true;
-  return structure;
+  return { structure, flushedSampleCounts };
 }
 
-Deno.test("shouldFlushRustChunk: fires once projected peak (2x estimate) crosses the byte threshold", async () => {
-  await initWasmForTests();
-  const structure = buildStructure();
-  const s = structure as unknown as {
-    rustFlushBytesThreshold: number;
-    rustAccumulatedEstimatedBytes: number;
-    rustAccumulatedData: unknown[];
-    shouldFlushRustChunk: () => boolean;
-  };
-
-  s.rustFlushBytesThreshold = 1000;
-  // Two accumulated samples so the record-count path (4096) is not the trigger.
-  s.rustAccumulatedData = [{}, {}];
-
-  // Accumulator estimate below threshold but its ~2x flush-time peak is at/above
-  // it: the old estimate-only check under-fired and let the real payload
-  // overshoot. It must now flush.
-  s.rustAccumulatedEstimatedBytes = Math.ceil(
-    1000 / RUST_FLUSH_PEAK_COPY_MULTIPLIER,
+/**
+ * Record one real sample at a time until the predicate fires, returning how
+ * many samples that took. Fails loudly rather than looping if it never fires.
+ */
+function recordUntilFlush(structure: DiscoverStructure): number {
+  const neuronPromises = new Map<number, Promise<void>>();
+  for (let sample = 1; sample <= MAX_SAMPLES; sample++) {
+    structure.record([makeSample(sample)], neuronPromises);
+    if (structure.shouldFlushRustChunk()) {
+      return sample;
+    }
+  }
+  throw new Error(
+    `shouldFlushRustChunk() never fired within ${MAX_SAMPLES} recorded samples`,
   );
-  assertEquals(structure.shouldFlushRustChunk(), true);
+}
+
+Deno.test("byte flush fires while the accumulator alone is still under the threshold", async () => {
+  await initWasmForTests();
+  const bytesThreshold = 10_000;
+  const { structure } = buildStructure(bytesThreshold);
+
+  try {
+    const samples = recordUntilFlush(structure);
+    const state = structure.getRustFlushByteState();
+
+    assertEquals(state.bytesThreshold, bytesThreshold);
+    assertEquals(state.accumulatedSamples, samples);
+    assert(
+      samples > 1,
+      `threshold ${bytesThreshold} must span more than one sample for this creature, fired after ${samples}`,
+    );
+    // The projected flush-time peak has reached the threshold …
+    assert(
+      state.projectedPeakBytes >= bytesThreshold,
+      `projected peak ${state.projectedPeakBytes} should have reached ${bytesThreshold}`,
+    );
+    // … while the accumulator on its own is still comfortably below it. This is
+    // the #3402 guard: an estimate-only predicate would still be accumulating
+    // here, and the flush-time copy would then push the real peak past the
+    // threshold.
+    assert(
+      state.accumulatedEstimatedBytes < bytesThreshold,
+      `accumulator ${state.accumulatedEstimatedBytes} should still be under ${bytesThreshold} when the flush fires`,
+    );
+  } finally {
+    await structure.cleanUp();
+  }
 });
 
-Deno.test("shouldFlushRustChunk: does not fire while the projected peak is under the threshold", async () => {
+Deno.test("byte flush holds off while the projected peak is under the threshold", async () => {
   await initWasmForTests();
-  const structure = buildStructure();
-  const s = structure as unknown as {
-    rustFlushBytesThreshold: number;
-    rustAccumulatedEstimatedBytes: number;
-    rustAccumulatedData: unknown[];
-    shouldFlushRustChunk: () => boolean;
-  };
+  const bytesThreshold = 1_000_000;
+  const { structure } = buildStructure(bytesThreshold);
 
-  s.rustFlushBytesThreshold = 1000;
-  s.rustAccumulatedData = [{}, {}];
-  // Projected peak = 2 * 400 = 800 < 1000 — no flush.
-  s.rustAccumulatedEstimatedBytes = 400;
-  assertEquals(structure.shouldFlushRustChunk(), false);
+  try {
+    const neuronPromises = new Map<number, Promise<void>>();
+    structure.record(
+      [makeSample(1), makeSample(2), makeSample(3)],
+      neuronPromises,
+    );
+
+    const state = structure.getRustFlushByteState();
+    assertEquals(state.accumulatedSamples, 3);
+    assert(
+      state.projectedPeakBytes < bytesThreshold,
+      `three samples must stay under ${bytesThreshold} for this test to mean anything`,
+    );
+    assertEquals(structure.shouldFlushRustChunk(), false);
+  } finally {
+    await structure.cleanUp();
+  }
 });
 
-Deno.test("shouldFlushRustChunk: record-count ceiling still forces a flush", async () => {
+Deno.test("record-count ceiling still forces a flush regardless of bytes", async () => {
   await initWasmForTests();
-  const structure = buildStructure();
-  const s = structure as unknown as {
-    rustFlushRecords: number;
-    rustFlushBytesThreshold: number;
-    rustAccumulatedEstimatedBytes: number;
-    rustAccumulatedData: unknown[];
-    shouldFlushRustChunk: () => boolean;
-  };
+  const { structure } = buildStructure(Number.MAX_SAFE_INTEGER, 3);
 
-  s.rustFlushRecords = 3;
-  s.rustFlushBytesThreshold = Number.MAX_SAFE_INTEGER;
-  s.rustAccumulatedEstimatedBytes = 0;
-  s.rustAccumulatedData = [{}, {}, {}];
-  assertEquals(structure.shouldFlushRustChunk(), true);
+  try {
+    const neuronPromises = new Map<number, Promise<void>>();
+    structure.record([makeSample(1), makeSample(2)], neuronPromises);
+    assertEquals(structure.shouldFlushRustChunk(), false);
+
+    structure.record([makeSample(3)], neuronPromises);
+    assertEquals(structure.shouldFlushRustChunk(), true);
+  } finally {
+    await structure.cleanUp();
+  }
+});
+
+Deno.test("flush driven by the byte predicate hands the accumulated samples to the FFI boundary", async () => {
+  await initWasmForTests();
+  const bytesThreshold = 10_000;
+  const { structure, flushedSampleCounts } = buildStructure(bytesThreshold);
+
+  try {
+    // Mirror the production call site (DataRecorderRecording): record, then
+    // flush as soon as the predicate says the projected peak has been reached.
+    const samples = recordUntilFlush(structure);
+    assertEquals(flushedSampleCounts, []);
+
+    assertEquals(structure.flushRustChunk(), true);
+    assertEquals(flushedSampleCounts, [samples]);
+
+    // The accumulator is cleared, so the next chunk starts from zero bytes.
+    const state = structure.getRustFlushByteState();
+    assertEquals(state.accumulatedSamples, 0);
+    assertEquals(state.accumulatedEstimatedBytes, 0);
+    assertEquals(state.projectedPeakBytes, 0);
+    assertEquals(structure.shouldFlushRustChunk(), false);
+
+    // A second chunk flushes at the same size — the threshold bounds every
+    // chunk, not just the first.
+    const secondSamples = recordUntilFlush(structure);
+    assertEquals(secondSamples, samples);
+    assertEquals(structure.flushRustChunk(), true);
+    assertEquals(flushedSampleCounts, [samples, samples]);
+  } finally {
+    await structure.cleanUp();
+  }
 });


### PR DESCRIPTION
# PR Summary — Issue #3676

## Summary

`test/ErrorGuidedStructuralEvolution/RustFlushPeakCopy.ts` arranged all three
cases by casting `DiscoverStructure` to an ad-hoc shape and hand-writing five
protected fields (`usingRustDualWrite`, `rustFlushBytesThreshold`,
`rustAccumulatedEstimatedBytes`, `rustAccumulatedData`, `rustFlushRecords`)
before asserting `shouldFlushRustChunk()`. That verified the predicate against
state the implementation might never produce: a rename of the internal
bookkeeping broke the tests with no behaviour change, and a drift in the real
accumulation path would leave them green while the Issue #3402 peak-copy guard
silently regressed.

The tests are rewritten to drive the predicate the way production does
(suggested fix (a) — the file is **not** deleted, so the #3402 behaviour keeps a
direct behavioural net):

- The byte threshold now comes from
  `DiscoverStructureOptions.rustFlushBytesThreshold` and the record ceiling from
  the constructor argument.
- The byte accounting is produced by recording **real** samples through the
  public `record()` path.
- `usingRustDualWrite` is no longer poked — `initialize()` already sets it.
- The flush itself is observed at the already-injected `recordDiscovery`
  boundary stub.

To let a test observe the flush decision without reaching into protected state,
`DiscoverStructureRecording` gains a small public accessor,
`getRustFlushByteState()`, returning the accumulated sample count, the
accumulated estimate, the projected flush-time peak, and the configured
threshold. `shouldFlushRustChunk()` now reads its projected peak from that same
accessor, so there is one source of truth for the decision inputs.

Closes #3676.

## Evidence

Backend-only change — no web interface to screenshot. Evidence is the test run
plus a deliberate regression check.

All four cases pass against the current implementation:

```
byte flush fires while the accumulator alone is still under the threshold ... ok
byte flush holds off while the projected peak is under the threshold ... ok
record-count ceiling still forces a flush regardless of bytes ... ok
flush driven by the byte predicate hands the accumulated samples to the FFI boundary ... ok
ok | 4 passed | 0 failed
```

Regression check — temporarily reverting `shouldFlushRustChunk()` to the
pre-#3402 estimate-only comparison
(`rustAccumulatedEstimatedBytes >= threshold`) fails the guard test, proving the
new behaviour-based arrange still nets the peak-copy fix:

```
byte flush fires while the accumulator alone is still under the threshold ... FAILED
error: AssertionError: accumulator 10300 should still be under 10000 when the flush fires
FAILED | 3 passed | 1 failed
```

The implementation was restored immediately afterwards; the diff contains no
such change.

```mermaid
flowchart LR
    Opt["new DiscoverStructure(..., { rustFlushBytesThreshold })"] --> Init[initialize]
    Init --> Rec["record(sample) — public path"]
    Rec --> State["getRustFlushByteState()"]
    State --> Pred{"shouldFlushRustChunk()<br/>projected peak ≥ threshold?"}
    Pred -- "no" --> Rec
    Pred -- "yes" --> Flush["flushRustChunk()"]
    Flush --> Stub["recordDiscovery stub<br/>observes payload size"]
```

## Test Plan

Rewritten in `test/ErrorGuidedStructuralEvolution/RustFlushPeakCopy.ts` (no test
was dropped — each original case has a behaviour-based successor):

- **byte flush fires while the accumulator alone is still under the threshold**
  — records real samples one at a time until the predicate fires, then asserts
  the projected peak has reached the configured threshold while the single-copy
  accumulator is still below it. This is the #3402 guard: an estimate-only
  predicate would still be accumulating at that point.
- **byte flush holds off while the projected peak is under the threshold** —
  records three samples under a large threshold and asserts no flush.
- **record-count ceiling still forces a flush regardless of bytes** — configures
  the ceiling via the constructor argument with an effectively infinite byte
  threshold; false at two samples, true at three.
- **flush driven by the byte predicate hands the accumulated samples to the FFI
  boundary** (new end-to-end case) — mirrors the `DataRecorderRecording` call
  site: the stub receives exactly the accumulated samples, the accumulator
  resets to zero bytes, and the next chunk flushes at the same size.

Full `./quality.sh` run passes.



## Milestone
This PR is part of the **Scan 20260807** milestone and targets the `milestone/scan-20260807` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-msjcb4xu-19383a`<!-- vibe-worker-issue-3676 -->