### PR TITLE
Verify the WASM bundle digest at runtime (Issue #3680)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -328,6 +328,19 @@ adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).
   once. As defence in depth, `DiscoverStructure` also asserts its temp directory
   resolves inside its base directory before creating or removing it. **Breaking
   only for callers that persisted a non-UUID creature `uuid`.**
+- **Issue #3680 (CWE-353, missing integrity check):** WASM activation bundle
+  bytes are now verified against a pinned SHA-256 **at runtime**, not only at
+  build time. `deno.json` `neatCore.assetSha256` pins the release _tarball_ and
+  is checked by `build.sh` alone, so bytes read back from the
+  environment-controlled disk cache (`NEAT_AI_WASM_CACHE_DIR` / `XDG_CACHE_HOME`
+  / `$HOME/.cache/neat-ai/wasm`) were instantiated unchecked — anyone able to
+  write there could plant a `<key>.wasm` file that ran on the next start.
+  `./build.sh` now also generates `src/wasm/WasmBundleSha256.ts`, whose
+  `EXPECTED_WASM_BUNDLE_SHA256` constant travels with the published package, and
+  `WasmBundleCache` compares it on both the cache-hit and post-fetch paths: a
+  poisoned cache entry is logged, deleted, and re-fetched, while substituted
+  network bytes are a hard error that is never cached or instantiated. The local
+  (`file:`) build path is unchanged.
 
 ## [5.2.0] - 2026-05-30
 

--- a/build.sh
+++ b/build.sh
@@ -146,6 +146,8 @@ PINNED_ASSET_SHA256="$NEAT_CORE_ASSET_SHA256_DEFAULT"
 
 # Tests may override via NEAT_PKG_DIR to avoid concurrent file-system races.
 DEST_DIR="${NEAT_PKG_DIR:-wasm_activation/pkg}"
+# Runtime-readable digest pin regenerated with the bundle (issue #3680).
+RUNTIME_PIN_FILE="${NEAT_RUNTIME_PIN_FILE:-src/wasm/WasmBundleSha256.ts}"
 required=(
   "wasm_activation.js"
   "wasm_activation_bg.wasm"
@@ -436,6 +438,46 @@ write_content_manifest() {
   fi
   ( cd "$DEST_DIR" && shasum -a 256 "${manifest_files[@]}" ) \
     > "$DEST_DIR/$CONTENT_MANIFEST"
+}
+
+# write_runtime_bundle_pin — regenerate src/wasm/WasmBundleSha256.ts so the
+# WASM bundle digest is readable at *runtime* (issue #3680). deno.json
+# neatCore.assetSha256 pins the release tarball and is only ever checked here
+# at build time; the loader needs the bundle's own digest to verify bytes read
+# back from the environment-controlled disk cache or fetched from JSR.
+write_runtime_bundle_pin() {
+  if ! command -v shasum >/dev/null 2>&1; then
+    echo "ERROR: shasum is required to write the runtime bundle pin" >&2
+    return 1
+  fi
+  local digest
+  digest="$(shasum -a 256 "$DEST_DIR/wasm_activation_bg.wasm" | awk '{print $1}')"
+  if ! [[ "$digest" =~ ^[0-9a-f]{64}$ ]]; then
+    echo "ERROR: could not compute SHA-256 of $DEST_DIR/wasm_activation_bg.wasm" >&2
+    return 1
+  fi
+  mkdir -p "$(dirname "$RUNTIME_PIN_FILE")"
+  cat > "$RUNTIME_PIN_FILE" <<EOF
+/**
+ * GENERATED FILE — do not edit by hand.
+ *
+ * Written by \`./build.sh\` from \`wasm_activation/pkg/wasm_activation_bg.wasm\`
+ * each time the vendored NEAT-AI-core bundle is refreshed, and committed
+ * alongside \`deno.json\` and \`wasm_activation/pkg/**\`.
+ *
+ * Issue #3680: \`deno.json\` \`neatCore.assetSha256\` pins the *release tarball*
+ * and is enforced only at build time, so the runtime had no value to compare
+ * the instantiated bundle against. This constant is part of the module graph —
+ * it travels with the published package and is integrity-checked by Deno's own
+ * JSR/lockfile verification — which makes it the trusted expectation used by
+ * {@link file://./WasmBundleCache.ts} to verify bytes coming from the
+ * environment-controlled disk cache or the network.
+ */
+
+/** Lowercase hex SHA-256 of \`wasm_activation/pkg/wasm_activation_bg.wasm\`. */
+export const EXPECTED_WASM_BUNDLE_SHA256 =
+  "${digest}";
+EOF
 }
 
 # verify_content_manifest — re-hash every file listed in the manifest
@@ -829,6 +871,10 @@ refresh_fingerprint "$TARGET_REV"
 # tarball. Commit content-manifest.sha256 with the rest of pkg/**.
 echo "Writing $DEST_DIR/$CONTENT_MANIFEST..."
 write_content_manifest
+
+# --- Record the runtime-readable bundle digest (issue #3680) -------------
+echo "Writing $RUNTIME_PIN_FILE..."
+write_runtime_bundle_pin
 
 echo ""
 echo "✅ wasm_activation/pkg refreshed to ${NEAT_CORE_REPO}@${TARGET_REV}"

--- a/docs/archive/pr-summaries/pr-summary-3680.md
+++ b/docs/archive/pr-summaries/pr-summary-3680.md
@@ -1,0 +1,92 @@
+# PR Summary — Verify the WASM bundle digest at runtime (Issue #3680)
+
+## Summary
+
+`deno.json` `neatCore.assetSha256` pins the NEAT-AI-core **release tarball** and
+is enforced by `build.sh` only, so at runtime the WASM activation bundle was
+instantiated with no digest check. The disk cache is environment-controlled
+(`NEAT_AI_WASM_CACHE_DIR`, then `XDG_CACHE_HOME`, then
+`$HOME/.cache/neat-ai/wasm`) and keyed by `SHA-256(url)`, so anyone able to
+write there could plant a `<key>.wasm` file that ran unchecked on the next
+start. Closes #3680.
+
+What changed:
+
+- **`build.sh`** gained `write_runtime_bundle_pin`, which regenerates
+  `src/wasm/WasmBundleSha256.ts` from
+  `wasm_activation/pkg/wasm_activation_bg.wasm` whenever the vendored bundle is
+  refreshed. Note this is the **bundle's own** digest — `neatCore.assetSha256`
+  is the tarball hash and cannot be compared against the bundle bytes. The
+  generated constant is part of the module graph, so it travels with the
+  published package and is covered by Deno's JSR/lockfile integrity checks
+  rather than by the mutable cache.
+- **`src/wasm/WasmBundleCache.ts`** verifies `SHA-256(bytes)` against that pin
+  on **both** untrusted paths. A cache hit that does not match is logged at
+  `error`, deleted, and re-fetched; fetched bytes that do not match throw and
+  are never cached or instantiated. An expected digest that is not 64 hex chars
+  fails fast rather than silently disabling verification. The digest is
+  injectable via the new `expectedSha256` option (tests only).
+- The local (`file:`) build path is untouched — those bytes come from the
+  checked-out tree, not a mutable cache.
+
+## Evidence
+
+Backend/CLI change with no web interface, so no screenshot applies. Evidence is
+the test suite plus the quality gate.
+
+```mermaid
+flowchart TD
+    Start[loadWasmBundleBytes] --> Local{file: URL?}
+    Local -- "yes (local build)" --> Read[Read vendored bundle<br/>no cache, no network]
+    Local -- no --> Hit{Cache entry present?}
+    Hit -- yes --> VerifyC{SHA-256 == pin?}
+    VerifyC -- yes --> Serve[Serve cached bytes offline]
+    VerifyC -- "no (poisoned)" --> Purge[Log integrity failure<br/>delete cache entry]
+    Hit -- no --> Fetch[Fetch with bounded backoff]
+    Purge --> Fetch
+    Fetch --> VerifyF{SHA-256 == pin?}
+    VerifyF -- yes --> Persist[Persist to cache] --> Serve
+    VerifyF -- no --> Fail[Throw integrity error<br/>nothing cached, nothing instantiated]
+```
+
+Quality gate:
+
+```text
+$ ./quality.sh < /dev/null
+ok | 8176 passed (5 steps) | 0 failed | 4 ignored (2m20s)
+```
+
+## Test Plan
+
+Added `test/wasm/WasmBundleIntegrity.ts` (six cases, one per acceptance
+criterion):
+
+- `cache hit with matching digest is served offline` — seeded cache, fetch
+  denied; bytes returned with zero network access.
+- `poisoned cache entry is rejected, deleted, and re-fetched` — tampered
+  `<key>.wasm` is not served, exactly one fetch happens, and the cache is
+  repaired with the verified bytes. This is the regression test for the issue:
+  against the unfixed loader the tampered bytes were returned verbatim.
+- `poisoned cache entry is removed even when the re-fetch fails` — the rejected
+  file does not survive to be served by the next start.
+- `fetched bytes with the wrong digest hard-fail` — the load throws, the error
+  names the expected digest, and nothing is written to the cache.
+- `an unusable expected digest fails fast` — a malformed pin is a loud error,
+  not silently-skipped verification.
+- `the runtime pin matches the vendored bundle` — the staleness guard: the
+  generated constant must equal both `SHA-256(wasm_activation_bg.wasm)` and the
+  digest recorded in `wasm_activation/pkg/content-manifest.sha256`, so a core
+  bump that forgets `./build.sh` fails here rather than as a permanent re-fetch
+  loop in production.
+
+Added to `test/scripts/BuildScriptContentHash.ts`:
+
+- `write_runtime_bundle_pin regenerates the runtime digest constant` — sources
+  the real bash function against a temp bundle and asserts the generated file
+  carries that bundle's digest and the exported constant.
+
+Modified (documented, no test removed or disabled): the existing
+`test/wasm/WasmBundleCache.ts` and `test/wasm/WasmInitDiagnostics.ts` fixtures
+seed arbitrary payloads, so each now passes `expectedSha256` computed from its
+own payload. Their assertions are unchanged; the `file:`-URL cases needed no
+change at all.

--- a/docs/troubleshooting/WASM.md
+++ b/docs/troubleshooting/WASM.md
@@ -123,6 +123,48 @@ fires and the worker slot still degrades gracefully; it is now just loud about
 _what_ it was waiting on. The contract is defined in
 `src/wasm/WasmInitDiagnostics.ts`.
 
+### 🔐 Bundle integrity check (Issue #3680)
+
+The disk cache lives in an environment-controlled directory
+(`NEAT_AI_WASM_CACHE_DIR`, else `XDG_CACHE_HOME`, else
+`$HOME/.cache/neat-ai/wasm`), so cached bytes are treated as untrusted. Before
+the bundle is instantiated its SHA-256 is compared with the pin generated into
+`src/wasm/WasmBundleSha256.ts` by `./build.sh` — a constant that travels with
+the published package and is covered by Deno's own JSR/lockfile integrity
+checks.
+
+```mermaid
+flowchart TD
+    Start[loadWasmBundleBytes] --> Local{file: URL?}
+    Local -- "yes (local build)" --> Read[Read vendored bundle<br/>no cache, no network]
+    Local -- no --> Hit{Cache entry present?}
+    Hit -- yes --> VerifyC{SHA-256 == pin?}
+    VerifyC -- yes --> Serve[Serve cached bytes offline]
+    VerifyC -- "no (poisoned)" --> Purge[Log integrity failure<br/>delete cache entry]
+    Hit -- no --> Fetch[Fetch with bounded backoff]
+    Purge --> Fetch
+    Fetch --> VerifyF{SHA-256 == pin?}
+    VerifyF -- yes --> Persist[Persist to cache] --> Serve
+    VerifyF -- no --> Fail[Throw integrity error<br/>nothing cached, nothing instantiated]
+```
+
+**Symptoms:** a startup error, or an error-level log line containing
+`WASM bundle integrity check failed`.
+
+**Solutions:**
+
+- On a **cached** bundle the entry is deleted and re-fetched automatically; the
+  log line names the cache path, so check who can write to that directory.
+- On a **fetched** bundle the load fails loud and nothing is cached — the bytes
+  served for the pinned version are not the published ones.
+- After bumping the NEAT-AI-core pin, run `./build.sh` so the runtime pin is
+  regenerated with `wasm_activation/pkg/**` and `deno.json`. A stale pin is
+  caught by `test/wasm/WasmBundleIntegrity.ts` rather than by a permanent
+  re-fetch loop in production.
+
+The local (`file:`) build path is unaffected: those bytes come from the
+checked-out tree, not a mutable cache.
+
 ## 🌐 JSR-hosted NEAT-AI in your own workers (Issue #2545)
 
 **Symptoms:**

--- a/src/wasm/WasmBundleCache.ts
+++ b/src/wasm/WasmBundleCache.ts
@@ -23,11 +23,19 @@
  * Fail-loud (Issue #3234): if the bytes genuinely cannot be obtained, the last
  * error is thrown so the caller (`initWasmActivation`) records it and the
  * existing "requires the NEAT-AI-core WASM bundle" guard still surfaces.
+ *
+ * Integrity (Issue #3680): the cache directory is environment-controlled, so
+ * cached bytes are untrusted. Every byte array returned from the cache or the
+ * network is checked against the generated
+ * {@link EXPECTED_WASM_BUNDLE_SHA256} pin before it can be instantiated — a
+ * poisoned cache entry is deleted and re-fetched, and substituted network bytes
+ * are a hard error.
  */
 
 import { dirname, fromFileUrl, join } from "@std/path";
 import { getLogger } from "@utils/Logger.ts";
 import type { WasmBundleLoadDiagnostics } from "@wasm/WasmInitDiagnostics.ts";
+import { EXPECTED_WASM_BUNDLE_SHA256 } from "@wasm/WasmBundleSha256.ts";
 
 /** Options for {@link loadWasmBundleBytes}; all are injectable for testing. */
 export interface LoadWasmBundleOptions {
@@ -55,6 +63,12 @@ export interface LoadWasmBundleOptions {
    * without real timing (Issue #3494).
    */
   now?: () => number;
+  /**
+   * Lowercase hex SHA-256 the bundle bytes must match before they are returned
+   * (Issue #3680). Defaults to the generated {@link EXPECTED_WASM_BUNDLE_SHA256}
+   * pin; injectable so tests can verify against their own fixture bytes.
+   */
+  expectedSha256?: string;
 }
 
 /** Bytes plus the phase-timing diagnostics for a single bundle load. */
@@ -186,6 +200,44 @@ async function writeCache(path: string, bytes: Uint8Array): Promise<void> {
   }
 }
 
+/** Delete a rejected cache entry so the poisoned bytes cannot be served again. */
+async function removeCache(path: string): Promise<void> {
+  try {
+    await Deno.remove(path);
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) {
+      return;
+    }
+    // Not fatal — the caller re-fetches and overwrites — but never silent.
+    getLogger().warn(
+      `WASM bundle integrity: could not delete rejected cache entry ${path}:`,
+      error,
+    );
+  }
+}
+
+/** Lowercase hex SHA-256 of the given bytes. */
+async function sha256Hex(bytes: Uint8Array): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", bytes as BufferSource);
+  return toHex(new Uint8Array(digest));
+}
+
+/**
+ * Resolve the digest the bundle must match, failing fast when it is unusable —
+ * an absent or malformed expectation would silently disable verification.
+ */
+function resolveExpectedSha256(override?: string): string {
+  const expected = (override ?? EXPECTED_WASM_BUNDLE_SHA256).toLowerCase();
+  if (!/^[0-9a-f]{64}$/.test(expected)) {
+    throw new Error(
+      `WASM bundle expected SHA-256 is not a 64-character hex digest: ` +
+        `"${expected}". The pin in src/wasm/WasmBundleSha256.ts is generated ` +
+        `by ./build.sh — regenerate it rather than skipping verification.`,
+    );
+  }
+  return expected;
+}
+
 /** Fetch the bundle bytes with bounded exponential backoff. Fails loud. */
 async function fetchWithRetry(
   wasmUrl: URL,
@@ -276,6 +328,8 @@ export async function loadWasmBundleBytesWithDiagnostics(
     };
   }
 
+  // Remote bytes (cache or network) are untrusted until they match the pin.
+  const expectedSha256 = resolveExpectedSha256(options.expectedSha256);
   const fetchFn = options.fetchFn ?? fetch;
   const sleepFn = options.sleepFn ?? defaultSleep;
   const maxAttempts = Math.max(1, options.maxAttempts ?? DEFAULT_MAX_ATTEMPTS);
@@ -292,24 +346,35 @@ export async function loadWasmBundleBytesWithDiagnostics(
     ? null
     : await wasmCacheFilePath(wasmUrl, cacheDir);
 
-  // Cache hit: return the immutable bundle with no network access.
+  // Cache hit: return the immutable bundle with no network access — but only
+  // once its digest matches the pin (Issue #3680). The cache directory is
+  // environment-controlled, so a hit is a claim, not a guarantee.
   if (cachePath !== null) {
     const cached = await readCache(cachePath);
     if (cached !== null) {
-      return {
-        bytes: cached,
-        diagnostics: {
-          outcome: "hit",
-          cacheDir,
-          byteLength: cached.byteLength,
-          elapsedMs: now() - start,
-        },
-      };
+      const actual = await sha256Hex(cached);
+      if (actual === expectedSha256) {
+        return {
+          bytes: cached,
+          diagnostics: {
+            outcome: "hit",
+            cacheDir,
+            byteLength: cached.byteLength,
+            elapsedMs: now() - start,
+          },
+        };
+      }
+      getLogger().error(
+        `WASM bundle integrity check failed for cached bundle ${cachePath}: ` +
+          `SHA-256 ${actual} does not match the expected ${expectedSha256}. ` +
+          `Deleting the rejected cache entry and re-fetching ${wasmUrl.href}.`,
+      );
+      await removeCache(cachePath);
     }
   }
 
-  // Cache miss (or disabled): fetch with backoff, then persist when caching is
-  // enabled so the next start is offline.
+  // Cache miss, or a rejected entry: fetch with backoff, verify, then persist
+  // when caching is enabled so the next start is offline.
   const bytes = await fetchWithRetry(
     wasmUrl,
     fetchFn,
@@ -317,6 +382,15 @@ export async function loadWasmBundleBytesWithDiagnostics(
     maxAttempts,
     baseDelayMs,
   );
+  const fetchedSha256 = await sha256Hex(bytes);
+  if (fetchedSha256 !== expectedSha256) {
+    // Nothing is cached and nothing is returned: substituted bytes must never
+    // reach `WebAssembly.instantiate`.
+    throw new Error(
+      `WASM bundle integrity check failed for ${wasmUrl.href}: SHA-256 ` +
+        `${fetchedSha256} does not match the expected ${expectedSha256}`,
+    );
+  }
   if (cachePath !== null) {
     await writeCache(cachePath, bytes);
   }

--- a/src/wasm/WasmBundleSha256.ts
+++ b/src/wasm/WasmBundleSha256.ts
@@ -1,0 +1,19 @@
+/**
+ * GENERATED FILE — do not edit by hand.
+ *
+ * Written by `./build.sh` from `wasm_activation/pkg/wasm_activation_bg.wasm`
+ * each time the vendored NEAT-AI-core bundle is refreshed, and committed
+ * alongside `deno.json` and `wasm_activation/pkg/**`.
+ *
+ * Issue #3680: `deno.json` `neatCore.assetSha256` pins the *release tarball*
+ * and is enforced only at build time, so the runtime had no value to compare
+ * the instantiated bundle against. This constant is part of the module graph —
+ * it travels with the published package and is integrity-checked by Deno's own
+ * JSR/lockfile verification — which makes it the trusted expectation used by
+ * {@link file://./WasmBundleCache.ts} to verify bytes coming from the
+ * environment-controlled disk cache or the network.
+ */
+
+/** Lowercase hex SHA-256 of `wasm_activation/pkg/wasm_activation_bg.wasm`. */
+export const EXPECTED_WASM_BUNDLE_SHA256 =
+  "ae0726be3ed4882f7c13ca5be3cf3fd19342b99f1b55c0b969b44201f0bab813";

--- a/test/scripts/BuildScriptContentHash.ts
+++ b/test/scripts/BuildScriptContentHash.ts
@@ -538,3 +538,47 @@ Deno.test({
     );
   },
 });
+
+Deno.test({
+  name:
+    "write_runtime_bundle_pin regenerates the runtime digest constant (issue #3680)",
+  permissions: { run: true, read: true, write: true },
+  fn: async () => {
+    const tmpDir = await Deno.makeTempDir({ prefix: "neat-runtime-pin-" });
+    try {
+      const pkgDir = `${tmpDir}/pkg`;
+      await Deno.mkdir(pkgDir, { recursive: true });
+      const bundle = new Uint8Array([0, 97, 115, 109, 1, 0, 0, 0]);
+      await Deno.writeFile(`${pkgDir}/wasm_activation_bg.wasm`, bundle);
+      const pinFile = `${tmpDir}/WasmBundleSha256.ts`;
+
+      const run = await runSourcedFn(
+        "write_runtime_bundle_pin",
+        `DEST_DIR='${pkgDir}' RUNTIME_PIN_FILE='${pinFile}' write_runtime_bundle_pin`,
+      );
+      assertEquals(
+        run.code,
+        0,
+        `write_runtime_bundle_pin must succeed; ${run.stderr}`,
+      );
+
+      const digest = Array.from(
+        new Uint8Array(
+          await crypto.subtle.digest("SHA-256", bundle as BufferSource),
+        ),
+      ).map((b) => b.toString(16).padStart(2, "0")).join("");
+
+      const generated = await Deno.readTextFile(pinFile);
+      assert(
+        generated.includes(`"${digest}"`),
+        `generated pin must carry the bundle digest ${digest}; got ${generated}`,
+      );
+      assert(
+        generated.includes("export const EXPECTED_WASM_BUNDLE_SHA256"),
+        "generated pin must export the runtime constant",
+      );
+    } finally {
+      await Deno.remove(tmpDir, { recursive: true });
+    }
+  },
+});

--- a/test/wasm/WasmBundleCache.ts
+++ b/test/wasm/WasmBundleCache.ts
@@ -9,6 +9,10 @@
  *      `TypeError: fetch failed`, backoff retry succeeds, cache is written;
  *   3. cache miss + exhausted retries — all attempts fail, bounded attempts,
  *      the fetch error surfaces (fail-loud, preserved by `requireWasm`).
+ *
+ * Issue #3680 added runtime digest verification, so each fixture declares the
+ * digest of its own payload via `expectedSha256`; the integrity behaviour
+ * itself is covered in `WasmBundleIntegrity.ts`.
  */
 
 import { assert, assertEquals, assertRejects } from "@std/assert";
@@ -33,6 +37,14 @@ function bytesResponse(bytes: Uint8Array): Response {
   return new Response(bytes as unknown as BodyInit, { status: 200 });
 }
 
+/** Lowercase hex SHA-256 of the given bytes — the loader's expected pin. */
+async function sha256Hex(bytes: Uint8Array): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", bytes as BufferSource);
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
 /** No-op sleep so backoff adds no real delay in tests. */
 const noSleep = (_ms: number): Promise<void> => Promise.resolve();
 
@@ -47,6 +59,7 @@ Deno.test("WasmBundleCache: cache hit loads offline with no network", async () =
       cacheDir,
       fetchFn: denyFetch(),
       sleepFn: noSleep,
+      expectedSha256: await sha256Hex(seeded),
     });
 
     assertEquals(bytes, seeded, "cached bytes should be returned verbatim");
@@ -80,6 +93,7 @@ Deno.test("WasmBundleCache: cache miss retries with backoff then succeeds and ca
       },
       maxAttempts: 5,
       baseDelayMs: 10,
+      expectedSha256: await sha256Hex(payload),
     });
 
     assertEquals(bytes, payload, "retried fetch should return the payload");

--- a/test/wasm/WasmBundleIntegrity.ts
+++ b/test/wasm/WasmBundleIntegrity.ts
@@ -1,0 +1,224 @@
+/**
+ * Issue #3680 — Runtime SHA-256 verification of the WASM activation bundle.
+ *
+ * The cache directory is environment-controlled
+ * (`NEAT_AI_WASM_CACHE_DIR` / `XDG_CACHE_HOME` / `$HOME/.cache/neat-ai/wasm`),
+ * so anyone able to write there could previously plant a `<key>.wasm` file that
+ * was instantiated unchecked. These tests pin the verification contract:
+ *
+ *   1. a cache hit whose bytes match the pinned digest is served offline;
+ *   2. a poisoned cache entry is rejected, deleted, and re-fetched;
+ *   3. fetched bytes that do not match the pin hard-fail (nothing cached);
+ *   4. the runtime-visible pin still describes the vendored bundle, so a core
+ *      bump that forgets to regenerate it is caught here rather than as a
+ *      permanent re-fetch loop in production.
+ */
+
+import { assert, assertEquals, assertRejects } from "@std/assert";
+import {
+  loadWasmBundleBytes,
+  wasmCacheFilePath,
+} from "@wasm/WasmBundleCache.ts";
+import { EXPECTED_WASM_BUNDLE_SHA256 } from "@wasm/WasmBundleSha256.ts";
+
+const BUNDLE_URL = new URL(
+  "https://jsr.io/@stsoftware/neat-ai/9.9.9/wasm_activation/pkg/wasm_activation_bg.wasm",
+);
+
+const noSleep = (_ms: number): Promise<void> => Promise.resolve();
+
+/** Lowercase hex SHA-256 of the given bytes — the value the loader compares. */
+async function sha256Hex(bytes: Uint8Array): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", bytes as BufferSource);
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+/** A fetch that fails the test if it is ever called. */
+function denyFetch(): typeof fetch {
+  return (() => {
+    throw new Error("network access attempted on a verified cache hit");
+  }) as unknown as typeof fetch;
+}
+
+/** A Response carrying the given bytes. */
+function bytesResponse(bytes: Uint8Array): Response {
+  return new Response(bytes as unknown as BodyInit, { status: 200 });
+}
+
+Deno.test("WasmBundleIntegrity: cache hit with matching digest is served offline", async () => {
+  const cacheDir = await Deno.makeTempDir();
+  try {
+    const genuine = new Uint8Array([0, 97, 115, 109, 1, 0, 0, 0]);
+    const cachePath = await wasmCacheFilePath(BUNDLE_URL, cacheDir);
+    await Deno.writeFile(cachePath, genuine);
+
+    const bytes = await loadWasmBundleBytes(BUNDLE_URL, {
+      cacheDir,
+      fetchFn: denyFetch(),
+      sleepFn: noSleep,
+      expectedSha256: await sha256Hex(genuine),
+    });
+
+    assertEquals(bytes, genuine, "verified cached bytes should be returned");
+  } finally {
+    await Deno.remove(cacheDir, { recursive: true });
+  }
+});
+
+Deno.test("WasmBundleIntegrity: poisoned cache entry is rejected, deleted, and re-fetched", async () => {
+  const cacheDir = await Deno.makeTempDir();
+  try {
+    const genuine = new Uint8Array([0, 97, 115, 109, 1, 0, 0, 0]);
+    const poisoned = new Uint8Array([0, 97, 115, 109, 9, 9, 9, 9]);
+    const cachePath = await wasmCacheFilePath(BUNDLE_URL, cacheDir);
+    await Deno.writeFile(cachePath, poisoned);
+
+    let fetches = 0;
+    const fetchFn = ((_url: URL) => {
+      fetches++;
+      return Promise.resolve(bytesResponse(genuine));
+    }) as unknown as typeof fetch;
+
+    const bytes = await loadWasmBundleBytes(BUNDLE_URL, {
+      cacheDir,
+      fetchFn,
+      sleepFn: noSleep,
+      expectedSha256: await sha256Hex(genuine),
+    });
+
+    assertEquals(bytes, genuine, "the tampered bytes must not be served");
+    assertEquals(fetches, 1, "a rejected cache entry forces a fresh fetch");
+
+    // The poisoned entry is replaced by the verified bundle, so the next start
+    // is offline again rather than re-serving the tampered file.
+    const persisted = await Deno.readFile(cachePath);
+    assertEquals(persisted, genuine, "cache is repaired with verified bytes");
+  } finally {
+    await Deno.remove(cacheDir, { recursive: true });
+  }
+});
+
+Deno.test("WasmBundleIntegrity: poisoned cache entry is removed even when the re-fetch fails", async () => {
+  const cacheDir = await Deno.makeTempDir();
+  try {
+    const genuine = new Uint8Array([0, 97, 115, 109, 1, 0, 0, 0]);
+    const poisoned = new Uint8Array([0, 97, 115, 109, 9, 9, 9, 9]);
+    const cachePath = await wasmCacheFilePath(BUNDLE_URL, cacheDir);
+    await Deno.writeFile(cachePath, poisoned);
+
+    const fetchFn = ((_url: URL) =>
+      Promise.reject(new TypeError("fetch failed"))) as unknown as typeof fetch;
+    const expected = await sha256Hex(genuine);
+
+    await assertRejects(
+      () =>
+        loadWasmBundleBytes(BUNDLE_URL, {
+          cacheDir,
+          fetchFn,
+          sleepFn: noSleep,
+          maxAttempts: 2,
+          baseDelayMs: 1,
+          expectedSha256: expected,
+        }),
+      Error,
+      "could not be fetched",
+    );
+
+    await assertRejects(
+      () =>
+        Deno.readFile(cachePath),
+      Deno.errors.NotFound,
+      undefined,
+      "the poisoned cache entry must not survive the failed re-fetch",
+    );
+  } finally {
+    await Deno.remove(cacheDir, { recursive: true });
+  }
+});
+
+Deno.test("WasmBundleIntegrity: fetched bytes with the wrong digest hard-fail", async () => {
+  const cacheDir = await Deno.makeTempDir();
+  try {
+    const genuine = new Uint8Array([0, 97, 115, 109, 1, 0, 0, 0]);
+    const substituted = new Uint8Array([0, 97, 115, 109, 4, 4, 4, 4]);
+    const expected = await sha256Hex(genuine);
+
+    const fetchFn = ((_url: URL) =>
+      Promise.resolve(bytesResponse(substituted))) as unknown as typeof fetch;
+
+    const error = await assertRejects(
+      () =>
+        loadWasmBundleBytes(BUNDLE_URL, {
+          cacheDir,
+          fetchFn,
+          sleepFn: noSleep,
+          expectedSha256: expected,
+        }),
+      Error,
+      "integrity check failed",
+    );
+    assert(
+      error.message.includes(expected),
+      "the error names the expected digest for operators",
+    );
+
+    // Substituted bytes are never persisted for the next start to trust.
+    const cachePath = await wasmCacheFilePath(BUNDLE_URL, cacheDir);
+    await assertRejects(() =>
+      Deno.readFile(cachePath), Deno.errors.NotFound);
+  } finally {
+    await Deno.remove(cacheDir, { recursive: true });
+  }
+});
+
+Deno.test("WasmBundleIntegrity: an unusable expected digest fails fast", async () => {
+  const cacheDir = await Deno.makeTempDir();
+  try {
+    await assertRejects(
+      () =>
+        loadWasmBundleBytes(BUNDLE_URL, {
+          cacheDir,
+          fetchFn: denyFetch(),
+          sleepFn: noSleep,
+          expectedSha256: "not-a-digest",
+        }),
+      Error,
+      "expected SHA-256",
+    );
+  } finally {
+    await Deno.remove(cacheDir, { recursive: true });
+  }
+});
+
+Deno.test("WasmBundleIntegrity: the runtime pin matches the vendored bundle", async () => {
+  const bundlePath = new URL(
+    "../../wasm_activation/pkg/wasm_activation_bg.wasm",
+    import.meta.url,
+  );
+  const actual = await sha256Hex(await Deno.readFile(bundlePath));
+  assertEquals(
+    EXPECTED_WASM_BUNDLE_SHA256,
+    actual,
+    "regenerate src/wasm/WasmBundleSha256.ts (run ./build.sh) after a core bump",
+  );
+
+  // The same digest is recorded in the build-time content manifest, so the
+  // runtime pin cannot drift from the artefact build.sh verifies.
+  const manifest = await Deno.readTextFile(
+    new URL(
+      "../../wasm_activation/pkg/content-manifest.sha256",
+      import.meta.url,
+    ),
+  );
+  const line = manifest.split("\n").find((l) =>
+    l.trim().endsWith("wasm_activation_bg.wasm")
+  );
+  assert(line !== undefined, "content manifest must cover the WASM bundle");
+  assertEquals(
+    line.trim().split(/\s+/)[0],
+    EXPECTED_WASM_BUNDLE_SHA256,
+    "runtime pin and content manifest must agree",
+  );
+});

--- a/test/wasm/WasmInitDiagnostics.ts
+++ b/test/wasm/WasmInitDiagnostics.ts
@@ -33,6 +33,18 @@ const BUNDLE_URL = new URL(
   "https://jsr.io/@stsoftware/neat-ai/9.9.9/wasm_activation/pkg/wasm_activation_bg.wasm",
 );
 
+/**
+ * Lowercase hex SHA-256 of the given bytes. Issue #3680 made the loader verify
+ * every remote/cached bundle against a pinned digest, so these fixtures declare
+ * the digest of their own payload.
+ */
+async function sha256Hex(bytes: Uint8Array): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", bytes as BufferSource);
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
 /** A monotonic clock returning a fixed sequence of values (deterministic ms). */
 function fakeClock(values: number[]): () => number {
   let i = 0;
@@ -67,6 +79,7 @@ Deno.test("WasmInitDiagnostics: cache hit reports outcome/dir/bytes/elapsed", as
         fetchFn: denyFetch(),
         sleepFn: noSleep,
         now: fakeClock([100, 103]),
+        expectedSha256: await sha256Hex(seeded),
       },
     );
 
@@ -90,7 +103,13 @@ Deno.test("WasmInitDiagnostics: cache miss fetches, persists, reports miss", asy
 
     const { bytes, diagnostics } = await loadWasmBundleBytesWithDiagnostics(
       BUNDLE_URL,
-      { cacheDir, fetchFn, sleepFn: noSleep, now: fakeClock([0, 42]) },
+      {
+        cacheDir,
+        fetchFn,
+        sleepFn: noSleep,
+        now: fakeClock([0, 42]),
+        expectedSha256: await sha256Hex(payload),
+      },
     );
 
     assertEquals(bytes, payload);
@@ -120,7 +139,13 @@ Deno.test("WasmInitDiagnostics: caching disabled fetches and reports a reason", 
   const { bytes, diagnostics } = await loadWasmBundleBytesWithDiagnostics(
     BUNDLE_URL,
     // cacheDir: null forces the disabled branch deterministically.
-    { cacheDir: null, fetchFn, sleepFn: noSleep, now: fakeClock([0, 7]) },
+    {
+      cacheDir: null,
+      fetchFn,
+      sleepFn: noSleep,
+      now: fakeClock([0, 7]),
+      expectedSha256: await sha256Hex(payload),
+    },
   );
 
   assertEquals(bytes, payload);


### PR DESCRIPTION
# PR Summary — Verify the WASM bundle digest at runtime (Issue #3680)

## Summary

`deno.json` `neatCore.assetSha256` pins the NEAT-AI-core **release tarball** and
is enforced by `build.sh` only, so at runtime the WASM activation bundle was
instantiated with no digest check. The disk cache is environment-controlled
(`NEAT_AI_WASM_CACHE_DIR`, then `XDG_CACHE_HOME`, then
`$HOME/.cache/neat-ai/wasm`) and keyed by `SHA-256(url)`, so anyone able to
write there could plant a `<key>.wasm` file that ran unchecked on the next
start. Closes #3680.

What changed:

- **`build.sh`** gained `write_runtime_bundle_pin`, which regenerates
  `src/wasm/WasmBundleSha256.ts` from
  `wasm_activation/pkg/wasm_activation_bg.wasm` whenever the vendored bundle is
  refreshed. Note this is the **bundle's own** digest — `neatCore.assetSha256`
  is the tarball hash and cannot be compared against the bundle bytes. The
  generated constant is part of the module graph, so it travels with the
  published package and is covered by Deno's JSR/lockfile integrity checks
  rather than by the mutable cache.
- **`src/wasm/WasmBundleCache.ts`** verifies `SHA-256(bytes)` against that pin
  on **both** untrusted paths. A cache hit that does not match is logged at
  `error`, deleted, and re-fetched; fetched bytes that do not match throw and
  are never cached or instantiated. An expected digest that is not 64 hex chars
  fails fast rather than silently disabling verification. The digest is
  injectable via the new `expectedSha256` option (tests only).
- The local (`file:`) build path is untouched — those bytes come from the
  checked-out tree, not a mutable cache.

## Evidence

Backend/CLI change with no web interface, so no screenshot applies. Evidence is
the test suite plus the quality gate.

```mermaid
flowchart TD
    Start[loadWasmBundleBytes] --> Local{file: URL?}
    Local -- "yes (local build)" --> Read[Read vendored bundle<br/>no cache, no network]
    Local -- no --> Hit{Cache entry present?}
    Hit -- yes --> VerifyC{SHA-256 == pin?}
    VerifyC -- yes --> Serve[Serve cached bytes offline]
    VerifyC -- "no (poisoned)" --> Purge[Log integrity failure<br/>delete cache entry]
    Hit -- no --> Fetch[Fetch with bounded backoff]
    Purge --> Fetch
    Fetch --> VerifyF{SHA-256 == pin?}
    VerifyF -- yes --> Persist[Persist to cache] --> Serve
    VerifyF -- no --> Fail[Throw integrity error<br/>nothing cached, nothing instantiated]
```

Quality gate:

```text
$ ./quality.sh < /dev/null
ok | 8176 passed (5 steps) | 0 failed | 4 ignored (2m20s)
```

## Test Plan

Added `test/wasm/WasmBundleIntegrity.ts` (six cases, one per acceptance
criterion):

- `cache hit with matching digest is served offline` — seeded cache, fetch
  denied; bytes returned with zero network access.
- `poisoned cache entry is rejected, deleted, and re-fetched` — tampered
  `<key>.wasm` is not served, exactly one fetch happens, and the cache is
  repaired with the verified bytes. This is the regression test for the issue:
  against the unfixed loader the tampered bytes were returned verbatim.
- `poisoned cache entry is removed even when the re-fetch fails` — the rejected
  file does not survive to be served by the next start.
- `fetched bytes with the wrong digest hard-fail` — the load throws, the error
  names the expected digest, and nothing is written to the cache.
- `an unusable expected digest fails fast` — a malformed pin is a loud error,
  not silently-skipped verification.
- `the runtime pin matches the vendored bundle` — the staleness guard: the
  generated constant must equal both `SHA-256(wasm_activation_bg.wasm)` and the
  digest recorded in `wasm_activation/pkg/content-manifest.sha256`, so a core
  bump that forgets `./build.sh` fails here rather than as a permanent re-fetch
  loop in production.

Added to `test/scripts/BuildScriptContentHash.ts`:

- `write_runtime_bundle_pin regenerates the runtime digest constant` — sources
  the real bash function against a temp bundle and asserts the generated file
  carries that bundle's digest and the exported constant.

Modified (documented, no test removed or disabled): the existing
`test/wasm/WasmBundleCache.ts` and `test/wasm/WasmInitDiagnostics.ts` fixtures
seed arbitrary payloads, so each now passes `expectedSha256` computed from its
own payload. Their assertions are unchanged; the `file:`-URL cases needed no
change at all.



## Milestone
This PR is part of the **Scan 20260807** milestone and targets the `milestone/scan-20260807` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-msjskjfg-985155`<!-- vibe-worker-issue-3680 -->