### PR TITLE
Tests: Drop framework-guarantee assertions, test the real clamps (#3679)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-3679.md
+++ b/docs/archive/pr-summaries/pr-summary-3679.md
@@ -1,0 +1,102 @@
+# Tests asserting language/library guarantees
+
+## Summary
+
+Removed the tests that assert guarantees owned by JavaScript or `@std/assert`
+rather than by this project, and replaced the one case that turned out to have
+real project logic underneath it. Closes #3679.
+
+**Deleted — pure framework/language guarantees (15 tests):**
+
+- `"<Error> - is instanceof Error"` and `"<Error> - can be caught selectively"`
+  across all seven typed error suites (`WasmError`, `TopologyError`,
+  `ValidationError`, `ConfigurationError`, `DatasetError`, `DiscoveryError`,
+  `ActivationError`). `class X extends Error` producing an `instanceof`
+  relationship is JavaScript semantics, and `assertThrows(fn, Ctor)` matching by
+  constructor is `@std/assert`'s own contract — neither can fail for a reason
+  this repo can fix.
+- `"assertNever - exhaustive switch never reaches the guard"`. The switch is
+  written inside the test, so the assertions only confirmed that a local
+  function returns the string literals it was written to return. The
+  exhaustiveness value of `assertNever` is compile-time and needs no runtime
+  test.
+
+**Rewritten — the BloomFilter case had project logic the old test hid:**
+
+The issue described `src/utils/BloomFilter.ts:94` as a bare getter echoing its
+constructor argument. It is not: the constructor clamps
+(`this.bitSize = Math.max(8, size)`, `this.hashCount = Math.max(1, hashCount)`).
+The old `"size getter returns configured size"` test passed `2048` — a value
+above both floors — so it never touched the clamp and would have passed with the
+clamps deleted. It is replaced by two tests that exercise the clamps directly.
+
+**Coverage kept.** Every deleted test's project-side behaviour is still asserted
+by siblings in the same file: each error suite asserts the overridden `name` and
+the `reason`/`path`/`activation` payload via `assertIsError` (e.g.
+`test/errors/WasmError.ts:4-31`), and `test/utils/AssertNever.ts` retains both
+tests that drive the real runtime throw path and its message formatting. The
+`"distinguishable from generic Error"` catch-block tests are untouched — the
+issue did not list them and they assert the `reason` payload after narrowing.
+
+## Evidence
+
+Backend/test-only change — no web interface to screenshot.
+
+**Mutation check.** The two new BloomFilter tests were verified to be sensitive
+to the project code they cover. With the clamps temporarily stripped from
+`src/utils/BloomFilter.ts` (`this.bitSize = size`,
+`this.hashCount = hashCount`):
+
+```text
+BloomFilter - constructor clamps size to the one-byte floor ... FAILED (16ms)
+BloomFilter - constructor clamps hash count to at least one ... FAILED (602µs)
+FAILED | 13 passed | 2 failed (145ms)
+```
+
+The source was restored immediately afterwards (`git diff --stat` on
+`src/utils/BloomFilter.ts` is empty — no production code changed in this PR).
+
+**Full quality gate**, `./quality.sh < /dev/null`:
+
+```text
+ok | 8169 passed (5 steps) | 0 failed | 4 ignored (3m44s)
+```
+
+The decision applied to each finding:
+
+```mermaid
+flowchart TD
+    A[Test flagged as framework-guarantee] --> B{Project logic beneath it?}
+    B -- No --> C[Delete: coverage already sits in sibling tests]
+    B -- Yes --> D[Rewrite to assert that logic]
+    C --> E["7 error suites x 2 tests + AssertNever switch test"]
+    D --> F["BloomFilter size/hashCount constructor clamps"]
+```
+
+## Test Plan
+
+Removed (framework/language guarantees, no project code beneath them):
+
+- `test/errors/WasmError.ts` — `is instanceof Error`,
+  `can be caught selectively`
+- `test/errors/TopologyError.ts` — same two
+- `test/errors/ValidationError.ts` — same two
+- `test/errors/ConfigurationError.ts` — same two
+- `test/errors/DatasetError.ts` — same two
+- `test/errors/DiscoveryError.ts` — same two
+- `test/errors/ActivationError.ts` — same two
+- `test/utils/AssertNever.ts` — `exhaustive switch never reaches the guard`
+- `test/utils/BloomFilter.ts` — `size getter returns configured size`
+
+Added (assert real constructor logic, mutation-verified above):
+
+- `test/utils/BloomFilter.ts` —
+  `BloomFilter - constructor clamps size to the one-byte floor`: sizes `0`, `3`
+  and `-64` all report `size === 8`; `2048` is reported unchanged.
+- `test/utils/BloomFilter.ts` —
+  `BloomFilter - constructor clamps hash count to at least one`: with
+  `hashCount = 0`, an added key is found **and** an unadded key is still
+  rejected — the latter only holds if at least one bit is actually probed.
+
+Unused `assert` / `assertThrows` imports were dropped from the seven error test
+files as a consequence of the deletions.

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -590,6 +590,10 @@
     "evex",
     "extremum",
     "unfloored",
-    "ungated"
+    "ungated",
+    "unadded",
+    "mintable",
+    "tokenlessly",
+    "trojanised"
   ]
 }

--- a/test/errors/ActivationError.ts
+++ b/test/errors/ActivationError.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals, assertIsError, assertThrows } from "@std/assert";
+import { assertEquals, assertIsError } from "@std/assert";
 import {
   ActivationError,
   type ActivationErrorReason,
@@ -42,30 +42,6 @@ Deno.test("ActivationError - UNKNOWN_ACTIVATION reason", () => {
   assertIsError(error, ActivationError);
   assertEquals(error.reason, "UNKNOWN_ACTIVATION");
   assertEquals(error.activation, "FOO");
-});
-
-Deno.test("ActivationError - is instanceof Error", () => {
-  const error = new ActivationError(
-    "test",
-    "NON_FINITE_INPUT",
-    "TANH",
-    Infinity,
-  );
-  assert(error instanceof Error);
-  assert(error instanceof ActivationError);
-});
-
-Deno.test("ActivationError - can be caught selectively", () => {
-  const fn = () => {
-    throw new ActivationError(
-      "non-finite input",
-      "NON_FINITE_INPUT",
-      "Mish",
-      NaN,
-    );
-  };
-
-  assertThrows(fn, ActivationError);
 });
 
 Deno.test("ActivationError - reason is typed", () => {

--- a/test/errors/ConfigurationError.ts
+++ b/test/errors/ConfigurationError.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals, assertIsError, assertThrows } from "@std/assert";
+import { assertEquals, assertIsError } from "@std/assert";
 import {
   ConfigurationError,
   type ConfigurationErrorReason,
@@ -52,20 +52,6 @@ Deno.test("ConfigurationError - CROSS_FIELD_VALIDATION reason", () => {
   );
   assertIsError(error, ConfigurationError);
   assertEquals(error.reason, "CROSS_FIELD_VALIDATION");
-});
-
-Deno.test("ConfigurationError - is instanceof Error", () => {
-  const error = new ConfigurationError("test", "INVALID_TYPE");
-  assert(error instanceof Error);
-  assert(error instanceof ConfigurationError);
-});
-
-Deno.test("ConfigurationError - can be caught selectively", () => {
-  const fn = () => {
-    throw new ConfigurationError("bad config", "OUT_OF_RANGE");
-  };
-
-  assertThrows(fn, ConfigurationError);
 });
 
 Deno.test("ConfigurationError - reason is typed", () => {

--- a/test/errors/DatasetError.ts
+++ b/test/errors/DatasetError.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals, assertIsError, assertThrows } from "@std/assert";
+import { assertEquals, assertIsError } from "@std/assert";
 import { DatasetError, type DatasetErrorReason } from "@errors/DatasetError.ts";
 
 Deno.test("DatasetError - DIRECTORY_MISSING reason", () => {
@@ -36,19 +36,6 @@ Deno.test("DatasetError - NO_DATA_FILES reason", () => {
   );
   assertEquals(error.reason, "NO_DATA_FILES");
   assertEquals(error.path, "/tmp/foo");
-});
-
-Deno.test("DatasetError - is instanceof Error", () => {
-  const error = new DatasetError("test", "FILE_MISSING", "/tmp/x.bin");
-  assert(error instanceof Error);
-  assert(error instanceof DatasetError);
-});
-
-Deno.test("DatasetError - can be caught selectively", () => {
-  const fn = () => {
-    throw new DatasetError("gone", "DIRECTORY_MISSING", "/tmp/gone");
-  };
-  assertThrows(fn, DatasetError);
 });
 
 Deno.test("DatasetError - reason is typed", () => {

--- a/test/errors/DiscoveryError.ts
+++ b/test/errors/DiscoveryError.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals, assertIsError, assertThrows } from "@std/assert";
+import { assertEquals, assertIsError } from "@std/assert";
 import {
   DiscoveryError,
   type DiscoveryErrorReason,
@@ -58,20 +58,6 @@ Deno.test("DiscoveryError - INVALID_CREATURE reason", () => {
   );
   assertIsError(error, DiscoveryError);
   assertEquals(error.reason, "INVALID_CREATURE");
-});
-
-Deno.test("DiscoveryError - is instanceof Error", () => {
-  const error = new DiscoveryError("test", "LIBRARY_NOT_FOUND");
-  assert(error instanceof Error);
-  assert(error instanceof DiscoveryError);
-});
-
-Deno.test("DiscoveryError - can be caught selectively", () => {
-  const fn = () => {
-    throw new DiscoveryError("lib not found", "LIBRARY_NOT_FOUND");
-  };
-
-  assertThrows(fn, DiscoveryError);
 });
 
 Deno.test("DiscoveryError - reason is typed", () => {

--- a/test/errors/TopologyError.ts
+++ b/test/errors/TopologyError.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals, assertIsError, assertThrows } from "@std/assert";
+import { assertEquals, assertIsError } from "@std/assert";
 import {
   TopologyError,
   type TopologyErrorReason,
@@ -85,20 +85,6 @@ Deno.test("TopologyError - EXCESSIVE_ERRORS reason", () => {
   );
   assertIsError(error, TopologyError);
   assertEquals(error.reason, "EXCESSIVE_ERRORS");
-});
-
-Deno.test("TopologyError - is instanceof Error", () => {
-  const error = new TopologyError("test", "INVALID_NEURON_TYPE");
-  assert(error instanceof Error);
-  assert(error instanceof TopologyError);
-});
-
-Deno.test("TopologyError - can be caught selectively", () => {
-  const fn = () => {
-    throw new TopologyError("bad topology", "INVALID_CONNECTION");
-  };
-
-  assertThrows(fn, TopologyError);
 });
 
 Deno.test("TopologyError - reason is typed", () => {

--- a/test/errors/ValidationError.ts
+++ b/test/errors/ValidationError.ts
@@ -4,7 +4,7 @@
  * @module
  */
 
-import { assert, assertEquals, assertIsError, assertThrows } from "@std/assert";
+import { assertEquals, assertIsError } from "@std/assert";
 import {
   ValidationError,
   type ValidationErrorName,
@@ -85,21 +85,6 @@ Deno.test("ValidationError - MEMETIC reason", () => {
   const error = new ValidationError("memetic validation failed", "MEMETIC");
   assertEquals(error.name, "ValidationError");
   assertEquals(error.reason, "MEMETIC");
-});
-
-Deno.test("ValidationError - is instanceof Error", () => {
-  const error = new ValidationError("test", "OTHER");
-  assert(error instanceof Error);
-  assert(error instanceof ValidationError);
-});
-
-Deno.test("ValidationError - can be caught selectively", () => {
-  assertThrows(
-    () => {
-      throw new ValidationError("test error", "OTHER");
-    },
-    ValidationError,
-  );
 });
 
 Deno.test("ValidationError - all reasons are valid", () => {

--- a/test/errors/WasmError.ts
+++ b/test/errors/WasmError.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals, assertIsError, assertThrows } from "@std/assert";
+import { assertEquals, assertIsError } from "@std/assert";
 import { WasmError, type WasmErrorReason } from "@errors/WasmError.ts";
 
 Deno.test("WasmError - COMPILATION_FAILED reason", () => {
@@ -28,20 +28,6 @@ Deno.test("WasmError - MODULE_NOT_LOADED reason", () => {
   );
   assertIsError(error, WasmError);
   assertEquals(error.reason, "MODULE_NOT_LOADED");
-});
-
-Deno.test("WasmError - is instanceof Error", () => {
-  const error = new WasmError("test", "MODULE_NOT_LOADED");
-  assert(error instanceof Error);
-  assert(error instanceof WasmError);
-});
-
-Deno.test("WasmError - can be caught selectively", () => {
-  const fn = () => {
-    throw new WasmError("module not loaded", "MODULE_NOT_LOADED");
-  };
-
-  assertThrows(fn, WasmError);
 });
 
 Deno.test("WasmError - reason is typed", () => {

--- a/test/utils/AssertNever.ts
+++ b/test/utils/AssertNever.ts
@@ -1,4 +1,4 @@
-import { assert, assertStringIncludes, assertThrows } from "@std/assert";
+import { assertStringIncludes, assertThrows } from "@std/assert";
 import { assertNever } from "@utils/assertNever.ts";
 
 Deno.test("assertNever - throws with the offending value embedded", () => {
@@ -12,24 +12,6 @@ Deno.test("assertNever - throws with the offending value embedded", () => {
   assertStringIncludes(err.message, "Unhandled variant");
   assertStringIncludes(err.message, "eighthVariant");
   assertStringIncludes(err.message, "42");
-});
-
-Deno.test("assertNever - exhaustive switch never reaches the guard", () => {
-  type Op = { type: "a" } | { type: "b" };
-
-  function handle(op: Op): string {
-    switch (op.type) {
-      case "a":
-        return "handled-a";
-      case "b":
-        return "handled-b";
-      default:
-        return assertNever(op);
-    }
-  }
-
-  assert(handle({ type: "a" }) === "handled-a");
-  assert(handle({ type: "b" }) === "handled-b");
 });
 
 Deno.test("assertNever - serialises a string-only value safely", () => {

--- a/test/utils/BloomFilter.ts
+++ b/test/utils/BloomFilter.ts
@@ -197,9 +197,40 @@ Deno.test("BloomFilter - handles empty and special strings", () => {
   assert(filter.mayContain(longString), "Long string should work");
 });
 
-Deno.test("BloomFilter - size getter returns configured size", () => {
-  const filter = new BloomFilter(2048, 5);
-  assertEquals(filter.size, 2048, "Size should match configured value");
+Deno.test("BloomFilter - constructor clamps size to the one-byte floor", () => {
+  // The constructor floors the bit array at 8 bits (one byte) so a degenerate
+  // size still allocates storage; the getter reports the clamped value.
+  assertEquals(new BloomFilter(0, 5).size, 8, "Zero size should clamp to 8");
+  assertEquals(
+    new BloomFilter(3, 5).size,
+    8,
+    "Sub-byte size should clamp to 8",
+  );
+  assertEquals(
+    new BloomFilter(-64, 5).size,
+    8,
+    "Negative size should clamp to 8",
+  );
+  assertEquals(
+    new BloomFilter(2048, 5).size,
+    2048,
+    "Size above the floor is reported unchanged",
+  );
+});
+
+Deno.test("BloomFilter - constructor clamps hash count to at least one", () => {
+  // A zero hash count would probe no bits, so every lookup would answer "may
+  // contain" and the filter would be useless; the constructor floors it at 1.
+  const filter = new BloomFilter(1024, 0);
+  filter.add("clamped-hash-count");
+  assert(
+    filter.mayContain("clamped-hash-count"),
+    "Added item must be found even when hash count is clamped",
+  );
+  assertFalse(
+    filter.mayContain("never-added-key"),
+    "Unadded item must still be rejected, so at least one bit is probed",
+  );
 });
 
 Deno.test("BloomFilter - count getter tracks added items", () => {


### PR DESCRIPTION
# Tests asserting language/library guarantees

## Summary

Removed the tests that assert guarantees owned by JavaScript or `@std/assert`
rather than by this project, and replaced the one case that turned out to have
real project logic underneath it. Closes #3679.

**Deleted — pure framework/language guarantees (15 tests):**

- `"<Error> - is instanceof Error"` and `"<Error> - can be caught selectively"`
  across all seven typed error suites (`WasmError`, `TopologyError`,
  `ValidationError`, `ConfigurationError`, `DatasetError`, `DiscoveryError`,
  `ActivationError`). `class X extends Error` producing an `instanceof`
  relationship is JavaScript semantics, and `assertThrows(fn, Ctor)` matching by
  constructor is `@std/assert`'s own contract — neither can fail for a reason
  this repo can fix.
- `"assertNever - exhaustive switch never reaches the guard"`. The switch is
  written inside the test, so the assertions only confirmed that a local
  function returns the string literals it was written to return. The
  exhaustiveness value of `assertNever` is compile-time and needs no runtime
  test.

**Rewritten — the BloomFilter case had project logic the old test hid:**

The issue described `src/utils/BloomFilter.ts:94` as a bare getter echoing its
constructor argument. It is not: the constructor clamps
(`this.bitSize = Math.max(8, size)`, `this.hashCount = Math.max(1, hashCount)`).
The old `"size getter returns configured size"` test passed `2048` — a value
above both floors — so it never touched the clamp and would have passed with the
clamps deleted. It is replaced by two tests that exercise the clamps directly.

**Coverage kept.** Every deleted test's project-side behaviour is still asserted
by siblings in the same file: each error suite asserts the overridden `name` and
the `reason`/`path`/`activation` payload via `assertIsError` (e.g.
`test/errors/WasmError.ts:4-31`), and `test/utils/AssertNever.ts` retains both
tests that drive the real runtime throw path and its message formatting. The
`"distinguishable from generic Error"` catch-block tests are untouched — the
issue did not list them and they assert the `reason` payload after narrowing.

## Evidence

Backend/test-only change — no web interface to screenshot.

**Mutation check.** The two new BloomFilter tests were verified to be sensitive
to the project code they cover. With the clamps temporarily stripped from
`src/utils/BloomFilter.ts` (`this.bitSize = size`,
`this.hashCount = hashCount`):

```text
BloomFilter - constructor clamps size to the one-byte floor ... FAILED (16ms)
BloomFilter - constructor clamps hash count to at least one ... FAILED (602µs)
FAILED | 13 passed | 2 failed (145ms)
```

The source was restored immediately afterwards (`git diff --stat` on
`src/utils/BloomFilter.ts` is empty — no production code changed in this PR).

**Full quality gate**, `./quality.sh < /dev/null`:

```text
ok | 8169 passed (5 steps) | 0 failed | 4 ignored (3m44s)
```

The decision applied to each finding:

```mermaid
flowchart TD
    A[Test flagged as framework-guarantee] --> B{Project logic beneath it?}
    B -- No --> C[Delete: coverage already sits in sibling tests]
    B -- Yes --> D[Rewrite to assert that logic]
    C --> E["7 error suites x 2 tests + AssertNever switch test"]
    D --> F["BloomFilter size/hashCount constructor clamps"]
```

## Test Plan

Removed (framework/language guarantees, no project code beneath them):

- `test/errors/WasmError.ts` — `is instanceof Error`,
  `can be caught selectively`
- `test/errors/TopologyError.ts` — same two
- `test/errors/ValidationError.ts` — same two
- `test/errors/ConfigurationError.ts` — same two
- `test/errors/DatasetError.ts` — same two
- `test/errors/DiscoveryError.ts` — same two
- `test/errors/ActivationError.ts` — same two
- `test/utils/AssertNever.ts` — `exhaustive switch never reaches the guard`
- `test/utils/BloomFilter.ts` — `size getter returns configured size`

Added (assert real constructor logic, mutation-verified above):

- `test/utils/BloomFilter.ts` —
  `BloomFilter - constructor clamps size to the one-byte floor`: sizes `0`, `3`
  and `-64` all report `size === 8`; `2048` is reported unchanged.
- `test/utils/BloomFilter.ts` —
  `BloomFilter - constructor clamps hash count to at least one`: with
  `hashCount = 0`, an added key is found **and** an unadded key is still
  rejected — the latter only holds if at least one bit is actually probed.

Unused `assert` / `assertThrows` imports were dropped from the seven error test
files as a consequence of the deletions.



## Milestone
This PR is part of the **Scan 20260807** milestone and targets the `milestone/scan-20260807` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-msjmxses-ce6803`<!-- vibe-worker-issue-3679 -->