### PR TITLE
Collapse four copy-paste test families into case tables (Issue #3677)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-3677.md
+++ b/docs/archive/pr-summaries/pr-summary-3677.md
@@ -1,0 +1,108 @@
+# Table-driven the four copy-paste test families (Issue #3677)
+
+## Summary
+
+Four test files each carried a family of near-identical bodies differing only in
+one input literal and its expected output. Each family is now one shared body
+driven by a reviewable case table, so adding an activation or tightening a
+validation message is a table row rather than a hand-copied body. Closes #3677.
+
+| File                                             | Family                                                 | Before    | After             |
+| ------------------------------------------------ | ------------------------------------------------------ | --------- | ----------------- |
+| `test/methods/activations/EdgeCases.ts`          | `squash(0)`, `squash(large)`, `squash(large_negative)` | 42 bodies | 3 tables + 1 body |
+| `test/wasm/WasmDerivative.ts`                    | WASM-vs-JS derivative comparison                       | 32 bodies | 1 table + 1 body  |
+| `test/config/MCMCConfig.ts`                      | `createNeatConfig` rejection of invalid `mcmc` values  | 16 bodies | 1 table + 1 body  |
+| `test/methods/activations/SafeZoneAdjustment.ts` | `safeZoneAdjustment` boundary scenarios                | 35 bodies | 1 table + 1 body  |
+
+Design decisions worth a reviewer's attention:
+
+- **Registration idiom.** The issue suggested `t.step`, but `deno.json` opts
+  into the `no-await-in-loop` lint rule and stepping over a table needs a
+  sequential `await` per case. The repo's own established data-driven idiom —
+  the generated `Deno.test` loop already present in `EdgeCases.ts` for
+  non-finite inputs — gives the same per-case reporting with no lint
+  suppression, so each table row registers its own named `Deno.test`.
+- **No coverage lost.** Every case literal moved across unchanged. The case
+  types keep the distinctions the original bodies carried: exact vs tolerant
+  comparison (`tolerance` omitted means `assertEquals`), and strict vs inclusive
+  range bounds (`gt`/`gte`/`lt`/`lte`) so the asymptotic `LOGISTIC`/`TANH`
+  assertions stay exactly as strict as before.
+- **Kept out of the tables.** `StdInverse: squash(0)` (asserts magnitude, not a
+  value), the `SQRT` derivative `x <= 0` edge assertions (compare WASM against a
+  fixed 0, not against the JS impl), the aggregate-derivative test, and the
+  per-activation boundary tests are genuinely one-off, so they stay as
+  standalone bodies. Splitting the `SQRT` edge assertions out is why the runtime
+  test count goes 150 → 151.
+- **Guard lifted.** `SafeZoneAdjustment.ts`'s three-line
+  `Activations.find(...)` + `hasSafeZone` preamble is now
+  `findSafeZoneActivation(name)`, which fails loud when an activation has no
+  safe-zone logic.
+
+```mermaid
+flowchart LR
+    subgraph Before
+        B1[body 1: name/input/expected]
+        B2[body 2: name/input/expected]
+        B3[...90 bodies]
+    end
+    subgraph After
+        T[CASE TABLE<br/>one row per case] --> R[shared assert body]
+        R --> D["Deno.test per row<br/>(named, per-case reporting)"]
+    end
+    Before -.->|Issue #3677| After
+```
+
+## Evidence
+
+Backend/test-only change — no web interface to screenshot. Evidence is the test
+run itself: the collapsed files register the same cases as before and the full
+quality gate is green.
+
+Per-file run (`deno test --allow-all` over the four files) — 151 tests, all
+named per case:
+
+```
+ArcTan: squash(0) ≈ 0 … ok
+LOGISTIC: squash(0) ≈ 0.5 … ok
+LOGISTIC: squash(100) > 0.99 and <= 1 … ok
+WASM Derivative: ReLU6 … ok
+MCMCConfig - coolingRate must be < 1 … ok
+SQUARE: recovery zone allows small value … ok
+
+ok | 151 passed | 0 failed (403ms)
+```
+
+Full quality gate (`./quality.sh < /dev/null`) — lint, format, type-check, WASM
+sync and the whole suite:
+
+```
+ok | 8186 passed (5 steps) | 0 failed | 4 ignored (4m40s)
+```
+
+Case-count parity, checked against `git show HEAD:<file>`:
+
+| File                    | Cases before                      | Cases after                       |
+| ----------------------- | --------------------------------- | --------------------------------- |
+| `EdgeCases.ts`          | 42                                | 42                                |
+| `WasmDerivative.ts`     | 32                                | 32                                |
+| `MCMCConfig.ts`         | 16                                | 16                                |
+| `SafeZoneAdjustment.ts` | 74 assertions across 35 scenarios | 74 assertions across 35 scenarios |
+
+## Test Plan
+
+No new behaviour, so no new assertions — the tests _are_ the change. What was
+verified:
+
+- `test/methods/activations/EdgeCases.ts` — `ZERO_CASES` (31 rows),
+  `LARGE_POSITIVE_CASES` (6), `LARGE_NEGATIVE_CASES` (5) each register a named
+  test; `StdInverse`, the non-finite loop and the five boundary tests unchanged.
+- `test/wasm/WasmDerivative.ts` — `DERIVATIVE_CASES` (32 rows) registers one
+  named test per activation, preserving each per-activation value set (`ReLU6`,
+  `HardTanh`, `Mish`, `TAN`, `Step`, `Sqrt`, `Exponential`) and the `Mish` 1e-3
+  tolerance override. WASM initialisation still registers first, so it runs
+  before the comparisons.
+- `test/config/MCMCConfig.ts` — `MCMC_REJECTION_CASES` (16 rows) covers every
+  former `assertThrows`, including the Issue #2201 (`adjustmentRate`,
+  `toleranceRate`) and Issue #2527 (`mcmcAdvantageMode`) cases.
+- `test/methods/activations/SafeZoneAdjustment.ts` — `SAFE_ZONE_SCENARIOS` (35
+  rows, 74 cases) registers one named test per scenario.

--- a/test/config/MCMCConfig.ts
+++ b/test/config/MCMCConfig.ts
@@ -1,6 +1,7 @@
 import { assertEquals, assertThrows } from "@std/assert";
 import { createNeatConfig } from "@config/NeatConfig.ts";
 import { DEFAULT_MCMC_CONFIG } from "@config/MCMCConfig.ts";
+import type { NeatOptionsInput } from "@config/NeatOptions.ts";
 
 Deno.test("MCMCConfig - defaults applied when not specified", () => {
   const config = createNeatConfig({});
@@ -75,175 +76,117 @@ Deno.test("MCMCConfig - string values coerced from CLI", () => {
   assertEquals(config.mcmc.targetAcceptanceRate, 0.3);
 });
 
-Deno.test("MCMCConfig - initialTemperature must be > 0", () => {
-  assertThrows(
-    () =>
-      createNeatConfig({
-        mcmc: { initialTemperature: 0 },
-      }),
-    Error,
-    "initialTemperature",
-  );
-});
+/** One rejected `mcmc` block and the field its error message must name. */
+type MCMCRejectionCase = {
+  /** Step name describing the rule under test. */
+  readonly scenario: string;
+  /** The `mcmc` block handed to `createNeatConfig`. */
+  readonly mcmc: NonNullable<NeatOptionsInput["mcmc"]>;
+  /** Substring the thrown message must contain (the offending field). */
+  readonly field: string;
+};
 
-Deno.test("MCMCConfig - negative initialTemperature rejected", () => {
-  assertThrows(
-    () =>
-      createNeatConfig({
-        mcmc: { initialTemperature: -1 },
-      }),
-    Error,
-    "initialTemperature",
-  );
-});
+/**
+ * Every invalid `mcmc` value `createNeatConfig` must reject. Table-driven
+ * (Issue #3677) so a new rule is one row, and tightening a message is one
+ * assertion site. Covers Issue #2201 (adjustmentRate / toleranceRate) and
+ * Issue #2527 (mcmcAdvantageMode).
+ */
+const MCMC_REJECTION_CASES: readonly MCMCRejectionCase[] = [
+  {
+    scenario: "initialTemperature must be > 0",
+    mcmc: { initialTemperature: 0 },
+    field: "initialTemperature",
+  },
+  {
+    scenario: "negative initialTemperature rejected",
+    mcmc: { initialTemperature: -1 },
+    field: "initialTemperature",
+  },
+  {
+    scenario: "minTemperature must be > 0",
+    mcmc: { minTemperature: 0 },
+    field: "minTemperature",
+  },
+  {
+    scenario: "negative minTemperature rejected",
+    mcmc: { minTemperature: -0.01 },
+    field: "minTemperature",
+  },
+  {
+    scenario: "coolingRate must be > 0",
+    mcmc: { coolingRate: 0 },
+    field: "coolingRate",
+  },
+  {
+    scenario: "coolingRate must be < 1",
+    mcmc: { coolingRate: 1 },
+    field: "coolingRate",
+  },
+  {
+    scenario: "coolingRate >= 1 rejected",
+    mcmc: { coolingRate: 1.5 },
+    field: "coolingRate",
+  },
+  {
+    scenario: "negative coolingRate rejected",
+    mcmc: { coolingRate: -0.5 },
+    field: "coolingRate",
+  },
+  {
+    scenario: "targetAcceptanceRate must be > 0",
+    mcmc: { targetAcceptanceRate: 0 },
+    field: "targetAcceptanceRate",
+  },
+  {
+    scenario: "targetAcceptanceRate must be < 1",
+    mcmc: { targetAcceptanceRate: 1 },
+    field: "targetAcceptanceRate",
+  },
+  {
+    scenario: "minTemperature must be <= initialTemperature",
+    mcmc: { initialTemperature: 0.5, minTemperature: 1.0 },
+    field: "minTemperature",
+  },
+  // Issue #2201: adjustmentRate and toleranceRate
+  {
+    scenario: "adjustmentRate must be > 0",
+    mcmc: { adjustmentRate: 0 },
+    field: "adjustmentRate",
+  },
+  {
+    scenario: "adjustmentRate must be < 1",
+    mcmc: { adjustmentRate: 1 },
+    field: "adjustmentRate",
+  },
+  {
+    scenario: "toleranceRate must be > 0",
+    mcmc: { toleranceRate: 0 },
+    field: "toleranceRate",
+  },
+  {
+    scenario: "toleranceRate must be < 1",
+    mcmc: { toleranceRate: 1 },
+    field: "toleranceRate",
+  },
+  // Issue #2527: mcmcAdvantageMode
+  {
+    scenario: "mcmcAdvantageMode rejects unknown strings",
+    // deno-lint-ignore no-explicit-any
+    mcmc: { mcmcAdvantageMode: "raw" as any },
+    field: "mcmcAdvantageMode",
+  },
+];
 
-Deno.test("MCMCConfig - minTemperature must be > 0", () => {
-  assertThrows(
-    () =>
-      createNeatConfig({
-        mcmc: { minTemperature: 0 },
-      }),
-    Error,
-    "minTemperature",
-  );
-});
-
-Deno.test("MCMCConfig - negative minTemperature rejected", () => {
-  assertThrows(
-    () =>
-      createNeatConfig({
-        mcmc: { minTemperature: -0.01 },
-      }),
-    Error,
-    "minTemperature",
-  );
-});
-
-Deno.test("MCMCConfig - coolingRate must be > 0", () => {
-  assertThrows(
-    () =>
-      createNeatConfig({
-        mcmc: { coolingRate: 0 },
-      }),
-    Error,
-    "coolingRate",
-  );
-});
-
-Deno.test("MCMCConfig - coolingRate must be < 1", () => {
-  assertThrows(
-    () =>
-      createNeatConfig({
-        mcmc: { coolingRate: 1 },
-      }),
-    Error,
-    "coolingRate",
-  );
-});
-
-Deno.test("MCMCConfig - coolingRate >= 1 rejected", () => {
-  assertThrows(
-    () =>
-      createNeatConfig({
-        mcmc: { coolingRate: 1.5 },
-      }),
-    Error,
-    "coolingRate",
-  );
-});
-
-Deno.test("MCMCConfig - negative coolingRate rejected", () => {
-  assertThrows(
-    () =>
-      createNeatConfig({
-        mcmc: { coolingRate: -0.5 },
-      }),
-    Error,
-    "coolingRate",
-  );
-});
-
-Deno.test("MCMCConfig - targetAcceptanceRate must be > 0", () => {
-  assertThrows(
-    () =>
-      createNeatConfig({
-        mcmc: { targetAcceptanceRate: 0 },
-      }),
-    Error,
-    "targetAcceptanceRate",
-  );
-});
-
-Deno.test("MCMCConfig - targetAcceptanceRate must be < 1", () => {
-  assertThrows(
-    () =>
-      createNeatConfig({
-        mcmc: { targetAcceptanceRate: 1 },
-      }),
-    Error,
-    "targetAcceptanceRate",
-  );
-});
-
-Deno.test("MCMCConfig - minTemperature must be <= initialTemperature", () => {
-  assertThrows(
-    () =>
-      createNeatConfig({
-        mcmc: {
-          initialTemperature: 0.5,
-          minTemperature: 1.0,
-        },
-      }),
-    Error,
-    "minTemperature",
-  );
-});
-
-// Issue #2201: Tests for adjustmentRate and toleranceRate
-
-Deno.test("MCMCConfig - adjustmentRate must be > 0", () => {
-  assertThrows(
-    () =>
-      createNeatConfig({
-        mcmc: { adjustmentRate: 0 },
-      }),
-    Error,
-    "adjustmentRate",
-  );
-});
-
-Deno.test("MCMCConfig - adjustmentRate must be < 1", () => {
-  assertThrows(
-    () =>
-      createNeatConfig({
-        mcmc: { adjustmentRate: 1 },
-      }),
-    Error,
-    "adjustmentRate",
-  );
-});
-
-Deno.test("MCMCConfig - toleranceRate must be > 0", () => {
-  assertThrows(
-    () =>
-      createNeatConfig({
-        mcmc: { toleranceRate: 0 },
-      }),
-    Error,
-    "toleranceRate",
-  );
-});
-
-Deno.test("MCMCConfig - toleranceRate must be < 1", () => {
-  assertThrows(
-    () =>
-      createNeatConfig({
-        mcmc: { toleranceRate: 1 },
-      }),
-    Error,
-    "toleranceRate",
-  );
-});
+for (const rejection of MCMC_REJECTION_CASES) {
+  Deno.test(`MCMCConfig - ${rejection.scenario}`, () => {
+    assertThrows(
+      () => createNeatConfig({ mcmc: rejection.mcmc }),
+      Error,
+      rejection.field,
+    );
+  });
+}
 
 Deno.test("MCMCConfig - custom adjustmentRate and toleranceRate override defaults", () => {
   const config = createNeatConfig({
@@ -294,18 +237,4 @@ Deno.test("MCMCConfig - mcmcAdvantageMode 'groupRelative' is accepted", () => {
   assertEquals(config.mcmc.minCohortSize, 8);
   assertEquals(config.mcmc.advantageEps, 1e-6);
   assertEquals(config.mcmc.advantageClip, 5);
-});
-
-Deno.test("MCMCConfig - mcmcAdvantageMode rejects unknown strings", () => {
-  assertThrows(
-    () =>
-      createNeatConfig({
-        mcmc: {
-          // deno-lint-ignore no-explicit-any
-          mcmcAdvantageMode: "raw" as any,
-        },
-      }),
-    Error,
-    "mcmcAdvantageMode",
-  );
 });

--- a/test/methods/activations/EdgeCases.ts
+++ b/test/methods/activations/EdgeCases.ts
@@ -7,6 +7,10 @@
  * - Non-finite inputs (NaN, ±Infinity)
  * - Boundary values specific to each activation
  *
+ * The x = 0, large-positive and large-negative families are table-driven
+ * (Issue #3677): each former one-off test is now a row in a case table, run by
+ * a single shared body and still reported as its own named test.
+ *
  * @module
  */
 
@@ -14,153 +18,141 @@ import { assert, assertAlmostEquals, assertEquals } from "@std/assert";
 import { Activations } from "@methods/activations/Activations.ts";
 import type { ActivationInterface } from "@methods/activations/ActivationInterface.ts";
 
+/** Inclusive/exclusive range expectation for cases without an exact value. */
+type SquashBounds = {
+  /** Result must be strictly greater than this. */
+  readonly gt?: number;
+  /** Result must be greater than or equal to this. */
+  readonly gte?: number;
+  /** Result must be strictly less than this. */
+  readonly lt?: number;
+  /** Result must be less than or equal to this. */
+  readonly lte?: number;
+};
+
+/**
+ * One `squash(input)` expectation.
+ *
+ * Supply `expected` (with an optional `tolerance` — omit it for an exact
+ * match) or `bounds` for the asymptotic cases where only a range is defined.
+ */
+type SquashCase = {
+  readonly name: string;
+  readonly input: number;
+  readonly expected?: number;
+  readonly tolerance?: number;
+  readonly bounds?: SquashBounds;
+};
+
+function findActivation(name: string): ActivationInterface {
+  return Activations.find(name) as unknown as ActivationInterface;
+}
+
+function describeBounds(bounds: SquashBounds): string {
+  const parts: string[] = [];
+  if (bounds.gt !== undefined) parts.push(`> ${bounds.gt}`);
+  if (bounds.gte !== undefined) parts.push(`>= ${bounds.gte}`);
+  if (bounds.lt !== undefined) parts.push(`< ${bounds.lt}`);
+  if (bounds.lte !== undefined) parts.push(`<= ${bounds.lte}`);
+  return parts.join(" and ");
+}
+
+function describeCase(testCase: SquashCase): string {
+  const call = `${testCase.name}: squash(${testCase.input})`;
+  if (testCase.expected !== undefined) {
+    const operator = testCase.tolerance === undefined ? "=" : "≈";
+    return `${call} ${operator} ${testCase.expected}`;
+  }
+  return `${call} ${describeBounds(testCase.bounds ?? {})}`;
+}
+
+function assertSquashCase(testCase: SquashCase): void {
+  const activation = findActivation(testCase.name);
+  const result = activation.squash(testCase.input);
+  const label = `${testCase.name}(${testCase.input}) = ${result}`;
+
+  if (testCase.expected !== undefined) {
+    if (testCase.tolerance === undefined) {
+      assertEquals(result, testCase.expected, label);
+    } else {
+      assertAlmostEquals(
+        result,
+        testCase.expected,
+        testCase.tolerance,
+        label,
+      );
+    }
+  }
+
+  const bounds = testCase.bounds;
+  if (bounds) {
+    if (bounds.gt !== undefined) {
+      assert(result > bounds.gt, `${label}, expected > ${bounds.gt}`);
+    }
+    if (bounds.gte !== undefined) {
+      assert(result >= bounds.gte, `${label}, expected >= ${bounds.gte}`);
+    }
+    if (bounds.lt !== undefined) {
+      assert(result < bounds.lt, `${label}, expected < ${bounds.lt}`);
+    }
+    if (bounds.lte !== undefined) {
+      assert(result <= bounds.lte, `${label}, expected <= ${bounds.lte}`);
+    }
+  }
+}
+
+/** Register one named test per case, so failures still name the activation. */
+function registerSquashCases(cases: readonly SquashCase[]): void {
+  for (const testCase of cases) {
+    Deno.test(describeCase(testCase), () => assertSquashCase(testCase));
+  }
+}
+
 // --- Behaviour at x = 0 ---
 
-Deno.test("ArcTan: squash(0) = 0", () => {
-  const a = Activations.find("ArcTan") as unknown as ActivationInterface;
-  assertAlmostEquals(a.squash(0), 0, 1e-10);
-});
-
-Deno.test("BENT_IDENTITY: squash(0) = 0", () => {
-  const a = Activations.find("BENT_IDENTITY") as unknown as ActivationInterface;
+/** Every activation with a defined value at x = 0. */
+const ZERO_CASES: readonly SquashCase[] = [
+  { name: "ArcTan", input: 0, expected: 0, tolerance: 1e-10 },
   // (sqrt(0 + 1) - 1) / 2 + 0 = 0
-  assertAlmostEquals(a.squash(0), 0, 1e-10);
-});
-
-Deno.test("COMPLEMENT: squash(0) = 1", () => {
-  const a = Activations.find("COMPLEMENT") as unknown as ActivationInterface;
-  assertAlmostEquals(a.squash(0), 1, 1e-10);
-});
-
-Deno.test("Cosine: squash(0) = 1", () => {
-  const a = Activations.find("Cosine") as unknown as ActivationInterface;
-  assertAlmostEquals(a.squash(0), 1, 1e-10);
-});
-
-Deno.test("Cube: squash(0) = 0", () => {
-  const a = Activations.find("Cube") as unknown as ActivationInterface;
-  assertAlmostEquals(a.squash(0), 0, 1e-10);
-});
-
-Deno.test("ELU: squash(0) = 0", () => {
-  const a = Activations.find("ELU") as unknown as ActivationInterface;
-  assertAlmostEquals(a.squash(0), 0, 1e-10);
-});
-
-Deno.test("Exponential: squash(0) = 1", () => {
-  const a = Activations.find("Exponential") as unknown as ActivationInterface;
-  assertAlmostEquals(a.squash(0), 1, 1e-10);
-});
-
-Deno.test("GAUSSIAN: squash(0) = 1", () => {
-  const a = Activations.find("GAUSSIAN") as unknown as ActivationInterface;
-  assertAlmostEquals(a.squash(0), 1, 1e-10);
-});
-
-Deno.test("HARD_TANH: squash(0) = 0", () => {
-  const a = Activations.find("HARD_TANH") as unknown as ActivationInterface;
-  assertAlmostEquals(a.squash(0), 0, 1e-10);
-});
-
-Deno.test("IDENTITY: squash(0) = 0", () => {
-  const a = Activations.find("IDENTITY") as unknown as ActivationInterface;
-  assertAlmostEquals(a.squash(0), 0, 1e-10);
-});
-
-Deno.test("LOGISTIC: squash(0) = 0.5", () => {
-  const a = Activations.find("LOGISTIC") as unknown as ActivationInterface;
-  assertAlmostEquals(a.squash(0), 0.5, 1e-10);
-});
-
-Deno.test("ReLU: squash(0) = 0", () => {
-  const a = Activations.find("ReLU") as unknown as ActivationInterface;
-  assertAlmostEquals(a.squash(0), 0, 1e-10);
-});
-
-Deno.test("ReLU6: squash(0) = 0", () => {
-  const a = Activations.find("ReLU6") as unknown as ActivationInterface;
-  assertAlmostEquals(a.squash(0), 0, 1e-10);
-});
-
-Deno.test("SINE: squash(0) = 0", () => {
-  const a = Activations.find("SINE") as unknown as ActivationInterface;
-  assertAlmostEquals(a.squash(0), 0, 1e-10);
-});
-
-Deno.test("TANH: squash(0) = 0", () => {
-  const a = Activations.find("TANH") as unknown as ActivationInterface;
-  assertAlmostEquals(a.squash(0), 0, 1e-10);
-});
-
-Deno.test("STEP: squash(0) = 0", () => {
-  const a = Activations.find("STEP") as unknown as ActivationInterface;
-  assertEquals(a.squash(0), 0);
-});
-
-Deno.test("BIPOLAR: squash(0) = -1", () => {
-  const a = Activations.find("BIPOLAR") as unknown as ActivationInterface;
-  assertEquals(a.squash(0), -1);
-});
-
-Deno.test("ABSOLUTE: squash(0) = 0", () => {
-  const a = Activations.find("ABSOLUTE") as unknown as ActivationInterface;
-  assertAlmostEquals(a.squash(0), 0, 1e-10);
-});
-
-Deno.test("SQUARE: squash(0) = 0", () => {
-  const a = Activations.find("SQUARE") as unknown as ActivationInterface;
-  assertAlmostEquals(a.squash(0), 0, 1e-10);
-});
-
-Deno.test("SQRT: squash(0) = 0", () => {
-  const a = Activations.find("SQRT") as unknown as ActivationInterface;
-  assertAlmostEquals(a.squash(0), 0, 1e-10);
-});
-
-Deno.test("Softplus: squash(0) ≈ ln(2)", () => {
-  const a = Activations.find("Softplus") as unknown as ActivationInterface;
-  assertAlmostEquals(a.squash(0), Math.log(2), 1e-6);
-});
-
-Deno.test("SOFTSIGN: squash(0) = 0", () => {
-  const a = Activations.find("SOFTSIGN") as unknown as ActivationInterface;
-  assertAlmostEquals(a.squash(0), 0, 1e-10);
-});
-
-Deno.test("Swish: squash(0) = 0", () => {
-  const a = Activations.find("Swish") as unknown as ActivationInterface;
+  { name: "BENT_IDENTITY", input: 0, expected: 0, tolerance: 1e-10 },
+  { name: "COMPLEMENT", input: 0, expected: 1, tolerance: 1e-10 },
+  { name: "Cosine", input: 0, expected: 1, tolerance: 1e-10 },
+  { name: "Cube", input: 0, expected: 0, tolerance: 1e-10 },
+  { name: "ELU", input: 0, expected: 0, tolerance: 1e-10 },
+  { name: "Exponential", input: 0, expected: 1, tolerance: 1e-10 },
+  { name: "GAUSSIAN", input: 0, expected: 1, tolerance: 1e-10 },
+  { name: "HARD_TANH", input: 0, expected: 0, tolerance: 1e-10 },
+  { name: "IDENTITY", input: 0, expected: 0, tolerance: 1e-10 },
+  { name: "LOGISTIC", input: 0, expected: 0.5, tolerance: 1e-10 },
+  { name: "ReLU", input: 0, expected: 0, tolerance: 1e-10 },
+  { name: "ReLU6", input: 0, expected: 0, tolerance: 1e-10 },
+  { name: "SINE", input: 0, expected: 0, tolerance: 1e-10 },
+  { name: "TANH", input: 0, expected: 0, tolerance: 1e-10 },
+  { name: "STEP", input: 0, expected: 0 },
+  { name: "BIPOLAR", input: 0, expected: -1 },
+  { name: "ABSOLUTE", input: 0, expected: 0, tolerance: 1e-10 },
+  { name: "SQUARE", input: 0, expected: 0, tolerance: 1e-10 },
+  { name: "SQRT", input: 0, expected: 0, tolerance: 1e-10 },
+  { name: "Softplus", input: 0, expected: Math.log(2), tolerance: 1e-6 },
+  { name: "SOFTSIGN", input: 0, expected: 0, tolerance: 1e-10 },
   // Swish(0) = 0 * sigmoid(0) = 0 * 0.5 = 0
-  assertAlmostEquals(a.squash(0), 0, 1e-10);
-});
-
-Deno.test("GELU: squash(0) = 0", () => {
-  const a = Activations.find("GELU") as unknown as ActivationInterface;
-  assertAlmostEquals(a.squash(0), 0, 1e-6);
-});
-
-Deno.test("Mish: squash(0) ≈ 0", () => {
-  const a = Activations.find("Mish") as unknown as ActivationInterface;
+  { name: "Swish", input: 0, expected: 0, tolerance: 1e-10 },
+  { name: "GELU", input: 0, expected: 0, tolerance: 1e-6 },
   // Mish(0) = 0 * tanh(ln(2)) ≈ 0
-  assertAlmostEquals(a.squash(0), 0, 1e-6);
-});
+  { name: "Mish", input: 0, expected: 0, tolerance: 1e-6 },
+  { name: "LeakyReLU", input: 0, expected: 0, tolerance: 1e-10 },
+  { name: "ISRU", input: 0, expected: 0, tolerance: 1e-10 },
+  { name: "SELU", input: 0, expected: 0, tolerance: 1e-10 },
+  { name: "TAN", input: 0, expected: 0, tolerance: 1e-10 },
+  // 2 * sigmoid(0) - 1 = 2 * 0.5 - 1 = 0
+  { name: "BIPOLAR_SIGMOID", input: 0, expected: 0, tolerance: 1e-10 },
+  { name: "LogSigmoid", input: 0, expected: -Math.log(2), tolerance: 1e-6 },
+];
 
-Deno.test("LeakyReLU: squash(0) = 0", () => {
-  const a = Activations.find("LeakyReLU") as unknown as ActivationInterface;
-  assertAlmostEquals(a.squash(0), 0, 1e-10);
-});
-
-Deno.test("ISRU: squash(0) = 0", () => {
-  const a = Activations.find("ISRU") as unknown as ActivationInterface;
-  assertAlmostEquals(a.squash(0), 0, 1e-10);
-});
-
-Deno.test("SELU: squash(0) = 0", () => {
-  const a = Activations.find("SELU") as unknown as ActivationInterface;
-  assertAlmostEquals(a.squash(0), 0, 1e-10);
-});
+registerSquashCases(ZERO_CASES);
 
 Deno.test("StdInverse: squash(0) produces large magnitude (1/x near zero)", () => {
-  const a = Activations.find("StdInverse") as unknown as ActivationInterface;
+  const a = findActivation("StdInverse");
   // StdInverse is 1/x; near 0 it produces very large magnitude values
   const result = a.squash(0);
   assert(
@@ -171,24 +163,6 @@ Deno.test("StdInverse: squash(0) produces large magnitude (1/x near zero)", () =
     Math.abs(result) > 1e10,
     `StdInverse: squash(0) should be very large magnitude, got ${result}`,
   );
-});
-
-Deno.test("TAN: squash(0) = 0", () => {
-  const a = Activations.find("TAN") as unknown as ActivationInterface;
-  assertAlmostEquals(a.squash(0), 0, 1e-10);
-});
-
-Deno.test("BIPOLAR_SIGMOID: squash(0) = 0", () => {
-  const a = Activations.find(
-    "BIPOLAR_SIGMOID",
-  ) as unknown as ActivationInterface;
-  // 2 * sigmoid(0) - 1 = 2 * 0.5 - 1 = 0
-  assertAlmostEquals(a.squash(0), 0, 1e-10);
-});
-
-Deno.test("LogSigmoid: squash(0) = -ln(2)", () => {
-  const a = Activations.find("LogSigmoid") as unknown as ActivationInterface;
-  assertAlmostEquals(a.squash(0), -Math.log(2), 1e-6);
 });
 
 // --- Non-finite input handling ---
@@ -207,7 +181,7 @@ const ACTIVATIONS_HANDLING_NON_FINITE: string[] = [
 
 for (const name of ACTIVATIONS_HANDLING_NON_FINITE) {
   Deno.test(`${name}: squash handles non-finite inputs gracefully`, () => {
-    const activation = Activations.find(name) as unknown as ActivationInterface;
+    const activation = findActivation(name);
 
     for (const x of [NaN, Infinity, -Infinity]) {
       const result = activation.squash(x);
@@ -221,74 +195,33 @@ for (const name of ACTIVATIONS_HANDLING_NON_FINITE) {
 
 // --- Large positive inputs ---
 
-Deno.test("LOGISTIC: squash(large) ≈ 1", () => {
-  const a = Activations.find("LOGISTIC") as unknown as ActivationInterface;
-  const result = a.squash(100);
-  assert(result > 0.99 && result <= 1, `LOGISTIC(100) = ${result}`);
-});
+const LARGE_POSITIVE_CASES: readonly SquashCase[] = [
+  { name: "LOGISTIC", input: 100, bounds: { gt: 0.99, lte: 1 } },
+  { name: "TANH", input: 100, bounds: { gt: 0.99, lte: 1 } },
+  { name: "ArcTan", input: 1000, expected: Math.PI / 2, tolerance: 0.01 },
+  { name: "ReLU", input: 1000, expected: 1000 },
+  { name: "HARD_TANH", input: 100, expected: 1 },
+  { name: "GAUSSIAN", input: 100, expected: 0, tolerance: 1e-6 },
+];
 
-Deno.test("TANH: squash(large) ≈ 1", () => {
-  const a = Activations.find("TANH") as unknown as ActivationInterface;
-  const result = a.squash(100);
-  assert(result > 0.99 && result <= 1, `TANH(100) = ${result}`);
-});
-
-Deno.test("ArcTan: squash(large) ≈ π/2", () => {
-  const a = Activations.find("ArcTan") as unknown as ActivationInterface;
-  const result = a.squash(1000);
-  assertAlmostEquals(result, Math.PI / 2, 0.01);
-});
-
-Deno.test("ReLU: squash(large) = large", () => {
-  const a = Activations.find("ReLU") as unknown as ActivationInterface;
-  assertEquals(a.squash(1000), 1000);
-});
-
-Deno.test("HARD_TANH: squash(large) = 1", () => {
-  const a = Activations.find("HARD_TANH") as unknown as ActivationInterface;
-  assertEquals(a.squash(100), 1);
-});
-
-Deno.test("GAUSSIAN: squash(large) ≈ 0", () => {
-  const a = Activations.find("GAUSSIAN") as unknown as ActivationInterface;
-  const result = a.squash(100);
-  assertAlmostEquals(result, 0, 1e-6);
-});
+registerSquashCases(LARGE_POSITIVE_CASES);
 
 // --- Large negative inputs ---
 
-Deno.test("LOGISTIC: squash(large_negative) ≈ 0", () => {
-  const a = Activations.find("LOGISTIC") as unknown as ActivationInterface;
-  const result = a.squash(-100);
-  assert(result >= 0 && result < 0.01, `LOGISTIC(-100) = ${result}`);
-});
+const LARGE_NEGATIVE_CASES: readonly SquashCase[] = [
+  { name: "LOGISTIC", input: -100, bounds: { gte: 0, lt: 0.01 } },
+  { name: "TANH", input: -100, bounds: { gte: -1, lt: -0.99 } },
+  { name: "ArcTan", input: -1000, expected: -Math.PI / 2, tolerance: 0.01 },
+  { name: "ReLU", input: -100, expected: 0 },
+  { name: "HARD_TANH", input: -100, expected: -1 },
+];
 
-Deno.test("TANH: squash(large_negative) ≈ -1", () => {
-  const a = Activations.find("TANH") as unknown as ActivationInterface;
-  const result = a.squash(-100);
-  assert(result >= -1 && result < -0.99, `TANH(-100) = ${result}`);
-});
-
-Deno.test("ArcTan: squash(large_negative) ≈ -π/2", () => {
-  const a = Activations.find("ArcTan") as unknown as ActivationInterface;
-  const result = a.squash(-1000);
-  assertAlmostEquals(result, -Math.PI / 2, 0.01);
-});
-
-Deno.test("ReLU: squash(negative) = 0", () => {
-  const a = Activations.find("ReLU") as unknown as ActivationInterface;
-  assertEquals(a.squash(-100), 0);
-});
-
-Deno.test("HARD_TANH: squash(large_negative) = -1", () => {
-  const a = Activations.find("HARD_TANH") as unknown as ActivationInterface;
-  assertEquals(a.squash(-100), -1);
-});
+registerSquashCases(LARGE_NEGATIVE_CASES);
 
 // --- Specific boundary values ---
 
 Deno.test("HARD_TANH: boundary at ±1", () => {
-  const a = Activations.find("HARD_TANH") as unknown as ActivationInterface;
+  const a = findActivation("HARD_TANH");
   assertEquals(a.squash(1), 1);
   assertEquals(a.squash(-1), -1);
   // Just inside linear range
@@ -297,7 +230,7 @@ Deno.test("HARD_TANH: boundary at ±1", () => {
 });
 
 Deno.test("ReLU6: boundary at 0 and 6", () => {
-  const a = Activations.find("ReLU6") as unknown as ActivationInterface;
+  const a = findActivation("ReLU6");
   assertEquals(a.squash(0), 0);
   assertEquals(a.squash(6), 6);
   assertEquals(a.squash(-1), 0);
@@ -305,21 +238,21 @@ Deno.test("ReLU6: boundary at 0 and 6", () => {
 });
 
 Deno.test("BIPOLAR: boundary at 0", () => {
-  const a = Activations.find("BIPOLAR") as unknown as ActivationInterface;
+  const a = findActivation("BIPOLAR");
   assertEquals(a.squash(0), -1);
   assertEquals(a.squash(0.001), 1);
   assertEquals(a.squash(-0.001), -1);
 });
 
 Deno.test("STEP: boundary at 0", () => {
-  const a = Activations.find("STEP") as unknown as ActivationInterface;
+  const a = findActivation("STEP");
   assertEquals(a.squash(0), 0);
   assertEquals(a.squash(0.001), 1);
   assertEquals(a.squash(-0.001), 0);
 });
 
 Deno.test("SOFTSIGN: asymptotic approach to ±0.99 (clamped range)", () => {
-  const a = Activations.find("SOFTSIGN") as unknown as ActivationInterface;
+  const a = findActivation("SOFTSIGN");
   const large = a.squash(1000);
   const smallNeg = a.squash(-1000);
   // SOFTSIGN range is clamped at ±0.99

--- a/test/methods/activations/SafeZoneAdjustment.ts
+++ b/test/methods/activations/SafeZoneAdjustment.ts
@@ -8,6 +8,11 @@
  * - Return low values (near 0) in saturation regions
  * - Recovery logic allows small values when error direction would help
  *
+ * The per-activation scenarios are table-driven (Issue #3677): the
+ * `Activations.find(...)` + `hasSafeZone` guard is lifted into one helper and
+ * each former test body is a row of `[activation, scenario, cases]`, still
+ * reported per scenario as its own named test.
+ *
  * @module
  */
 
@@ -15,327 +20,377 @@ import { assert, assertAlmostEquals, assertEquals } from "@std/assert";
 import { Activations } from "@methods/activations/Activations.ts";
 import type { AbstractActivationInterface } from "@methods/activations/AbstractActivationInterface.ts";
 
-function hasSafeZone(
-  activation: AbstractActivationInterface,
-): activation is AbstractActivationInterface & {
+type SafeZoneActivation = AbstractActivationInterface & {
   safeZoneAdjustment(
     rawInput: number,
     error: number,
     weight: number,
   ): number;
-} {
+};
+
+function hasSafeZone(
+  activation: AbstractActivationInterface,
+): activation is SafeZoneActivation {
   return typeof activation.safeZoneAdjustment === "function";
+}
+
+/** Resolve an activation, failing loud when it has no safe-zone logic. */
+function findSafeZoneActivation(name: string): SafeZoneActivation {
+  const activation = Activations.find(name);
+  assert(hasSafeZone(activation), `${name} must have safeZoneAdjustment`);
+  return activation;
+}
+
+/** One `safeZoneAdjustment(rawInput, error, weight)` expectation. */
+type SafeZoneCase = {
+  readonly rawInput: number;
+  readonly error: number;
+  /** Incoming synapse weight; defaults to 1. */
+  readonly weight?: number;
+  readonly expected: number;
+  /** Omit for an exact match. */
+  readonly tolerance?: number;
+};
+
+/** A named scenario for one activation. */
+type SafeZoneScenario = {
+  readonly name: string;
+  readonly scenario: string;
+  readonly cases: readonly SafeZoneCase[];
+};
+
+function assertSafeZoneCase(
+  activation: SafeZoneActivation,
+  name: string,
+  safeZoneCase: SafeZoneCase,
+): void {
+  const weight = safeZoneCase.weight ?? 1;
+  const result = activation.safeZoneAdjustment(
+    safeZoneCase.rawInput,
+    safeZoneCase.error,
+    weight,
+  );
+  const label =
+    `${name}.safeZoneAdjustment(${safeZoneCase.rawInput}, ${safeZoneCase.error}, ${weight})`;
+
+  if (safeZoneCase.tolerance === undefined) {
+    assertEquals(result, safeZoneCase.expected, label);
+  } else {
+    assertAlmostEquals(
+      result,
+      safeZoneCase.expected,
+      safeZoneCase.tolerance,
+      label,
+    );
+  }
 }
 
 // --- Specific safe-zone boundary tests for key activations ---
 
-Deno.test("ArcTan: full confidence in linear zone [-2, 2]", () => {
-  const activation = Activations.find("ArcTan");
-  assert(hasSafeZone(activation), "ArcTan must have safeZoneAdjustment");
-
-  assertEquals(activation.safeZoneAdjustment(0, 0.1, 1), 1);
-  assertEquals(activation.safeZoneAdjustment(1, 0.1, 1), 1);
-  assertEquals(activation.safeZoneAdjustment(-2, 0.1, 1), 1);
-  assertEquals(activation.safeZoneAdjustment(2, -0.1, 1), 1);
-});
-
-Deno.test("ArcTan: zero confidence beyond saturation zone (|x| > 4)", () => {
-  const activation = Activations.find("ArcTan");
-  assert(hasSafeZone(activation), "ArcTan must have safeZoneAdjustment");
-
-  assertEquals(activation.safeZoneAdjustment(5, 0.1, 1), 0);
-  assertEquals(activation.safeZoneAdjustment(-5, -0.1, 1), 0);
-});
-
-Deno.test("ArcTan: recovery zone allows small values", () => {
-  const activation = Activations.find("ArcTan");
-  assert(hasSafeZone(activation), "ArcTan must have safeZoneAdjustment");
-
-  // rawInput > 2 and error < 0 (pushing toward centre)
-  assertAlmostEquals(activation.safeZoneAdjustment(3, -0.1, 1), 0.3, 0.01);
-  // rawInput < -2 and error > 0 (pushing toward centre)
-  assertAlmostEquals(activation.safeZoneAdjustment(-3, 0.1, 1), 0.3, 0.01);
-});
-
-Deno.test("LOGISTIC: full confidence in safe zone [-6, 6]", () => {
-  const activation = Activations.find("LOGISTIC");
-  assert(hasSafeZone(activation), "LOGISTIC must have safeZoneAdjustment");
-
-  assertEquals(activation.safeZoneAdjustment(0, 0.1, 1), 1);
-  assertEquals(activation.safeZoneAdjustment(5, 0.1, 1), 1);
-  assertEquals(activation.safeZoneAdjustment(-6, 0.1, 1), 1);
-});
-
-Deno.test("LOGISTIC: zero confidence beyond hard saturation", () => {
-  const activation = Activations.find("LOGISTIC");
-  assert(hasSafeZone(activation), "LOGISTIC must have safeZoneAdjustment");
-
-  assertEquals(activation.safeZoneAdjustment(11, 0.1, 1), 0);
-  assertEquals(activation.safeZoneAdjustment(-11, -0.1, 1), 0);
-});
-
-Deno.test("LOGISTIC: recovery allows small propagation", () => {
-  const activation = Activations.find("LOGISTIC");
-  assert(hasSafeZone(activation), "LOGISTIC must have safeZoneAdjustment");
-
-  // rawInput < -6 and error > 0 → recovery
-  assertAlmostEquals(activation.safeZoneAdjustment(-8, 0.1, 1), 0.2, 0.01);
-  // rawInput > 6 and error < 0 → recovery
-  assertAlmostEquals(activation.safeZoneAdjustment(8, -0.1, 1), 0.2, 0.01);
-});
-
-Deno.test("TANH: full confidence in safe zone [-2, 2]", () => {
-  const activation = Activations.find("TANH");
-  assert(hasSafeZone(activation), "TANH must have safeZoneAdjustment");
-
-  assertEquals(activation.safeZoneAdjustment(0, 0.1, 1), 1);
-  assertEquals(activation.safeZoneAdjustment(1.5, 0.1, 1), 1);
-  assertEquals(activation.safeZoneAdjustment(-2, 0.1, 1), 1);
-});
-
-Deno.test("TANH: zero confidence beyond saturation", () => {
-  const activation = Activations.find("TANH");
-  assert(hasSafeZone(activation), "TANH must have safeZoneAdjustment");
-
-  assertEquals(activation.safeZoneAdjustment(7, 0.1, 1), 0);
-  assertEquals(activation.safeZoneAdjustment(-7, -0.1, 1), 0);
-});
-
-Deno.test("TANH: fade zone between safe and saturation", () => {
-  const activation = Activations.find("TANH");
-  assert(hasSafeZone(activation), "TANH must have safeZoneAdjustment");
-
-  // rawInput = 4, between safe (2) and max (6)
-  // fade = 1 - (4 - 2) / (6 - 2) = 0.5
-  const result = activation.safeZoneAdjustment(4, 0.1, 1);
-  assertAlmostEquals(result, 0.5, 0.01);
-});
-
-Deno.test("HARD_TANH: full confidence in linear zone [-0.9, 0.9]", () => {
-  const activation = Activations.find("HARD_TANH");
-  assert(hasSafeZone(activation), "HARD_TANH must have safeZoneAdjustment");
-
-  assertEquals(activation.safeZoneAdjustment(0, 0.1, 1), 1);
-  assertEquals(activation.safeZoneAdjustment(0.5, 0.1, 1), 1);
-  assertEquals(activation.safeZoneAdjustment(-0.9, 0.1, 1), 1);
-});
-
-Deno.test("HARD_TANH: zero confidence far outside clipping zone", () => {
-  const activation = Activations.find("HARD_TANH");
-  assert(hasSafeZone(activation), "HARD_TANH must have safeZoneAdjustment");
-
-  assertEquals(activation.safeZoneAdjustment(2, 0.1, 1), 0);
-  assertEquals(activation.safeZoneAdjustment(-2, -0.1, 1), 0);
-});
-
-Deno.test("ReLU: full confidence when active (x > 0)", () => {
-  const activation = Activations.find("ReLU");
-  assert(hasSafeZone(activation), "ReLU must have safeZoneAdjustment");
-
-  assertEquals(activation.safeZoneAdjustment(1, 0.1, 1), 1);
-  assertEquals(activation.safeZoneAdjustment(100, 0.1, 1), 1);
-});
-
-Deno.test("ReLU: dead zone when x <= 0 and error <= 0", () => {
-  const activation = Activations.find("ReLU");
-  assert(hasSafeZone(activation), "ReLU must have safeZoneAdjustment");
-
-  assertEquals(activation.safeZoneAdjustment(-1, -0.1, 1), 0);
-  assertEquals(activation.safeZoneAdjustment(0, -0.1, 1), 0);
-});
-
-Deno.test("ReLU: recovery when x <= 0 and error > 0", () => {
-  const activation = Activations.find("ReLU");
-  assert(hasSafeZone(activation), "ReLU must have safeZoneAdjustment");
-
-  assertEquals(activation.safeZoneAdjustment(-1, 0.1, 1), 1);
-  assertEquals(activation.safeZoneAdjustment(0, 0.1, 1), 1);
-});
-
-Deno.test("ReLU6: full confidence in active zone (0, 6)", () => {
-  const activation = Activations.find("ReLU6");
-  assert(hasSafeZone(activation), "ReLU6 must have safeZoneAdjustment");
-
-  assertEquals(activation.safeZoneAdjustment(3, 0.1, 1), 1);
-  assertEquals(activation.safeZoneAdjustment(0.1, 0.1, 1), 1);
-  assertEquals(activation.safeZoneAdjustment(5.9, 0.1, 1), 1);
-});
-
-Deno.test("ReLU6: dead zones at both ends", () => {
-  const activation = Activations.find("ReLU6");
-  assert(hasSafeZone(activation), "ReLU6 must have safeZoneAdjustment");
-
-  assertEquals(activation.safeZoneAdjustment(-1, -0.1, 1), 0);
-  assertEquals(activation.safeZoneAdjustment(7, 0.1, 1), 0);
-});
-
-Deno.test("ReLU6: recovery from saturation", () => {
-  const activation = Activations.find("ReLU6");
-  assert(hasSafeZone(activation), "ReLU6 must have safeZoneAdjustment");
-
-  // x <= 0 with positive error → recovery
-  assertEquals(activation.safeZoneAdjustment(-1, 0.1, 1), 1);
-  // x >= 6 with negative error → recovery
-  assertEquals(activation.safeZoneAdjustment(7, -0.1, 1), 1);
-});
-
-Deno.test("GAUSSIAN: full confidence near zero [-3, 3]", () => {
-  const activation = Activations.find("GAUSSIAN");
-  assert(hasSafeZone(activation), "GAUSSIAN must have safeZoneAdjustment");
-
-  assertEquals(activation.safeZoneAdjustment(0, 0.1, 1), 1);
-  assertEquals(activation.safeZoneAdjustment(2, 0.1, 1), 1);
-});
-
-Deno.test("GAUSSIAN: zero confidence far from zero with worsening error", () => {
-  const activation = Activations.find("GAUSSIAN");
-  assert(hasSafeZone(activation), "GAUSSIAN must have safeZoneAdjustment");
-
-  // Raw > 3 and error > 0 → getting worse
-  assertEquals(activation.safeZoneAdjustment(5, 0.1, 1), 0);
-  // Raw < -3 and error < 0 → getting worse
-  assertEquals(activation.safeZoneAdjustment(-5, -0.1, 1), 0);
-});
-
-Deno.test("IDENTITY: full confidence for normal inputs", () => {
-  const activation = Activations.find("IDENTITY");
-  assert(hasSafeZone(activation), "IDENTITY must have safeZoneAdjustment");
-
-  assertEquals(activation.safeZoneAdjustment(0, 0.1, 1), 1);
-  assertEquals(activation.safeZoneAdjustment(100, 0.1, 1), 1);
-  assertEquals(activation.safeZoneAdjustment(-100, -0.1, 1), 1);
-});
-
-Deno.test("IDENTITY: zero confidence for extreme input with tiny weight", () => {
-  const activation = Activations.find("IDENTITY");
-  assert(hasSafeZone(activation), "IDENTITY must have safeZoneAdjustment");
-
-  assertEquals(activation.safeZoneAdjustment(2e6, 0.1, 1e-7), 0);
-  assertEquals(activation.safeZoneAdjustment(-2e6, -0.1, 1e-7), 0);
-});
-
-Deno.test("STEP: high confidence when on wrong side of threshold", () => {
-  const activation = Activations.find("STEP");
-  assert(hasSafeZone(activation), "STEP must have safeZoneAdjustment");
-
-  // isAbove = true (rawInput > 0), expectedAbove = false (error < 0) → wrong side
-  assertEquals(activation.safeZoneAdjustment(1, -0.1, 1), 1);
-  // isAbove = false, expectedAbove = true → wrong side
-  assertEquals(activation.safeZoneAdjustment(-1, 0.1, 1), 1);
-});
-
-Deno.test("STEP: reduced confidence when on correct side", () => {
-  const activation = Activations.find("STEP");
-  assert(hasSafeZone(activation), "STEP must have safeZoneAdjustment");
-
-  assertAlmostEquals(activation.safeZoneAdjustment(1, 0.1, 1), 0.2, 0.01);
-  assertAlmostEquals(activation.safeZoneAdjustment(-1, -0.1, 1), 0.2, 0.01);
-});
-
-Deno.test("ABSOLUTE: full confidence for most inputs", () => {
-  const activation = Activations.find("ABSOLUTE");
-  assert(hasSafeZone(activation), "ABSOLUTE must have safeZoneAdjustment");
-
-  assertEquals(activation.safeZoneAdjustment(5, 0.1, 1), 1);
-  assertEquals(activation.safeZoneAdjustment(-5, 0.1, 1), 1);
-});
-
-Deno.test("ABSOLUTE: full confidence for near-zero inputs", () => {
-  const activation = Activations.find("ABSOLUTE");
-  assert(hasSafeZone(activation), "ABSOLUTE must have safeZoneAdjustment");
-
-  // Near-zero inputs should still have full confidence — the sign ambiguity
-  // at zero does not warrant suppressing the gradient signal.
-  assertEquals(activation.safeZoneAdjustment(0.5, 0.1, 1), 1);
-  assertEquals(activation.safeZoneAdjustment(-0.5, -0.1, 1), 1);
-  assertEquals(activation.safeZoneAdjustment(0.01, 0.1, 1), 1);
-  assertEquals(activation.safeZoneAdjustment(0, 0.1, 1), 1);
-});
-
-Deno.test("ABSOLUTE: zero for extreme input with tiny weight", () => {
-  const activation = Activations.find("ABSOLUTE");
-  assert(hasSafeZone(activation), "ABSOLUTE must have safeZoneAdjustment");
-
-  assertEquals(activation.safeZoneAdjustment(2000, 0.1, 1e-4), 0);
-});
-
-Deno.test("Cosine: high confidence where slope is strong", () => {
-  const activation = Activations.find("Cosine");
-  assert(hasSafeZone(activation), "Cosine must have safeZoneAdjustment");
-
-  // At x = π/2, sin(x) = 1 → strong slope
-  const result = activation.safeZoneAdjustment(Math.PI / 2, 0.1, 1);
-  assertEquals(result, 1);
-});
-
-Deno.test("Cosine: zero confidence at flat peaks", () => {
-  const activation = Activations.find("Cosine");
-  assert(hasSafeZone(activation), "Cosine must have safeZoneAdjustment");
-
-  // At x = 0, sin(0) = 0 → flat
-  const result = activation.safeZoneAdjustment(0, 0.1, 1);
-  assertEquals(result, 0);
-});
-
-Deno.test("SINE: high confidence where cos is strong", () => {
-  const activation = Activations.find("SINE");
-  assert(hasSafeZone(activation), "SINE must have safeZoneAdjustment");
-
-  // At x = 0, cos(0) = 1 → strong slope
-  const result = activation.safeZoneAdjustment(0, 0.1, 1);
-  assertEquals(result, 1);
-});
-
-Deno.test("Exponential: full confidence in safe zone [-10, 30]", () => {
-  const activation = Activations.find("Exponential");
-  assert(hasSafeZone(activation), "Exponential must have safeZoneAdjustment");
-
-  assertEquals(activation.safeZoneAdjustment(0, 0.1, 1), 1);
-  assertEquals(activation.safeZoneAdjustment(20, 0.1, 1), 1);
-  assertEquals(activation.safeZoneAdjustment(-5, 0.1, 1), 1);
-});
-
-Deno.test("Exponential: zero when far outside safe zone and worsening", () => {
-  const activation = Activations.find("Exponential");
-  assert(hasSafeZone(activation), "Exponential must have safeZoneAdjustment");
-
-  // rawInput > 30 and error > 0 → worsening
-  assertEquals(activation.safeZoneAdjustment(50, 0.1, 1), 0);
-  // rawInput < -10 and error < 0 → worsening
-  assertEquals(activation.safeZoneAdjustment(-30, -0.1, 1), 0);
-});
-
-Deno.test("SQUARE: full confidence in [-5, 5]", () => {
-  const activation = Activations.find("SQUARE");
-  assert(hasSafeZone(activation), "SQUARE must have safeZoneAdjustment");
-
-  assertEquals(activation.safeZoneAdjustment(0, 0.1, 1), 1);
-  assertEquals(activation.safeZoneAdjustment(3, 0.1, 1), 1);
-  assertEquals(activation.safeZoneAdjustment(-5, 0.1, 1), 1);
-});
-
-Deno.test("SQUARE: fade zone between 5 and 10", () => {
-  const activation = Activations.find("SQUARE");
-  assert(hasSafeZone(activation), "SQUARE must have safeZoneAdjustment");
-
-  // rawInput = 7.5, fade = 1 - (7.5 - 5) / 5 = 0.5
-  const result = activation.safeZoneAdjustment(7.5, 0.1, 1);
-  assertAlmostEquals(result, 0.5, 0.01);
-});
-
-Deno.test("SQUARE: zero confidence beyond 10", () => {
-  const activation = Activations.find("SQUARE");
-  assert(hasSafeZone(activation), "SQUARE must have safeZoneAdjustment");
-
-  assertEquals(activation.safeZoneAdjustment(11, 0.1, 1), 0);
-});
-
-Deno.test("SQUARE: recovery zone allows small value", () => {
-  const activation = Activations.find("SQUARE");
-  assert(hasSafeZone(activation), "SQUARE must have safeZoneAdjustment");
-
-  // rawInput > 5 and error < 0 → recovery
-  assertAlmostEquals(activation.safeZoneAdjustment(6, -0.1, 1), 0.2, 0.01);
-  // rawInput < -5 and error > 0 → recovery
-  assertAlmostEquals(activation.safeZoneAdjustment(-6, 0.1, 1), 0.2, 0.01);
-});
+const SAFE_ZONE_SCENARIOS: readonly SafeZoneScenario[] = [
+  {
+    name: "ArcTan",
+    scenario: "full confidence in linear zone [-2, 2]",
+    cases: [
+      { rawInput: 0, error: 0.1, expected: 1 },
+      { rawInput: 1, error: 0.1, expected: 1 },
+      { rawInput: -2, error: 0.1, expected: 1 },
+      { rawInput: 2, error: -0.1, expected: 1 },
+    ],
+  },
+  {
+    name: "ArcTan",
+    scenario: "zero confidence beyond saturation zone (|x| > 4)",
+    cases: [
+      { rawInput: 5, error: 0.1, expected: 0 },
+      { rawInput: -5, error: -0.1, expected: 0 },
+    ],
+  },
+  {
+    name: "ArcTan",
+    scenario: "recovery zone allows small values",
+    cases: [
+      // rawInput > 2 and error < 0 (pushing toward centre)
+      { rawInput: 3, error: -0.1, expected: 0.3, tolerance: 0.01 },
+      // rawInput < -2 and error > 0 (pushing toward centre)
+      { rawInput: -3, error: 0.1, expected: 0.3, tolerance: 0.01 },
+    ],
+  },
+  {
+    name: "LOGISTIC",
+    scenario: "full confidence in safe zone [-6, 6]",
+    cases: [
+      { rawInput: 0, error: 0.1, expected: 1 },
+      { rawInput: 5, error: 0.1, expected: 1 },
+      { rawInput: -6, error: 0.1, expected: 1 },
+    ],
+  },
+  {
+    name: "LOGISTIC",
+    scenario: "zero confidence beyond hard saturation",
+    cases: [
+      { rawInput: 11, error: 0.1, expected: 0 },
+      { rawInput: -11, error: -0.1, expected: 0 },
+    ],
+  },
+  {
+    name: "LOGISTIC",
+    scenario: "recovery allows small propagation",
+    cases: [
+      // rawInput < -6 and error > 0 → recovery
+      { rawInput: -8, error: 0.1, expected: 0.2, tolerance: 0.01 },
+      // rawInput > 6 and error < 0 → recovery
+      { rawInput: 8, error: -0.1, expected: 0.2, tolerance: 0.01 },
+    ],
+  },
+  {
+    name: "TANH",
+    scenario: "full confidence in safe zone [-2, 2]",
+    cases: [
+      { rawInput: 0, error: 0.1, expected: 1 },
+      { rawInput: 1.5, error: 0.1, expected: 1 },
+      { rawInput: -2, error: 0.1, expected: 1 },
+    ],
+  },
+  {
+    name: "TANH",
+    scenario: "zero confidence beyond saturation",
+    cases: [
+      { rawInput: 7, error: 0.1, expected: 0 },
+      { rawInput: -7, error: -0.1, expected: 0 },
+    ],
+  },
+  {
+    name: "TANH",
+    scenario: "fade zone between safe and saturation",
+    cases: [
+      // rawInput = 4, between safe (2) and max (6)
+      // fade = 1 - (4 - 2) / (6 - 2) = 0.5
+      { rawInput: 4, error: 0.1, expected: 0.5, tolerance: 0.01 },
+    ],
+  },
+  {
+    name: "HARD_TANH",
+    scenario: "full confidence in linear zone [-0.9, 0.9]",
+    cases: [
+      { rawInput: 0, error: 0.1, expected: 1 },
+      { rawInput: 0.5, error: 0.1, expected: 1 },
+      { rawInput: -0.9, error: 0.1, expected: 1 },
+    ],
+  },
+  {
+    name: "HARD_TANH",
+    scenario: "zero confidence far outside clipping zone",
+    cases: [
+      { rawInput: 2, error: 0.1, expected: 0 },
+      { rawInput: -2, error: -0.1, expected: 0 },
+    ],
+  },
+  {
+    name: "ReLU",
+    scenario: "full confidence when active (x > 0)",
+    cases: [
+      { rawInput: 1, error: 0.1, expected: 1 },
+      { rawInput: 100, error: 0.1, expected: 1 },
+    ],
+  },
+  {
+    name: "ReLU",
+    scenario: "dead zone when x <= 0 and error <= 0",
+    cases: [
+      { rawInput: -1, error: -0.1, expected: 0 },
+      { rawInput: 0, error: -0.1, expected: 0 },
+    ],
+  },
+  {
+    name: "ReLU",
+    scenario: "recovery when x <= 0 and error > 0",
+    cases: [
+      { rawInput: -1, error: 0.1, expected: 1 },
+      { rawInput: 0, error: 0.1, expected: 1 },
+    ],
+  },
+  {
+    name: "ReLU6",
+    scenario: "full confidence in active zone (0, 6)",
+    cases: [
+      { rawInput: 3, error: 0.1, expected: 1 },
+      { rawInput: 0.1, error: 0.1, expected: 1 },
+      { rawInput: 5.9, error: 0.1, expected: 1 },
+    ],
+  },
+  {
+    name: "ReLU6",
+    scenario: "dead zones at both ends",
+    cases: [
+      { rawInput: -1, error: -0.1, expected: 0 },
+      { rawInput: 7, error: 0.1, expected: 0 },
+    ],
+  },
+  {
+    name: "ReLU6",
+    scenario: "recovery from saturation",
+    cases: [
+      // x <= 0 with positive error → recovery
+      { rawInput: -1, error: 0.1, expected: 1 },
+      // x >= 6 with negative error → recovery
+      { rawInput: 7, error: -0.1, expected: 1 },
+    ],
+  },
+  {
+    name: "GAUSSIAN",
+    scenario: "full confidence near zero [-3, 3]",
+    cases: [
+      { rawInput: 0, error: 0.1, expected: 1 },
+      { rawInput: 2, error: 0.1, expected: 1 },
+    ],
+  },
+  {
+    name: "GAUSSIAN",
+    scenario: "zero confidence far from zero with worsening error",
+    cases: [
+      // Raw > 3 and error > 0 → getting worse
+      { rawInput: 5, error: 0.1, expected: 0 },
+      // Raw < -3 and error < 0 → getting worse
+      { rawInput: -5, error: -0.1, expected: 0 },
+    ],
+  },
+  {
+    name: "IDENTITY",
+    scenario: "full confidence for normal inputs",
+    cases: [
+      { rawInput: 0, error: 0.1, expected: 1 },
+      { rawInput: 100, error: 0.1, expected: 1 },
+      { rawInput: -100, error: -0.1, expected: 1 },
+    ],
+  },
+  {
+    name: "IDENTITY",
+    scenario: "zero confidence for extreme input with tiny weight",
+    cases: [
+      { rawInput: 2e6, error: 0.1, weight: 1e-7, expected: 0 },
+      { rawInput: -2e6, error: -0.1, weight: 1e-7, expected: 0 },
+    ],
+  },
+  {
+    name: "STEP",
+    scenario: "high confidence when on wrong side of threshold",
+    cases: [
+      // isAbove = true (rawInput > 0), expectedAbove = false (error < 0) → wrong side
+      { rawInput: 1, error: -0.1, expected: 1 },
+      // isAbove = false, expectedAbove = true → wrong side
+      { rawInput: -1, error: 0.1, expected: 1 },
+    ],
+  },
+  {
+    name: "STEP",
+    scenario: "reduced confidence when on correct side",
+    cases: [
+      { rawInput: 1, error: 0.1, expected: 0.2, tolerance: 0.01 },
+      { rawInput: -1, error: -0.1, expected: 0.2, tolerance: 0.01 },
+    ],
+  },
+  {
+    name: "ABSOLUTE",
+    scenario: "full confidence for most inputs",
+    cases: [
+      { rawInput: 5, error: 0.1, expected: 1 },
+      { rawInput: -5, error: 0.1, expected: 1 },
+    ],
+  },
+  {
+    name: "ABSOLUTE",
+    scenario: "full confidence for near-zero inputs",
+    // Near-zero inputs should still have full confidence — the sign ambiguity
+    // at zero does not warrant suppressing the gradient signal.
+    cases: [
+      { rawInput: 0.5, error: 0.1, expected: 1 },
+      { rawInput: -0.5, error: -0.1, expected: 1 },
+      { rawInput: 0.01, error: 0.1, expected: 1 },
+      { rawInput: 0, error: 0.1, expected: 1 },
+    ],
+  },
+  {
+    name: "ABSOLUTE",
+    scenario: "zero for extreme input with tiny weight",
+    cases: [{ rawInput: 2000, error: 0.1, weight: 1e-4, expected: 0 }],
+  },
+  {
+    name: "Cosine",
+    scenario: "high confidence where slope is strong",
+    // At x = π/2, sin(x) = 1 → strong slope
+    cases: [{ rawInput: Math.PI / 2, error: 0.1, expected: 1 }],
+  },
+  {
+    name: "Cosine",
+    scenario: "zero confidence at flat peaks",
+    // At x = 0, sin(0) = 0 → flat
+    cases: [{ rawInput: 0, error: 0.1, expected: 0 }],
+  },
+  {
+    name: "SINE",
+    scenario: "high confidence where cos is strong",
+    // At x = 0, cos(0) = 1 → strong slope
+    cases: [{ rawInput: 0, error: 0.1, expected: 1 }],
+  },
+  {
+    name: "Exponential",
+    scenario: "full confidence in safe zone [-10, 30]",
+    cases: [
+      { rawInput: 0, error: 0.1, expected: 1 },
+      { rawInput: 20, error: 0.1, expected: 1 },
+      { rawInput: -5, error: 0.1, expected: 1 },
+    ],
+  },
+  {
+    name: "Exponential",
+    scenario: "zero when far outside safe zone and worsening",
+    cases: [
+      // rawInput > 30 and error > 0 → worsening
+      { rawInput: 50, error: 0.1, expected: 0 },
+      // rawInput < -10 and error < 0 → worsening
+      { rawInput: -30, error: -0.1, expected: 0 },
+    ],
+  },
+  {
+    name: "SQUARE",
+    scenario: "full confidence in [-5, 5]",
+    cases: [
+      { rawInput: 0, error: 0.1, expected: 1 },
+      { rawInput: 3, error: 0.1, expected: 1 },
+      { rawInput: -5, error: 0.1, expected: 1 },
+    ],
+  },
+  {
+    name: "SQUARE",
+    scenario: "fade zone between 5 and 10",
+    cases: [
+      // rawInput = 7.5, fade = 1 - (7.5 - 5) / 5 = 0.5
+      { rawInput: 7.5, error: 0.1, expected: 0.5, tolerance: 0.01 },
+    ],
+  },
+  {
+    name: "SQUARE",
+    scenario: "zero confidence beyond 10",
+    cases: [{ rawInput: 11, error: 0.1, expected: 0 }],
+  },
+  {
+    name: "SQUARE",
+    scenario: "recovery zone allows small value",
+    cases: [
+      // rawInput > 5 and error < 0 → recovery
+      { rawInput: 6, error: -0.1, expected: 0.2, tolerance: 0.01 },
+      // rawInput < -5 and error > 0 → recovery
+      { rawInput: -6, error: 0.1, expected: 0.2, tolerance: 0.01 },
+    ],
+  },
+];
+
+for (const scenario of SAFE_ZONE_SCENARIOS) {
+  Deno.test(`${scenario.name}: ${scenario.scenario}`, () => {
+    const activation = findSafeZoneActivation(scenario.name);
+    for (const safeZoneCase of scenario.cases) {
+      assertSafeZoneCase(activation, scenario.name, safeZoneCase);
+    }
+  });
+}

--- a/test/wasm/WasmDerivative.ts
+++ b/test/wasm/WasmDerivative.ts
@@ -5,6 +5,11 @@
  *
  * These tests verify that the WASM derivative() produces the same results
  * as the JS-based derivative() implementations for all 32 standard activation functions.
+ *
+ * The per-activation comparisons are table-driven (Issue #3677): each row names
+ * the activation, its `SquashType`, the JS implementation to compare against,
+ * and any per-activation value set or tolerance. One body runs them all, still
+ * reporting each activation as its own named test.
  */
 
 import { assert } from "@std/assert";
@@ -99,408 +104,136 @@ const testValues = [
   10.0,
 ];
 
-Deno.test({
-  name: "WASM Derivative: Identity",
-  fn() {
-    const jsImpl = new IDENTITY();
-    for (const x of testValues) {
-      const wasmResult = wasmDerivative(SquashType.Identity, x);
-      const jsResult = jsImpl.derivative(x);
-      assertClose(wasmResult, jsResult, `Identity derivative at x=${x}`);
-    }
-  },
-});
+/** JS activation implementations expose a derivative for comparison. */
+type JsDerivative = { derivative(x: number): number };
 
-Deno.test({
-  name: "WASM Derivative: ReLU",
-  fn() {
-    const jsImpl = new ReLU();
-    for (const x of testValues) {
-      const wasmResult = wasmDerivative(SquashType.Relu, x);
-      const jsResult = jsImpl.derivative(x);
-      assertClose(wasmResult, jsResult, `ReLU derivative at x=${x}`);
-    }
-  },
-});
+/** One WASM-vs-JS derivative comparison. */
+type DerivativeCase = {
+  /** Label used in the step name and assertion messages. */
+  readonly name: string;
+  /** WASM squash type under test. */
+  readonly type: SquashType;
+  /** JS implementation the WASM result must match. */
+  readonly js: JsDerivative;
+  /** Values to compare at; defaults to the shared `testValues`. */
+  readonly values?: readonly number[];
+  /** Per-activation tolerance override. */
+  readonly tolerance?: number;
+};
 
-Deno.test({
-  name: "WASM Derivative: ReLU6",
-  fn() {
-    const jsImpl = new ReLU6();
+const DERIVATIVE_CASES: readonly DerivativeCase[] = [
+  { name: "Identity", type: SquashType.Identity, js: new IDENTITY() },
+  { name: "ReLU", type: SquashType.Relu, js: new ReLU() },
+  {
+    name: "ReLU6",
+    type: SquashType.Relu6,
+    js: new ReLU6(),
     // Add values specific to ReLU6 boundary at 6
-    const values = [...testValues, 5.5, 5.9, 6.0, 6.1, 7.0];
-    for (const x of values) {
-      const wasmResult = wasmDerivative(SquashType.Relu6, x);
-      const jsResult = jsImpl.derivative(x);
-      assertClose(wasmResult, jsResult, `ReLU6 derivative at x=${x}`);
-    }
+    values: [...testValues, 5.5, 5.9, 6.0, 6.1, 7.0],
   },
-});
-
-Deno.test({
-  name: "WASM Derivative: LeakyReLU",
-  fn() {
-    const jsImpl = new LeakyReLU();
-    for (const x of testValues) {
-      const wasmResult = wasmDerivative(SquashType.LeakyRelu, x);
-      const jsResult = jsImpl.derivative(x);
-      assertClose(wasmResult, jsResult, `LeakyReLU derivative at x=${x}`);
-    }
-  },
-});
-
-Deno.test({
-  name: "WASM Derivative: SELU",
-  fn() {
-    const jsImpl = new SELU();
-    for (const x of testValues) {
-      const wasmResult = wasmDerivative(SquashType.Selu, x);
-      const jsResult = jsImpl.derivative(x);
-      assertClose(wasmResult, jsResult, `SELU derivative at x=${x}`);
-    }
-  },
-});
-
-Deno.test({
-  name: "WASM Derivative: ELU",
-  fn() {
-    const jsImpl = new ELU();
-    for (const x of testValues) {
-      const wasmResult = wasmDerivative(SquashType.Elu, x);
-      const jsResult = jsImpl.derivative(x);
-      assertClose(wasmResult, jsResult, `ELU derivative at x=${x}`);
-    }
-  },
-});
-
-Deno.test({
-  name: "WASM Derivative: LOGISTIC (Sigmoid)",
-  fn() {
-    const jsImpl = new LOGISTIC();
-    for (const x of testValues) {
-      const wasmResult = wasmDerivative(SquashType.Logistic, x);
-      const jsResult = jsImpl.derivative(x);
-      assertClose(wasmResult, jsResult, `LOGISTIC derivative at x=${x}`);
-    }
-  },
-});
-
-Deno.test({
-  name: "WASM Derivative: TANH",
-  fn() {
-    const jsImpl = new TANH();
-    for (const x of testValues) {
-      const wasmResult = wasmDerivative(SquashType.Tanh, x);
-      const jsResult = jsImpl.derivative(x);
-      assertClose(wasmResult, jsResult, `TANH derivative at x=${x}`);
-    }
-  },
-});
-
-Deno.test({
-  name: "WASM Derivative: HardTanh",
-  fn() {
-    const jsImpl = new HARD_TANH();
+  { name: "LeakyReLU", type: SquashType.LeakyRelu, js: new LeakyReLU() },
+  { name: "SELU", type: SquashType.Selu, js: new SELU() },
+  { name: "ELU", type: SquashType.Elu, js: new ELU() },
+  { name: "LOGISTIC", type: SquashType.Logistic, js: new LOGISTIC() },
+  { name: "TANH", type: SquashType.Tanh, js: new TANH() },
+  {
+    name: "HardTanh",
+    type: SquashType.HardTanh,
+    js: new HARD_TANH(),
     // Add values around the boundaries -1 and 1
-    const values = [...testValues, -1.1, -0.99, 0.99, 1.1];
-    for (const x of values) {
-      const wasmResult = wasmDerivative(SquashType.HardTanh, x);
-      const jsResult = jsImpl.derivative(x);
-      assertClose(wasmResult, jsResult, `HardTanh derivative at x=${x}`);
-    }
+    values: [...testValues, -1.1, -0.99, 0.99, 1.1],
   },
-});
-
-Deno.test({
-  name: "WASM Derivative: Softsign",
-  fn() {
-    const jsImpl = new SOFTSIGN();
-    for (const x of testValues) {
-      const wasmResult = wasmDerivative(SquashType.Softsign, x);
-      const jsResult = jsImpl.derivative(x);
-      assertClose(wasmResult, jsResult, `Softsign derivative at x=${x}`);
-    }
-  },
-});
-
-Deno.test({
-  name: "WASM Derivative: Softplus",
-  fn() {
-    const jsImpl = new Softplus();
-    for (const x of testValues) {
-      const wasmResult = wasmDerivative(SquashType.Softplus, x);
-      const jsResult = jsImpl.derivative(x);
-      assertClose(wasmResult, jsResult, `Softplus derivative at x=${x}`);
-    }
-  },
-});
-
-Deno.test({
-  name: "WASM Derivative: Swish",
-  fn() {
-    const jsImpl = new Swish();
-    for (const x of testValues) {
-      const wasmResult = wasmDerivative(SquashType.Swish, x);
-      const jsResult = jsImpl.derivative(x);
-      assertClose(wasmResult, jsResult, `Swish derivative at x=${x}`);
-    }
-  },
-});
-
-Deno.test({
-  name: "WASM Derivative: Mish",
-  fn() {
-    const jsImpl = new Mish();
+  { name: "Softsign", type: SquashType.Softsign, js: new SOFTSIGN() },
+  { name: "Softplus", type: SquashType.Softplus, js: new Softplus() },
+  { name: "Swish", type: SquashType.Swish, js: new Swish() },
+  {
+    name: "Mish",
+    type: SquashType.Mish,
+    js: new Mish(),
     // Mish has complex derivative, use smaller range to avoid numerical issues
-    const values = [-5.0, -2.0, -1.0, -0.5, 0.0, 0.5, 1.0, 2.0, 5.0];
-    for (const x of values) {
-      const wasmResult = wasmDerivative(SquashType.Mish, x);
-      const jsResult = jsImpl.derivative(x);
-      // Use larger tolerance for Mish due to complex derivative formula
-      assertClose(wasmResult, jsResult, `Mish derivative at x=${x}`, 1e-3);
-    }
+    values: [-5.0, -2.0, -1.0, -0.5, 0.0, 0.5, 1.0, 2.0, 5.0],
+    // Use larger tolerance for Mish due to complex derivative formula
+    tolerance: 1e-3,
   },
-});
-
-Deno.test({
-  name: "WASM Derivative: GELU",
-  fn() {
-    const jsImpl = new GELU();
-    for (const x of testValues) {
-      const wasmResult = wasmDerivative(SquashType.Gelu, x);
-      const jsResult = jsImpl.derivative(x);
-      assertClose(wasmResult, jsResult, `GELU derivative at x=${x}`);
-    }
-  },
-});
-
-Deno.test({
-  name: "WASM Derivative: SINE",
-  fn() {
-    const jsImpl = new SINE();
-    for (const x of testValues) {
-      const wasmResult = wasmDerivative(SquashType.Sine, x);
-      const jsResult = jsImpl.derivative(x);
-      assertClose(wasmResult, jsResult, `SINE derivative at x=${x}`);
-    }
-  },
-});
-
-Deno.test({
-  name: "WASM Derivative: Cosine",
-  fn() {
-    const jsImpl = new Cosine();
-    for (const x of testValues) {
-      const wasmResult = wasmDerivative(SquashType.Cosine, x);
-      const jsResult = jsImpl.derivative(x);
-      assertClose(wasmResult, jsResult, `Cosine derivative at x=${x}`);
-    }
-  },
-});
-
-Deno.test({
-  name: "WASM Derivative: TAN",
-  fn() {
-    const jsImpl = new TAN();
+  { name: "GELU", type: SquashType.Gelu, js: new GELU() },
+  { name: "SINE", type: SquashType.Sine, js: new SINE() },
+  { name: "Cosine", type: SquashType.Cosine, js: new Cosine() },
+  {
+    name: "TAN",
+    type: SquashType.Tan,
+    js: new TAN(),
     // Avoid values near pi/2 where tan is undefined
-    const values = [-1.0, -0.5, 0.0, 0.5, 1.0];
-    for (const x of values) {
-      const wasmResult = wasmDerivative(SquashType.Tan, x);
-      const jsResult = jsImpl.derivative(x);
-      assertClose(wasmResult, jsResult, `TAN derivative at x=${x}`);
-    }
+    values: [-1.0, -0.5, 0.0, 0.5, 1.0],
   },
-});
-
-Deno.test({
-  name: "WASM Derivative: ArcTan",
-  fn() {
-    const jsImpl = new ArcTan();
-    for (const x of testValues) {
-      const wasmResult = wasmDerivative(SquashType.ArcTan, x);
-      const jsResult = jsImpl.derivative(x);
-      assertClose(wasmResult, jsResult, `ArcTan derivative at x=${x}`);
-    }
+  { name: "ArcTan", type: SquashType.ArcTan, js: new ArcTan() },
+  { name: "GAUSSIAN", type: SquashType.Gaussian, js: new GAUSSIAN() },
+  {
+    name: "BentIdentity",
+    type: SquashType.BentIdentity,
+    js: new BENT_IDENTITY(),
   },
-});
-
-Deno.test({
-  name: "WASM Derivative: GAUSSIAN",
-  fn() {
-    const jsImpl = new GAUSSIAN();
-    for (const x of testValues) {
-      const wasmResult = wasmDerivative(SquashType.Gaussian, x);
-      const jsResult = jsImpl.derivative(x);
-      assertClose(wasmResult, jsResult, `GAUSSIAN derivative at x=${x}`);
-    }
+  {
+    name: "BipolarSigmoid",
+    type: SquashType.BipolarSigmoid,
+    js: new BIPOLAR_SIGMOID(),
   },
-});
-
-Deno.test({
-  name: "WASM Derivative: BentIdentity",
-  fn() {
-    const jsImpl = new BENT_IDENTITY();
-    for (const x of testValues) {
-      const wasmResult = wasmDerivative(SquashType.BentIdentity, x);
-      const jsResult = jsImpl.derivative(x);
-      assertClose(wasmResult, jsResult, `BentIdentity derivative at x=${x}`);
-    }
-  },
-});
-
-Deno.test({
-  name: "WASM Derivative: BipolarSigmoid",
-  fn() {
-    const jsImpl = new BIPOLAR_SIGMOID();
-    for (const x of testValues) {
-      const wasmResult = wasmDerivative(SquashType.BipolarSigmoid, x);
-      const jsResult = jsImpl.derivative(x);
-      assertClose(wasmResult, jsResult, `BipolarSigmoid derivative at x=${x}`);
-    }
-  },
-});
-
-Deno.test({
-  name: "WASM Derivative: Bipolar",
-  fn() {
-    const jsImpl = new BIPOLAR();
-    for (const x of testValues) {
-      const wasmResult = wasmDerivative(SquashType.Bipolar, x);
-      const jsResult = jsImpl.derivative(x);
-      assertClose(wasmResult, jsResult, `Bipolar derivative at x=${x}`);
-    }
-  },
-});
-
-Deno.test({
-  name: "WASM Derivative: Step",
-  fn() {
-    const jsImpl = new STEP();
+  { name: "Bipolar", type: SquashType.Bipolar, js: new BIPOLAR() },
+  {
+    name: "Step",
+    type: SquashType.Step,
+    js: new STEP(),
     // Step has a special derivative near 0
-    const values = [-1.0, -0.1, 0.1, 1.0];
-    for (const x of values) {
-      const wasmResult = wasmDerivative(SquashType.Step, x);
-      const jsResult = jsImpl.derivative(x);
-      assertClose(wasmResult, jsResult, `Step derivative at x=${x}`);
-    }
+    values: [-1.0, -0.1, 0.1, 1.0],
   },
-});
-
-Deno.test({
-  name: "WASM Derivative: Complement",
-  fn() {
-    const jsImpl = new COMPLEMENT();
-    for (const x of testValues) {
-      const wasmResult = wasmDerivative(SquashType.Complement, x);
-      const jsResult = jsImpl.derivative(x);
-      assertClose(wasmResult, jsResult, `Complement derivative at x=${x}`);
-    }
-  },
-});
-
-Deno.test({
-  name: "WASM Derivative: Absolute",
-  fn() {
-    const jsImpl = new ABSOLUTE();
-    // Note: derivative at x=0 is undefined, both implementations return 0
-    for (const x of testValues) {
-      const wasmResult = wasmDerivative(SquashType.Absolute, x);
-      const jsResult = jsImpl.derivative(x);
-      assertClose(wasmResult, jsResult, `Absolute derivative at x=${x}`);
-    }
-  },
-});
-
-Deno.test({
-  name: "WASM Derivative: Square",
-  fn() {
-    const jsImpl = new SQUARE();
-    for (const x of testValues) {
-      const wasmResult = wasmDerivative(SquashType.Square, x);
-      const jsResult = jsImpl.derivative(x);
-      assertClose(wasmResult, jsResult, `Square derivative at x=${x}`);
-    }
-  },
-});
-
-Deno.test({
-  name: "WASM Derivative: Cube",
-  fn() {
-    const jsImpl = new Cube();
-    for (const x of testValues) {
-      const wasmResult = wasmDerivative(SquashType.Cube, x);
-      const jsResult = jsImpl.derivative(x);
-      assertClose(wasmResult, jsResult, `Cube derivative at x=${x}`);
-    }
-  },
-});
-
-Deno.test({
-  name: "WASM Derivative: Sqrt",
-  fn() {
-    const jsImpl = new SQRT();
+  { name: "Complement", type: SquashType.Complement, js: new COMPLEMENT() },
+  // Note: derivative at x=0 is undefined, both implementations return 0
+  { name: "Absolute", type: SquashType.Absolute, js: new ABSOLUTE() },
+  { name: "Square", type: SquashType.Square, js: new SQUARE() },
+  { name: "Cube", type: SquashType.Cube, js: new Cube() },
+  {
+    name: "Sqrt",
+    type: SquashType.Sqrt,
+    js: new SQRT(),
     // Only test positive values for sqrt
-    const values = [0.1, 0.5, 1.0, 2.0, 5.0, 10.0];
-    for (const x of values) {
-      const wasmResult = wasmDerivative(SquashType.Sqrt, x);
-      const jsResult = jsImpl.derivative(x);
-      assertClose(wasmResult, jsResult, `Sqrt derivative at x=${x}`);
-    }
-    // Test edge case: x <= 0 should return 0
+    values: [0.1, 0.5, 1.0, 2.0, 5.0, 10.0],
+  },
+  { name: "StdInverse", type: SquashType.StdInverse, js: new StdInverse() },
+  {
+    name: "Exponential",
+    type: SquashType.Exponential,
+    js: new Exponential(),
+    // Limit range to avoid overflow
+    values: [-10.0, -5.0, -2.0, -1.0, 0.0, 1.0, 2.0, 3.0],
+  },
+  { name: "LogSigmoid", type: SquashType.LogSigmoid, js: new LogSigmoid() },
+  { name: "ISRU", type: SquashType.Isru, js: new ISRU() },
+];
+
+for (const derivativeCase of DERIVATIVE_CASES) {
+  Deno.test({
+    name: `WASM Derivative: ${derivativeCase.name}`,
+    fn() {
+      for (const x of derivativeCase.values ?? testValues) {
+        const wasmResult = wasmDerivative(derivativeCase.type, x);
+        const jsResult = derivativeCase.js.derivative(x);
+        assertClose(
+          wasmResult,
+          jsResult,
+          `${derivativeCase.name} derivative at x=${x}`,
+          derivativeCase.tolerance,
+        );
+      }
+    },
+  });
+}
+
+Deno.test({
+  name: "WASM Derivative: Sqrt returns 0 for x <= 0",
+  fn() {
     const zeroResult = wasmDerivative(SquashType.Sqrt, 0.0);
     assertClose(zeroResult, 0.0, "Sqrt derivative at x=0");
     const negResult = wasmDerivative(SquashType.Sqrt, -1.0);
     assertClose(negResult, 0.0, "Sqrt derivative at x=-1");
-  },
-});
-
-Deno.test({
-  name: "WASM Derivative: StdInverse",
-  fn() {
-    const jsImpl = new StdInverse();
-    for (const x of testValues) {
-      const wasmResult = wasmDerivative(SquashType.StdInverse, x);
-      const jsResult = jsImpl.derivative(x);
-      assertClose(wasmResult, jsResult, `StdInverse derivative at x=${x}`);
-    }
-  },
-});
-
-Deno.test({
-  name: "WASM Derivative: Exponential",
-  fn() {
-    const jsImpl = new Exponential();
-    // Limit range to avoid overflow
-    const values = [-10.0, -5.0, -2.0, -1.0, 0.0, 1.0, 2.0, 3.0];
-    for (const x of values) {
-      const wasmResult = wasmDerivative(SquashType.Exponential, x);
-      const jsResult = jsImpl.derivative(x);
-      assertClose(wasmResult, jsResult, `Exponential derivative at x=${x}`);
-    }
-  },
-});
-
-Deno.test({
-  name: "WASM Derivative: LogSigmoid",
-  fn() {
-    const jsImpl = new LogSigmoid();
-    for (const x of testValues) {
-      const wasmResult = wasmDerivative(SquashType.LogSigmoid, x);
-      const jsResult = jsImpl.derivative(x);
-      assertClose(wasmResult, jsResult, `LogSigmoid derivative at x=${x}`);
-    }
-  },
-});
-
-Deno.test({
-  name: "WASM Derivative: ISRU",
-  fn() {
-    const jsImpl = new ISRU();
-    for (const x of testValues) {
-      const wasmResult = wasmDerivative(SquashType.Isru, x);
-      const jsResult = jsImpl.derivative(x);
-      assertClose(wasmResult, jsResult, `ISRU derivative at x=${x}`);
-    }
   },
 });
 
@@ -523,7 +256,7 @@ Deno.test({
 
 // NOTE (Issue #3172): the former "Comprehensive comparison with JS
 // implementations" test was removed as redundant. Every squash type it
-// compared (all 32) already has a dedicated per-function test above running the
-// identical wasmDerivative-vs-jsImpl.derivative assertClose check over an
-// equal-or-wider set of values with the same tolerance, so it exercised no
-// additional derivative code path.
+// compared (all 32) already has a dedicated per-function case in
+// DERIVATIVE_CASES above running the identical wasmDerivative-vs-jsImpl
+// .derivative assertClose check over an equal-or-wider set of values with the
+// same tolerance, so it exercised no additional derivative code path.


### PR DESCRIPTION
# Table-driven the four copy-paste test families (Issue #3677)

## Summary

Four test files each carried a family of near-identical bodies differing only in
one input literal and its expected output. Each family is now one shared body
driven by a reviewable case table, so adding an activation or tightening a
validation message is a table row rather than a hand-copied body. Closes #3677.

| File                                             | Family                                                 | Before    | After             |
| ------------------------------------------------ | ------------------------------------------------------ | --------- | ----------------- |
| `test/methods/activations/EdgeCases.ts`          | `squash(0)`, `squash(large)`, `squash(large_negative)` | 42 bodies | 3 tables + 1 body |
| `test/wasm/WasmDerivative.ts`                    | WASM-vs-JS derivative comparison                       | 32 bodies | 1 table + 1 body  |
| `test/config/MCMCConfig.ts`                      | `createNeatConfig` rejection of invalid `mcmc` values  | 16 bodies | 1 table + 1 body  |
| `test/methods/activations/SafeZoneAdjustment.ts` | `safeZoneAdjustment` boundary scenarios                | 35 bodies | 1 table + 1 body  |

Design decisions worth a reviewer's attention:

- **Registration idiom.** The issue suggested `t.step`, but `deno.json` opts
  into the `no-await-in-loop` lint rule and stepping over a table needs a
  sequential `await` per case. The repo's own established data-driven idiom —
  the generated `Deno.test` loop already present in `EdgeCases.ts` for
  non-finite inputs — gives the same per-case reporting with no lint
  suppression, so each table row registers its own named `Deno.test`.
- **No coverage lost.** Every case literal moved across unchanged. The case
  types keep the distinctions the original bodies carried: exact vs tolerant
  comparison (`tolerance` omitted means `assertEquals`), and strict vs inclusive
  range bounds (`gt`/`gte`/`lt`/`lte`) so the asymptotic `LOGISTIC`/`TANH`
  assertions stay exactly as strict as before.
- **Kept out of the tables.** `StdInverse: squash(0)` (asserts magnitude, not a
  value), the `SQRT` derivative `x <= 0` edge assertions (compare WASM against a
  fixed 0, not against the JS impl), the aggregate-derivative test, and the
  per-activation boundary tests are genuinely one-off, so they stay as
  standalone bodies. Splitting the `SQRT` edge assertions out is why the runtime
  test count goes 150 → 151.
- **Guard lifted.** `SafeZoneAdjustment.ts`'s three-line
  `Activations.find(...)` + `hasSafeZone` preamble is now
  `findSafeZoneActivation(name)`, which fails loud when an activation has no
  safe-zone logic.

```mermaid
flowchart LR
    subgraph Before
        B1[body 1: name/input/expected]
        B2[body 2: name/input/expected]
        B3[...90 bodies]
    end
    subgraph After
        T[CASE TABLE<br/>one row per case] --> R[shared assert body]
        R --> D["Deno.test per row<br/>(named, per-case reporting)"]
    end
    Before -.->|Issue #3677| After
```

## Evidence

Backend/test-only change — no web interface to screenshot. Evidence is the test
run itself: the collapsed files register the same cases as before and the full
quality gate is green.

Per-file run (`deno test --allow-all` over the four files) — 151 tests, all
named per case:

```
ArcTan: squash(0) ≈ 0 … ok
LOGISTIC: squash(0) ≈ 0.5 … ok
LOGISTIC: squash(100) > 0.99 and <= 1 … ok
WASM Derivative: ReLU6 … ok
MCMCConfig - coolingRate must be < 1 … ok
SQUARE: recovery zone allows small value … ok

ok | 151 passed | 0 failed (403ms)
```

Full quality gate (`./quality.sh < /dev/null`) — lint, format, type-check, WASM
sync and the whole suite:

```
ok | 8186 passed (5 steps) | 0 failed | 4 ignored (4m40s)
```

Case-count parity, checked against `git show HEAD:<file>`:

| File                    | Cases before                      | Cases after                       |
| ----------------------- | --------------------------------- | --------------------------------- |
| `EdgeCases.ts`          | 42                                | 42                                |
| `WasmDerivative.ts`     | 32                                | 32                                |
| `MCMCConfig.ts`         | 16                                | 16                                |
| `SafeZoneAdjustment.ts` | 74 assertions across 35 scenarios | 74 assertions across 35 scenarios |

## Test Plan

No new behaviour, so no new assertions — the tests _are_ the change. What was
verified:

- `test/methods/activations/EdgeCases.ts` — `ZERO_CASES` (31 rows),
  `LARGE_POSITIVE_CASES` (6), `LARGE_NEGATIVE_CASES` (5) each register a named
  test; `StdInverse`, the non-finite loop and the five boundary tests unchanged.
- `test/wasm/WasmDerivative.ts` — `DERIVATIVE_CASES` (32 rows) registers one
  named test per activation, preserving each per-activation value set (`ReLU6`,
  `HardTanh`, `Mish`, `TAN`, `Step`, `Sqrt`, `Exponential`) and the `Mish` 1e-3
  tolerance override. WASM initialisation still registers first, so it runs
  before the comparisons.
- `test/config/MCMCConfig.ts` — `MCMC_REJECTION_CASES` (16 rows) covers every
  former `assertThrows`, including the Issue #2201 (`adjustmentRate`,
  `toleranceRate`) and Issue #2527 (`mcmcAdvantageMode`) cases.
- `test/methods/activations/SafeZoneAdjustment.ts` — `SAFE_ZONE_SCENARIOS` (35
  rows, 74 cases) registers one named test per scenario.



## Milestone
This PR is part of the **Scan 20260807** milestone and targets the `milestone/scan-20260807` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-msjlm4ab-d64ae5`<!-- vibe-worker-issue-3677 -->