### PR TITLE
🟡 PR-authored `scripts/merge_junit.ts` runs with unrestricted `--allow-write` before `CODECOV_TOKEN` in the same job (.github/workflows/coverage.yaml:320) (Issue #3681)

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -317,7 +317,13 @@ jobs:
             echo "No shard JUnit reports found"
             exit 0
           fi
-          deno run --allow-read --allow-write scripts/merge_junit.ts \
+          # `--allow-write=junit.xml` (Issue #3681) — this step runs an in-repo
+          # script, so a same-repo PR controls what executes here, and the
+          # Codecov uploads later in this job hold `secrets.CODECOV_TOKEN`. An
+          # unrestricted write grant reaches `$GITHUB_ENV` / `$GITHUB_PATH`,
+          # which those later steps honour, so it must be scoped to exactly the
+          # merged report the script writes.
+          deno run --allow-read --allow-write=junit.xml scripts/merge_junit.ts \
             --output=junit.xml "${reports[@]}"
           if [ -s junit.xml ]; then
             echo "junit_exists=true" >> "$GITHUB_OUTPUT"

--- a/docs/archive/pr-summaries/pr-summary-3681.md
+++ b/docs/archive/pr-summaries/pr-summary-3681.md
@@ -62,7 +62,7 @@ New file `test/ci/CoverageMergeStepLeastPrivilege.ts`:
   `--allow-write`, `-A`, or `--allow-all`. This catches permission drift back to
   unrestricted, which never fails at runtime.
 - **`the committed permission set still merges the shard reports`** — executes
-  `scripts/merge_junit.ts` in a throwaway directory under the *exact* flags
+  `scripts/merge_junit.ts` in a throwaway directory under the _exact_ flags
   parsed out of the committed workflow, over two fixture shard reports, and
   asserts the merged `junit.xml` aggregates both (`tests="5" failures="1"`).
   Narrowing the grant too far turns this red instead of failing CI later.
@@ -76,7 +76,7 @@ and still passes; the script's behaviour is untouched.
 
 ## Files changed
 
-- `.github/workflows/coverage.yaml` — `--allow-write` → `--allow-write=junit.xml`
-  on the merge step, with a comment recording why.
+- `.github/workflows/coverage.yaml` — `--allow-write` →
+  `--allow-write=junit.xml` on the merge step, with a comment recording why.
 - `scripts/merge_junit.ts` — CLI usage comment updated to the scoped invocation.
 - `test/ci/CoverageMergeStepLeastPrivilege.ts` — new tests (above).

--- a/docs/archive/pr-summaries/pr-summary-3681.md
+++ b/docs/archive/pr-summaries/pr-summary-3681.md
@@ -1,0 +1,82 @@
+# PR Summary — Scope the JUnit merge step's write grant (Issue #3681)
+
+## Summary
+
+The `merge` job of `.github/workflows/coverage.yaml` ran the in-repo script
+`scripts/merge_junit.ts` with an unrestricted `--allow-write`, ahead of two
+steps in the same job that hold `secrets.CODECOV_TOKEN`. A same-repo pull
+request controls what executes at that step, and an unrestricted write grant
+reaches `$GITHUB_ENV` and `$GITHUB_PATH` — both honoured by later steps in the
+same job — which is enough to shim a binary onto `PATH` or set an environment
+variable the Codecov action reads, and thereby observe or redirect the token.
+
+The grant is now scoped to exactly the file the script writes
+(`--allow-write=junit.xml`), matching the already-narrow `--allow-read`
+treatment of `coverage_merge_gate.ts` and the SBOM step's
+`--allow-write=sbom.cdx.json` (Issue #3668). Fork PRs never receive the secret,
+so the exposure was limited to branch PRs, but the ordering still put
+PR-authored code with unrestricted write ahead of the token.
+
+`Closes #3681`.
+
+## Evidence
+
+Backend/CI-only change — there is no web interface to screenshot. Verification
+is the new test file, run below.
+
+```mermaid
+flowchart TD
+    subgraph merge["merge job (holds CODECOV_TOKEN)"]
+        A["Merge JUnit reports<br/>deno run scripts/merge_junit.ts"]
+        B["Upload test results to Codecov<br/>token: secrets.CODECOV_TOKEN"]
+        C["Upload coverage to Codecov<br/>token: secrets.CODECOV_TOKEN"]
+        A --> B --> C
+    end
+    A -. "before: --allow-write<br/>can write \$GITHUB_ENV / \$GITHUB_PATH" .-> X["Token observable<br/>or redirectable"]
+    A == "after: --allow-write=junit.xml<br/>write denied outside the report" ==> Y["Token out of reach"]
+```
+
+Test run (`deno test test/ci/CoverageMergeStepLeastPrivilege.ts`):
+
+```text
+the JUnit merge step scopes --allow-write to its output (Issue #3681) ... ok
+no secret-bearing job grants unrestricted write to repo-authored code (Issue #3681) ... ok
+the committed permission set still merges the shard reports (Issue #3681) ... ok
+the committed permission set blocks writes outside the report (Issue #3681) ... ok
+ok | 4 passed | 0 failed
+```
+
+All four fail (bar the first behavioural one) against the unfixed workflow —
+they were written first and confirmed red before the workflow was changed.
+
+## Test Plan
+
+New file `test/ci/CoverageMergeStepLeastPrivilege.ts`:
+
+- **`the JUnit merge step scopes --allow-write to its output`** — parses the
+  committed workflow and asserts the merge step grants exactly one
+  `--allow-write`, qualified with a path equal to the step's `--output` value.
+- **`no secret-bearing job grants unrestricted write to repo-authored code`** —
+  the regression guard the issue asks for: any job in `coverage.yaml` that
+  references a secret must not run `deno run/test/bench/eval` with a bare
+  `--allow-write`, `-A`, or `--allow-all`. This catches permission drift back to
+  unrestricted, which never fails at runtime.
+- **`the committed permission set still merges the shard reports`** — executes
+  `scripts/merge_junit.ts` in a throwaway directory under the *exact* flags
+  parsed out of the committed workflow, over two fixture shard reports, and
+  asserts the merged `junit.xml` aggregates both (`tests="5" failures="1"`).
+  Narrowing the grant too far turns this red instead of failing CI later.
+- **`the committed permission set blocks writes outside the report`** — same
+  flags, but asks the script to write a different path; asserts a non-zero exit
+  with a Deno permission error and that no file was created. This proves the
+  narrowing is actually binding, not cosmetic.
+
+Existing `test/scripts/MergeJunit.ts` (the script's own unit tests) is unchanged
+and still passes; the script's behaviour is untouched.
+
+## Files changed
+
+- `.github/workflows/coverage.yaml` — `--allow-write` → `--allow-write=junit.xml`
+  on the merge step, with a comment recording why.
+- `scripts/merge_junit.ts` — CLI usage comment updated to the scoped invocation.
+- `test/ci/CoverageMergeStepLeastPrivilege.ts` — new tests (above).

--- a/scripts/merge_junit.ts
+++ b/scripts/merge_junit.ts
@@ -9,8 +9,10 @@
  * Results" checks and N Codecov uploads; merging them yields the single
  * consolidated report the acceptance criteria require.
  *
- * CLI usage:
- *   deno run --allow-read --allow-write scripts/merge_junit.ts \
+ * CLI usage — scope the write grant to the output path (Issue #3681); the CI
+ * job that runs this script also holds `secrets.CODECOV_TOKEN`, and an
+ * unrestricted grant would reach `$GITHUB_ENV` / `$GITHUB_PATH`:
+ *   deno run --allow-read --allow-write=junit.xml scripts/merge_junit.ts \
  *     --output=junit.xml junit-0.xml junit-1.xml ...
  */
 

--- a/test/ci/CoverageMergeStepLeastPrivilege.ts
+++ b/test/ci/CoverageMergeStepLeastPrivilege.ts
@@ -1,0 +1,236 @@
+/**
+ * Issue #3681 — the coverage `merge` job runs repo-authored code **before** the
+ * steps that hold `secrets.CODECOV_TOKEN`:
+ *
+ * ```yaml
+ * run: deno run --allow-read --allow-write scripts/merge_junit.ts --output=junit.xml junit-*.xml
+ * ...
+ * with:
+ *   token: ${{ secrets.CODECOV_TOKEN }}
+ * ```
+ *
+ * `scripts/merge_junit.ts` is an in-repo file, so a same-repo pull request
+ * controls what executes at that step. An unrestricted `--allow-write` reaches
+ * `$GITHUB_ENV` and `$GITHUB_PATH` — both honoured by later steps in the same
+ * job — which is enough to shim a binary onto `PATH` or set an environment
+ * variable the Codecov action reads, and thereby observe or redirect the token.
+ *
+ * The fix scopes the grant to the merged report the script actually writes, so
+ * the step cannot reach the runner files that carry the token forward.
+ *
+ * These are "what" tests: they parse the committed workflow YAML and assert on
+ * the resulting configuration, and they execute the script under exactly the
+ * committed permission set to prove that set is both sufficient and binding.
+ */
+
+import { assert, assertEquals } from "@std/assert";
+import { fromFileUrl, join } from "@std/path";
+import { parse } from "@std/yaml";
+
+const REPO_ROOT = fromFileUrl(new URL("../../", import.meta.url));
+const COVERAGE_WORKFLOW = ".github/workflows/coverage.yaml";
+const MERGE_SCRIPT = join(REPO_ROOT, "scripts/merge_junit.ts");
+
+interface Step {
+  name?: string;
+  uses?: string;
+  run?: string;
+  with?: Record<string, unknown>;
+  env?: Record<string, string>;
+}
+
+interface Job {
+  steps?: Step[];
+}
+
+interface Workflow {
+  jobs?: Record<string, Job>;
+}
+
+async function readWorkflow(relPath: string): Promise<Workflow> {
+  return parse(await Deno.readTextFile(join(REPO_ROOT, relPath))) as Workflow;
+}
+
+/** Drop shell comment lines so prose about a flag is not read as a grant. */
+function stripComments(run: string): string {
+  return run
+    .split("\n")
+    .filter((line) => !/^\s*#/.test(line))
+    .join("\n");
+}
+
+/** Permission flags granted to a `deno` invocation inside a `run:` block. */
+function grantedFlags(run: string): string[] {
+  return stripComments(run).match(/--allow-[a-z-]+(?:=[^\s\\]*)?/g) ?? [];
+}
+
+function grantsUnrestrictedWrite(run: string): boolean {
+  if (/(^|\s)(-A|--allow-all)(\s|$)/.test(stripComments(run))) return true;
+  return grantedFlags(run).some((flag) => flag === "--allow-write");
+}
+
+/** The `run:` block that invokes the JUnit merge script. */
+async function mergeStepRun(): Promise<string> {
+  const wf = await readWorkflow(COVERAGE_WORKFLOW);
+  for (const job of Object.values(wf.jobs ?? {})) {
+    for (const step of job.steps ?? []) {
+      if (typeof step.run === "string" && /merge_junit\.ts/.test(step.run)) {
+        return step.run;
+      }
+    }
+  }
+  throw new Error(
+    `${COVERAGE_WORKFLOW} must run scripts/merge_junit.ts to consolidate the ` +
+      "per-shard JUnit reports",
+  );
+}
+
+/** Flags between `deno run` and the script path of the merge invocation. */
+function mergeInvocationFlags(run: string): string[] {
+  const match = stripComments(run).match(
+    /deno\s+run\s+([\s\S]*?)scripts\/merge_junit\.ts/,
+  );
+  assert(match !== null, `no 'deno run … merge_junit.ts' found in: ${run}`);
+  return match![1]
+    .split(/\s+/)
+    .map((token) => token.trim())
+    .filter((token) => token.length > 0 && token !== "\\");
+}
+
+Deno.test("the JUnit merge step scopes --allow-write to its output (Issue #3681)", async () => {
+  const run = await mergeStepRun();
+  const writes = grantedFlags(run).filter((flag) =>
+    flag.split("=")[0] === "--allow-write"
+  );
+  assertEquals(
+    writes.length,
+    1,
+    `expected exactly one --allow-write flag, got '${writes.join(", ")}'`,
+  );
+  const value = writes[0].split("=")[1];
+  assert(
+    value !== undefined && value.trim().length > 0,
+    "--allow-write must name the merged report path rather than granting " +
+      "write access runner-wide — an unrestricted grant reaches $GITHUB_ENV " +
+      "and $GITHUB_PATH, which later steps in the same job honour while they " +
+      "hold secrets.CODECOV_TOKEN",
+  );
+  const output = stripComments(run).match(/--output=([^\s\\]+)/)?.[1];
+  assertEquals(
+    value,
+    output,
+    "--allow-write must be scoped to exactly the --output path the script " +
+      "writes, so the grant stays as narrow as the job's real need",
+  );
+});
+
+Deno.test("no secret-bearing job grants unrestricted write to repo-authored code (Issue #3681)", async () => {
+  const wf = await readWorkflow(COVERAGE_WORKFLOW);
+  let checkedSecretJobs = 0;
+  for (const [jobId, job] of Object.entries(wf.jobs ?? {})) {
+    if (!/secrets\./.test(JSON.stringify(job))) continue;
+    checkedSecretJobs++;
+    for (const step of job.steps ?? []) {
+      if (typeof step.run !== "string") continue;
+      if (!/\bdeno\s+(run|test|bench|eval)\b/.test(step.run)) continue;
+      assert(
+        !grantsUnrestrictedWrite(step.run),
+        `${COVERAGE_WORKFLOW} job "${jobId}" step "${
+          step.name ?? "<unnamed>"
+        }" runs repo-authored code with unrestricted write access while the ` +
+          "same job holds a secret. Scope the grant to the paths the step " +
+          "writes (--allow-write=<path>) so it cannot mutate $GITHUB_ENV or " +
+          "$GITHUB_PATH and reach the secret through a later step.",
+      );
+    }
+  }
+  assert(
+    checkedSecretJobs > 0,
+    `${COVERAGE_WORKFLOW} expected at least one job that references a secret`,
+  );
+});
+
+/**
+ * Run the merge script under the exact permission set the workflow grants, in a
+ * throwaway working directory, and assert it still produces the merged report.
+ * If the grant is narrowed past what the script needs, Deno exits non-zero with
+ * a PermissionDenied and this test fails — the same signal CI would give.
+ */
+async function runMergeScript(
+  cwd: string,
+  scriptArgs: string[],
+): Promise<{ code: number; stderr: string }> {
+  const flags = mergeInvocationFlags(await mergeStepRun());
+  const command = new Deno.Command(Deno.execPath(), {
+    args: ["run", ...flags, MERGE_SCRIPT, ...scriptArgs],
+    cwd,
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const { code, stderr } = await command.output();
+  return { code, stderr: new TextDecoder().decode(stderr) };
+}
+
+const SHARD_ONE = `<?xml version="1.0" encoding="UTF-8"?>
+<testsuites tests="2" failures="0" errors="0" skipped="0" time="1.5">
+<testsuite name="shard-0" tests="2" failures="0" errors="0" skipped="0" time="1.5"/>
+</testsuites>
+`;
+
+const SHARD_TWO = `<?xml version="1.0" encoding="UTF-8"?>
+<testsuites tests="3" failures="1" errors="0" skipped="0" time="2.5">
+<testsuite name="shard-1" tests="3" failures="1" errors="0" skipped="0" time="2.5"/>
+</testsuites>
+`;
+
+Deno.test("the committed permission set still merges the shard reports (Issue #3681)", async () => {
+  const cwd = await Deno.makeTempDir({ prefix: "merge-junit-perms-" });
+  try {
+    await Deno.writeTextFile(join(cwd, "junit-0.xml"), SHARD_ONE);
+    await Deno.writeTextFile(join(cwd, "junit-1.xml"), SHARD_TWO);
+    const { code, stderr } = await runMergeScript(cwd, [
+      "--output=junit.xml",
+      "junit-0.xml",
+      "junit-1.xml",
+    ]);
+    assertEquals(code, 0, `merge failed under the workflow grant: ${stderr}`);
+    const merged = await Deno.readTextFile(join(cwd, "junit.xml"));
+    assert(
+      merged.includes('tests="5"') && merged.includes('failures="1"'),
+      `merged report should aggregate both shards, got:\n${merged}`,
+    );
+  } finally {
+    await Deno.remove(cwd, { recursive: true });
+  }
+});
+
+Deno.test("the committed permission set blocks writes outside the report (Issue #3681)", async () => {
+  const cwd = await Deno.makeTempDir({ prefix: "merge-junit-perms-" });
+  try {
+    await Deno.writeTextFile(join(cwd, "junit-0.xml"), SHARD_ONE);
+    // `$GITHUB_ENV` is the file a compromised merge step would target: writing
+    // to it seeds environment variables into every later step of the same job,
+    // including the ones that hold secrets.CODECOV_TOKEN.
+    const { code, stderr } = await runMergeScript(cwd, [
+      "--output=github-env",
+      "junit-0.xml",
+    ]);
+    assert(
+      code !== 0,
+      "the workflow grant must deny writes to any path other than the merged " +
+        "report; a step that can write arbitrary files can seed $GITHUB_ENV " +
+        "or $GITHUB_PATH for the token-bearing steps that follow",
+    );
+    assert(
+      /NotCapable|PermissionDenied|Requires write access/i.test(stderr),
+      `expected a Deno permission failure, got:\n${stderr}`,
+    );
+    assertEquals(
+      await Deno.stat(join(cwd, "github-env")).catch(() => null),
+      null,
+      "no file should have been written outside the granted path",
+    );
+  } finally {
+    await Deno.remove(cwd, { recursive: true });
+  }
+});


### PR DESCRIPTION
# PR Summary — Scope the JUnit merge step's write grant (Issue #3681)

## Summary

The `merge` job of `.github/workflows/coverage.yaml` ran the in-repo script
`scripts/merge_junit.ts` with an unrestricted `--allow-write`, ahead of two
steps in the same job that hold `secrets.CODECOV_TOKEN`. A same-repo pull
request controls what executes at that step, and an unrestricted write grant
reaches `$GITHUB_ENV` and `$GITHUB_PATH` — both honoured by later steps in the
same job — which is enough to shim a binary onto `PATH` or set an environment
variable the Codecov action reads, and thereby observe or redirect the token.

The grant is now scoped to exactly the file the script writes
(`--allow-write=junit.xml`), matching the already-narrow `--allow-read`
treatment of `coverage_merge_gate.ts` and the SBOM step's
`--allow-write=sbom.cdx.json` (Issue #3668). Fork PRs never receive the secret,
so the exposure was limited to branch PRs, but the ordering still put
PR-authored code with unrestricted write ahead of the token.

`Closes #3681`.

## Evidence

Backend/CI-only change — there is no web interface to screenshot. Verification
is the new test file, run below.

```mermaid
flowchart TD
    subgraph merge["merge job (holds CODECOV_TOKEN)"]
        A["Merge JUnit reports<br/>deno run scripts/merge_junit.ts"]
        B["Upload test results to Codecov<br/>token: ***REDACTED***
        C["Upload coverage to Codecov<br/>token: ***REDACTED***
        A --> B --> C
    end
    A -. "before: --allow-write<br/>can write \$GITHUB_ENV / \$GITHUB_PATH" .-> X["Token observable<br/>or redirectable"]
    A == "after: --allow-write=junit.xml<br/>write denied outside the report" ==> Y["Token out of reach"]
```

Test run (`deno test test/ci/CoverageMergeStepLeastPrivilege.ts`):

```text
the JUnit merge step scopes --allow-write to its output (Issue #3681) ... ok
no secret-bearing job grants unrestricted write to repo-authored code (Issue #3681) ... ok
the committed permission set still merges the shard reports (Issue #3681) ... ok
the committed permission set blocks writes outside the report (Issue #3681) ... ok
ok | 4 passed | 0 failed
```

All four fail (bar the first behavioural one) against the unfixed workflow —
they were written first and confirmed red before the workflow was changed.

## Test Plan

New file `test/ci/CoverageMergeStepLeastPrivilege.ts`:

- **`the JUnit merge step scopes --allow-write to its output`** — parses the
  committed workflow and asserts the merge step grants exactly one
  `--allow-write`, qualified with a path equal to the step's `--output` value.
- **`no secret-bearing job grants unrestricted write to repo-authored code`** —
  the regression guard the issue asks for: any job in `coverage.yaml` that
  references a secret must not run `deno run/test/bench/eval` with a bare
  `--allow-write`, `-A`, or `--allow-all`. This catches permission drift back to
  unrestricted, which never fails at runtime.
- **`the committed permission set still merges the shard reports`** — executes
  `scripts/merge_junit.ts` in a throwaway directory under the *exact* flags
  parsed out of the committed workflow, over two fixture shard reports, and
  asserts the merged `junit.xml` aggregates both (`tests="5" failures="1"`).
  Narrowing the grant too far turns this red instead of failing CI later.
- **`the committed permission set blocks writes outside the report`** — same
  flags, but asks the script to write a different path; asserts a non-zero exit
  with a Deno permission error and that no file was created. This proves the
  narrowing is actually binding, not cosmetic.

Existing `test/scripts/MergeJunit.ts` (the script's own unit tests) is unchanged
and still passes; the script's behaviour is untouched.

## Files changed

- `.github/workflows/coverage.yaml` — `--allow-write` → `--allow-write=junit.xml`
  on the merge step, with a comment recording why.
- `scripts/merge_junit.ts` — CLI usage comment updated to the scoped invocation.
- `test/ci/CoverageMergeStepLeastPrivilege.ts` — new tests (above).



## Milestone
This PR is part of the **Scan 20260807** milestone and targets the `milestone/scan-20260807` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mskaumhd-9622f2`<!-- vibe-worker-issue-3681 -->