### PR TITLE
🟡 Bound memetic `ancestry` depth on the load side (Issue #3682)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-3682.md
+++ b/docs/archive/pr-summaries/pr-summary-3682.md
@@ -1,0 +1,95 @@
+# Bound memetic `ancestry` depth on the load side (Issue #3682)
+
+## Summary
+
+`convertMemeticToIntIds` in `src/creature/CreatureSerialization.ts` recursed
+through `memetic.ancestry` with no depth cap and re-cloned its whole remaining
+subtree (`JSON.parse(JSON.stringify(...))`) at every level. A compact,
+hand-written model JSON with a deep `ancestry` chain therefore cost O(d²) work
+before it overflowed the stack — a cheap denial of service against any process
+loading untrusted model files. The write side (`addToAncestry`) has always
+bounded ancestry, so the invariant existed but was never enforced where
+untrusted bytes arrive. Closes #3682.
+
+Changes:
+
+- **Shared cap.** `addToAncestry` now defaults `maxDepth` to the existing
+  `DEFAULT_ANCESTRY_DEPTH` (3) from `@blackbox/MemeticInterface.ts` instead of a
+  bare literal, and the load side enforces the same constant — one source of
+  truth for both directions.
+- **Truncate, don't reject.** `truncateAncestryDepth` bounds the incoming chain
+  to `DEFAULT_ANCESTRY_DEPTH` nested levels, matching the writer's
+  circular-buffer semantics so existing files still load. It shallow-copies only
+  the retained levels and returns the original object untouched when the chain
+  is already within the bound, so the common path allocates nothing and the
+  caller's JSON is never mutated.
+- **Clone once.** The deep clone was hoisted out of the recursion to the entry
+  point, and conversion now runs in place over that single private clone
+  (`convertSnapshotInPlace` / `convertSnapshotTree`). Depth no longer multiplies
+  serialisation cost.
+- **Depth parameter.** `convertSnapshotTree` carries an explicit `depth` and
+  refuses to descend past the cap — a second line of defence if a future caller
+  hands it an untruncated tree.
+
+Per-snapshot conversion semantics are unchanged: a snapshot carrying no wire
+identities is still left exactly as it arrived, and its own ancestry is still
+not descended into.
+
+## Evidence
+
+Backend-only change — no web interface to screenshot. Evidence is the test
+suite.
+
+Before the fix, `test/creature/MemeticAncestryDepth.ts` killed the test process
+outright (fatal V8 out-of-memory inside the repeated
+`JSON.parse`/`JSON.stringify` of the nested subtree, stack frames alternating
+`ParseJsonObject` / `ParseJsonArray`). After the fix the same 10 000-level input
+loads in ~1 ms:
+
+```text
+running 4 tests from ./test/creature/MemeticAncestryDepth.ts
+deeply nested memetic ancestry loads without a stack overflow ... ok (1ms)
+deeply nested memetic ancestry still converts UUID keys to int ids ... ok (514µs)
+memetic within the ancestry depth cap round-trips unchanged ... ok (798µs)
+ancestry nesting at the depth cap is preserved ... ok (81µs)
+
+ok | 4 passed | 0 failed (4ms)
+```
+
+Full gate: `./quality.sh` → `ok | 8184 passed (5 steps) | 0 failed | 4 ignored`.
+
+Load path after the change:
+
+```mermaid
+flowchart LR
+    J[Untrusted model JSON<br/>memetic.ancestry] --> T{depth &gt; 3?}
+    T -- "yes" --> Tr[truncate to<br/>DEFAULT_ANCESTRY_DEPTH]
+    T -- "no" --> Same[return input as-is<br/>no copy]
+    Tr --> N{needs int-id<br/>conversion?}
+    Same --> N
+    N -- "no" --> Out[bounded memetic]
+    N -- "yes" --> C[one deep clone<br/>of bounded tree]
+    C --> W[convert snapshots in place<br/>depth-capped walk]
+    W --> Out
+```
+
+## Test Plan
+
+Added `test/creature/MemeticAncestryDepth.ts`:
+
+- `deeply nested memetic ancestry loads without a stack overflow` — regression
+  test: a model JSON with 10 000 nested `ancestry` levels loads and is truncated
+  to `DEFAULT_ANCESTRY_DEPTH`. Fatally crashes the runner against the unfixed
+  code.
+- `deeply nested memetic ancestry still converts UUID keys to int ids` — the
+  retained levels are still rewritten from wire UUIDs to runtime integer ids.
+- `memetic within the ancestry depth cap round-trips unchanged` — a well-formed
+  block with three ancestors survives `fromJSON` → `exportJSON` identical,
+  guarding against over-aggressive truncation.
+- `ancestry nesting at the depth cap is preserved` — nesting exactly at the cap
+  is kept.
+
+Existing coverage kept green: `test/creature/` and `test/blackbox/` (including
+`MemeticExportSingleClone.ts`, `CreatureSerialization.ts`,
+`test/architecture/ExportSchemaValidation.ts` against the updated
+`docs/snapshot-schema.json`).

--- a/docs/snapshot-schema.json
+++ b/docs/snapshot-schema.json
@@ -256,7 +256,7 @@
         },
         "ancestry": {
           "type": "array",
-          "description": "Optional circular buffer of ancestor snapshots, ordered from most recent to oldest. Limited to 3 entries by default.",
+          "description": "Optional circular buffer of ancestor snapshots, ordered from most recent to oldest. Limited to 3 entries by default. Ancestor snapshots carry no ancestry of their own; the loader truncates any nesting beyond 3 levels (Issue #3682).",
           "maxItems": 3,
           "items": {
             "$ref": "#/$defs/memeticAncestorSnapshot"

--- a/src/blackbox/MemeticTrajectory.ts
+++ b/src/blackbox/MemeticTrajectory.ts
@@ -1,6 +1,7 @@
-import type {
-  MemeticAncestorSnapshot,
-  MemeticInterface,
+import {
+  DEFAULT_ANCESTRY_DEPTH,
+  type MemeticAncestorSnapshot,
+  type MemeticInterface,
 } from "@blackbox/MemeticInterface.ts";
 
 /**
@@ -250,13 +251,15 @@ export function createAncestorSnapshot(
  *
  * @param ancestry - The current ancestry array (or undefined)
  * @param newAncestor - The new ancestor to add
- * @param maxDepth - Maximum number of ancestors to keep (default: 3)
+ * @param maxDepth - Maximum number of ancestors to keep
+ *   (default: {@link DEFAULT_ANCESTRY_DEPTH}). The load side enforces the same
+ *   constant on untrusted JSON — see Issue #3682.
  * @returns Updated ancestry array
  */
 export function addToAncestry(
   ancestry: MemeticAncestorSnapshot[] | undefined,
   newAncestor: MemeticAncestorSnapshot,
-  maxDepth: number = 3,
+  maxDepth: number = DEFAULT_ANCESTRY_DEPTH,
 ): MemeticAncestorSnapshot[] {
   const newAncestry = ancestry ? [...ancestry] : [];
 

--- a/src/creature/CreatureSerialization.ts
+++ b/src/creature/CreatureSerialization.ts
@@ -29,7 +29,10 @@ import type {
   SynapseInternal,
   SynapseTrace,
 } from "@architecture/SynapseInterfaces.ts";
-import type { MemeticInterface } from "@blackbox/MemeticInterface.ts";
+import {
+  DEFAULT_ANCESTRY_DEPTH,
+  type MemeticInterface,
+} from "@blackbox/MemeticInterface.ts";
 import {
   isMemeticWireData,
   type MemeticWeightEntryWire,
@@ -270,63 +273,93 @@ export function traceJSON(creature: Creature): CreatureTrace {
   return exportCreature as CreatureTrace;
 }
 
+/** True when `key` is a wire UUID this creature can resolve to an integer id. */
+function keyNeedsConversion(
+  key: string,
+  uuidToIntId: Map<string, number>,
+): boolean {
+  return isNaN(Number(key)) && uuidToIntId.has(key);
+}
+
 /**
- * Converts wire memetic JSON to runtime integer neuron IDs.
- * Wire exports use string bias keys and a `weights` array of
- * `{ fromUUID, toUUID, weight }`; legacy object maps are still accepted.
+ * True when this snapshot carries wire identities that must be rewritten to
+ * runtime integer ids: UUID bias/weight keys, or the wire `weights` array.
  */
-function convertMemeticToIntIds(
+function snapshotNeedsConversion(
   memetic: MemeticWireData,
-  creature: Creature,
-  uuidToIndex: Map<string, number>,
-): MemeticInterface | MemeticWireData {
-  if (!memetic) return memetic;
+  uuidToIntId: Map<string, number>,
+): boolean {
+  if (Array.isArray(memetic.weights)) return true;
 
-  const uuidToIntId = new Map<string, number>();
-  for (const [uuid, index] of uuidToIndex) {
-    if (index < creature.neurons.length) {
-      uuidToIntId.set(uuid, creature.neurons[index].id);
-    }
-  }
-
-  const needsConversion = (key: string): boolean => {
-    return isNaN(Number(key)) && uuidToIntId.has(key);
-  };
-
-  // Check if any keys need conversion
-  let hasUuidKeys = false;
   if (memetic.biases) {
     for (const key of Object.keys(memetic.biases)) {
-      if (needsConversion(key)) {
-        hasUuidKeys = true;
-        break;
-      }
+      if (keyNeedsConversion(key, uuidToIntId)) return true;
     }
   }
-  const weightsAreWireArray = Array.isArray(memetic.weights);
 
-  if (
-    !hasUuidKeys && memetic.weights && !weightsAreWireArray
-  ) {
+  if (memetic.weights) {
     for (
       const key of Object.keys(
         memetic.weights as Record<string, MemeticWeightEntryWire[]>,
       )
     ) {
-      if (needsConversion(key)) {
-        hasUuidKeys = true;
-        break;
-      }
+      if (keyNeedsConversion(key, uuidToIntId)) return true;
     }
   }
 
-  if (!hasUuidKeys && !weightsAreWireArray) return memetic;
+  return false;
+}
 
-  // Deep clone to avoid mutating the original JSON, then validate
-  const parsed: unknown = JSON.parse(JSON.stringify(memetic));
-  if (!isMemeticWireData(parsed)) return memetic;
-  const result: MemeticWireData = parsed;
+/**
+ * Issue #3682: bound the `ancestry` nesting arriving from untrusted model JSON.
+ *
+ * The write side (`addToAncestry` in `@blackbox/MemeticTrajectory.ts`) keeps at
+ * most {@link DEFAULT_ANCESTRY_DEPTH} ancestors, so anything this codebase
+ * produces is already within the bound. The read side used to accept unbounded
+ * nesting, which a hand-written model file could exploit to burn CPU and then
+ * overflow the stack. Deeper chains are truncated — matching the writer's
+ * circular-buffer semantics — rather than rejected, so existing files still
+ * load.
+ *
+ * Only the retained levels are shallow-copied, and the original object is
+ * returned untouched when the chain is already within the bound, so the common
+ * case allocates nothing and the caller's JSON is never mutated.
+ *
+ * @param node - Snapshot at the current level
+ * @param remainingDepth - Nested ancestry levels still permitted below `node`
+ */
+function truncateAncestryDepth(
+  node: MemeticWireData,
+  remainingDepth: number,
+): MemeticWireData {
+  const ancestry = node.ancestry;
+  if (!Array.isArray(ancestry) || ancestry.length === 0) return node;
 
+  if (remainingDepth <= 0) {
+    const truncated: MemeticWireData = { ...node };
+    delete truncated.ancestry;
+    return truncated;
+  }
+
+  let changed = false;
+  const bounded = ancestry.map((ancestor) => {
+    if (!isRecord(ancestor)) return ancestor;
+    const next = truncateAncestryDepth(ancestor, remainingDepth - 1);
+    if (next !== ancestor) changed = true;
+    return next;
+  });
+
+  return changed ? { ...node, ancestry: bounded } : node;
+}
+
+/**
+ * Rewrites one snapshot's `biases` and `weights` to runtime integer ids,
+ * in place. The caller owns a private clone, so mutation is safe here.
+ */
+function convertSnapshotInPlace(
+  result: MemeticWireData,
+  uuidToIntId: Map<string, number>,
+): void {
   // Convert biases keys
   if (result.biases) {
     const newBiases: Record<number, number> = {};
@@ -344,65 +377,122 @@ function convertMemeticToIntIds(
     (result as unknown as Record<string, unknown>).biases = newBiases;
   }
 
-  // Convert weights: wire array { fromUUID, toUUID, weight } or UUID-keyed map
-  if (result.weights) {
-    const newWeights: Record<number, MemeticWeightEntryWire[]> = {};
-    if (Array.isArray(result.weights)) {
-      for (const row of result.weights) {
-        if (
-          row === null || row === undefined || typeof row.weight !== "number"
-        ) {
-          continue;
-        }
-        const fu = row.fromUUID;
-        const tu = row.toUUID;
-        if (typeof fu !== "string" || typeof tu !== "string") continue;
-        const fromInt = uuidToIntId.get(fu);
-        const toInt = uuidToIntId.get(tu);
-        if (fromInt === undefined || toInt === undefined) continue;
-        if (!newWeights[fromInt]) newWeights[fromInt] = [];
-        newWeights[fromInt].push({ toId: toInt, weight: row.weight });
-      }
-      (result as unknown as Record<string, unknown>).weights = newWeights;
-    } else {
-      const weightMap = result.weights as Record<
-        string,
-        MemeticWeightEntryWire[]
-      >;
-      for (const key of Object.keys(weightMap)) {
-        const intId = uuidToIntId.get(key);
-        const numericKey = intId !== undefined ? intId : Number(key);
-        if (isNaN(numericKey)) continue;
+  if (!result.weights) return;
 
-        const entries = weightMap[key].map(
-          (entry: MemeticWeightEntryWire) => {
-            const newEntry: MemeticWeightEntryWire = { ...entry };
-            if (typeof newEntry.toUUID === "string") {
-              const toIntId = uuidToIntId.get(newEntry.toUUID);
-              if (toIntId !== undefined) {
-                newEntry.toId = toIntId;
-                delete newEntry.toUUID;
-              }
-            }
-            return newEntry;
-          },
-        );
-        newWeights[numericKey] = entries;
+  // Convert weights: wire array { fromUUID, toUUID, weight } or UUID-keyed map
+  const newWeights: Record<number, MemeticWeightEntryWire[]> = {};
+  if (Array.isArray(result.weights)) {
+    for (const row of result.weights) {
+      if (
+        row === null || row === undefined || typeof row.weight !== "number"
+      ) {
+        continue;
       }
-      (result as unknown as Record<string, unknown>).weights = newWeights;
+      const fu = row.fromUUID;
+      const tu = row.toUUID;
+      if (typeof fu !== "string" || typeof tu !== "string") continue;
+      const fromInt = uuidToIntId.get(fu);
+      const toInt = uuidToIntId.get(tu);
+      if (fromInt === undefined || toInt === undefined) continue;
+      if (!newWeights[fromInt]) newWeights[fromInt] = [];
+      newWeights[fromInt].push({ toId: toInt, weight: row.weight });
+    }
+  } else {
+    const weightMap = result.weights as Record<
+      string,
+      MemeticWeightEntryWire[]
+    >;
+    for (const key of Object.keys(weightMap)) {
+      const intId = uuidToIntId.get(key);
+      const numericKey = intId !== undefined ? intId : Number(key);
+      if (isNaN(numericKey)) continue;
+
+      const entries = weightMap[key].map(
+        (entry: MemeticWeightEntryWire) => {
+          const newEntry: MemeticWeightEntryWire = { ...entry };
+          if (typeof newEntry.toUUID === "string") {
+            const toIntId = uuidToIntId.get(newEntry.toUUID);
+            if (toIntId !== undefined) {
+              newEntry.toId = toIntId;
+              delete newEntry.toUUID;
+            }
+          }
+          return newEntry;
+        },
+      );
+      newWeights[numericKey] = entries;
+    }
+  }
+  (result as unknown as Record<string, unknown>).weights = newWeights;
+}
+
+/**
+ * Converts a snapshot and its (already depth-bounded) ancestry chain in place.
+ *
+ * `depth` is a second line of defence behind {@link truncateAncestryDepth}: it
+ * refuses to descend past {@link DEFAULT_ANCESTRY_DEPTH} even if a future
+ * caller hands over an untruncated tree.
+ */
+function convertSnapshotTree(
+  node: MemeticWireData,
+  uuidToIntId: Map<string, number>,
+  depth: number,
+): void {
+  convertSnapshotInPlace(node, uuidToIntId);
+
+  const ancestry = node.ancestry;
+  if (!Array.isArray(ancestry)) return;
+  if (depth >= DEFAULT_ANCESTRY_DEPTH) {
+    delete node.ancestry;
+    return;
+  }
+
+  for (const ancestor of ancestry) {
+    // A snapshot that carries no wire identities is left exactly as it
+    // arrived — and, as before, its own ancestry is not descended into.
+    if (
+      isMemeticWireData(ancestor) &&
+      snapshotNeedsConversion(ancestor, uuidToIntId)
+    ) {
+      convertSnapshotTree(ancestor, uuidToIntId, depth + 1);
+    }
+  }
+}
+
+/**
+ * Converts wire memetic JSON to runtime integer neuron IDs.
+ * Wire exports use string bias keys and a `weights` array of
+ * `{ fromUUID, toUUID, weight }`; legacy object maps are still accepted.
+ *
+ * Issue #3682: `ancestry` nesting is bounded to {@link DEFAULT_ANCESTRY_DEPTH}
+ * — the same cap the write side applies — and the deep clone is taken once, at
+ * this entry point, so depth no longer multiplies serialisation cost.
+ */
+function convertMemeticToIntIds(
+  memetic: MemeticWireData,
+  creature: Creature,
+  uuidToIndex: Map<string, number>,
+): MemeticInterface | MemeticWireData {
+  if (!memetic) return memetic;
+
+  const uuidToIntId = new Map<string, number>();
+  for (const [uuid, index] of uuidToIndex) {
+    if (index < creature.neurons.length) {
+      uuidToIntId.set(uuid, creature.neurons[index].id);
     }
   }
 
-  // Convert ancestry if present
-  if (result.ancestry && Array.isArray(result.ancestry)) {
-    result.ancestry = result.ancestry.map((ancestor: MemeticWireData) => {
-      return convertMemeticToIntIds(
-        ancestor,
-        creature,
-        uuidToIndex,
-      ) as MemeticWireData;
-    });
-  }
+  // Bound the untrusted ancestry chain before anything walks or clones it.
+  const bounded = truncateAncestryDepth(memetic, DEFAULT_ANCESTRY_DEPTH);
+
+  if (!snapshotNeedsConversion(bounded, uuidToIntId)) return bounded;
+
+  // One deep clone of the now-bounded tree, so the caller's JSON is untouched.
+  const parsed: unknown = JSON.parse(JSON.stringify(bounded));
+  if (!isMemeticWireData(parsed)) return bounded;
+  const result: MemeticWireData = parsed;
+
+  convertSnapshotTree(result, uuidToIntId, 0);
 
   return result;
 }

--- a/test/creature/MemeticAncestryDepth.ts
+++ b/test/creature/MemeticAncestryDepth.ts
@@ -1,0 +1,127 @@
+/**
+ * Issue #3682 — the memetic load path must bound `ancestry` nesting.
+ *
+ * `convertMemeticToIntIds` used to recurse through `memetic.ancestry` with no
+ * depth cap, re-cloning the whole remaining subtree at every level, so a
+ * compact model JSON with a deeply nested ancestry chain burned super-linear
+ * CPU and then overflowed the stack. The write side (`addToAncestry`) has
+ * always bounded ancestry to `DEFAULT_ANCESTRY_DEPTH`; these tests assert the
+ * read side enforces the same bound on untrusted JSON.
+ *
+ * These are "what" tests: they assert on the loaded `creature.memetic` and on
+ * the exported wire JSON, never on how the conversion is implemented.
+ */
+import { assert, assertEquals } from "@std/assert";
+import type { CreatureExport } from "../../mod.ts";
+import { Creature } from "@creature";
+import {
+  DEFAULT_ANCESTRY_DEPTH,
+  type MemeticInterface,
+} from "@blackbox/MemeticInterface.ts";
+import type { MemeticWireData } from "@blackbox/MemeticWireData.ts";
+
+function baseCreatureJSON(): CreatureExport {
+  return {
+    neurons: [
+      { type: "hidden", uuid: "hidden-3", squash: "Cosine", bias: 3 },
+      { type: "hidden", uuid: "hidden-4", squash: "CLIPPED", bias: 2 },
+      { type: "output", squash: "IDENTITY", uuid: "output-0", bias: 1 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-3", weight: -0.3 },
+      { fromUUID: "input-1", toUUID: "hidden-3", weight: 0.3 },
+      { fromUUID: "hidden-3", toUUID: "hidden-4", weight: -0.5 },
+      { fromUUID: "hidden-4", toUUID: "output-0", weight: 0.6 },
+    ],
+    input: 2,
+    output: 1,
+  };
+}
+
+/** One memetic snapshot in wire format (UUID bias keys, wire weight rows). */
+function wireSnapshot(generation: number): MemeticWireData {
+  return {
+    generation,
+    score: -generation,
+    biases: { "hidden-3": generation + 0.1, "hidden-4": generation + 0.2 },
+    weights: [
+      { fromUUID: "hidden-3", toUUID: "hidden-4", weight: generation + 0.3 },
+    ],
+  };
+}
+
+/** A chain of `depth` nested `ancestry` levels below the returned root. */
+function nestedAncestry(depth: number): MemeticWireData {
+  let node = wireSnapshot(0);
+  for (let generation = 1; generation <= depth; generation++) {
+    node = { ...wireSnapshot(generation), ancestry: [node] };
+  }
+  return node;
+}
+
+/** Length of the `ancestry` chain hanging below `root` (iterative, no recursion). */
+function ancestryChainDepth(root: MemeticWireData): number {
+  let depth = 0;
+  let node: MemeticWireData | undefined = root;
+  while (node?.ancestry && node.ancestry.length > 0) {
+    depth++;
+    node = node.ancestry[0];
+  }
+  return depth;
+}
+
+function loadWithMemetic(memetic: MemeticWireData): Creature {
+  const json = baseCreatureJSON() as CreatureExport & {
+    memetic: MemeticInterface;
+  };
+  json.memetic = memetic as unknown as MemeticInterface;
+  return Creature.fromJSON(json);
+}
+
+Deno.test("deeply nested memetic ancestry loads without a stack overflow", () => {
+  const creature = loadWithMemetic(nestedAncestry(10_000));
+
+  const memetic = creature.memetic as unknown as MemeticWireData | undefined;
+  assert(memetic, "memetic should survive the load");
+  assertEquals(
+    ancestryChainDepth(memetic),
+    DEFAULT_ANCESTRY_DEPTH,
+    "ancestry nesting must be truncated to the shared write-side cap",
+  );
+});
+
+Deno.test("deeply nested memetic ancestry still converts UUID keys to int ids", () => {
+  const creature = loadWithMemetic(nestedAncestry(10_000));
+
+  const memetic = creature.memetic as unknown as MemeticWireData;
+  const idOf = (uuid: string): number =>
+    creature.neurons.find((n) => n.uuid === uuid)!.id;
+
+  assertEquals(memetic.biases?.[`${idOf("hidden-3")}`], 10_000.1);
+  assertEquals(memetic.ancestry?.length, 1);
+  assertEquals(memetic.ancestry?.[0].biases?.[`${idOf("hidden-3")}`], 9999.1);
+});
+
+Deno.test("memetic within the ancestry depth cap round-trips unchanged", () => {
+  const memetic: MemeticWireData = {
+    ...wireSnapshot(9),
+    ancestry: [wireSnapshot(8), wireSnapshot(7), wireSnapshot(6)],
+  };
+  const expected = structuredClone(memetic);
+
+  const creature = loadWithMemetic(structuredClone(memetic));
+  const exported = creature.exportJSON();
+
+  assertEquals(
+    exported.memetic as unknown as MemeticWireData,
+    expected,
+    "a well-formed memetic block must survive load/export untouched",
+  );
+});
+
+Deno.test("ancestry nesting at the depth cap is preserved", () => {
+  const creature = loadWithMemetic(nestedAncestry(DEFAULT_ANCESTRY_DEPTH));
+
+  const memetic = creature.memetic as unknown as MemeticWireData;
+  assertEquals(ancestryChainDepth(memetic), DEFAULT_ANCESTRY_DEPTH);
+});


### PR DESCRIPTION
# Bound memetic `ancestry` depth on the load side (Issue #3682)

## Summary

`convertMemeticToIntIds` in `src/creature/CreatureSerialization.ts` recursed
through `memetic.ancestry` with no depth cap and re-cloned its whole remaining
subtree (`JSON.parse(JSON.stringify(...))`) at every level. A compact,
hand-written model JSON with a deep `ancestry` chain therefore cost O(d²) work
before it overflowed the stack — a cheap denial of service against any process
loading untrusted model files. The write side (`addToAncestry`) has always
bounded ancestry, so the invariant existed but was never enforced where
untrusted bytes arrive. Closes #3682.

Changes:

- **Shared cap.** `addToAncestry` now defaults `maxDepth` to the existing
  `DEFAULT_ANCESTRY_DEPTH` (3) from `@blackbox/MemeticInterface.ts` instead of a
  bare literal, and the load side enforces the same constant — one source of
  truth for both directions.
- **Truncate, don't reject.** `truncateAncestryDepth` bounds the incoming chain
  to `DEFAULT_ANCESTRY_DEPTH` nested levels, matching the writer's
  circular-buffer semantics so existing files still load. It shallow-copies only
  the retained levels and returns the original object untouched when the chain
  is already within the bound, so the common path allocates nothing and the
  caller's JSON is never mutated.
- **Clone once.** The deep clone was hoisted out of the recursion to the entry
  point, and conversion now runs in place over that single private clone
  (`convertSnapshotInPlace` / `convertSnapshotTree`). Depth no longer multiplies
  serialisation cost.
- **Depth parameter.** `convertSnapshotTree` carries an explicit `depth` and
  refuses to descend past the cap — a second line of defence if a future caller
  hands it an untruncated tree.

Per-snapshot conversion semantics are unchanged: a snapshot carrying no wire
identities is still left exactly as it arrived, and its own ancestry is still
not descended into.

## Evidence

Backend-only change — no web interface to screenshot. Evidence is the test
suite.

Before the fix, `test/creature/MemeticAncestryDepth.ts` killed the test process
outright (fatal V8 out-of-memory inside the repeated
`JSON.parse`/`JSON.stringify` of the nested subtree, stack frames alternating
`ParseJsonObject` / `ParseJsonArray`). After the fix the same 10 000-level input
loads in ~1 ms:

```text
running 4 tests from ./test/creature/MemeticAncestryDepth.ts
deeply nested memetic ancestry loads without a stack overflow ... ok (1ms)
deeply nested memetic ancestry still converts UUID keys to int ids ... ok (514µs)
memetic within the ancestry depth cap round-trips unchanged ... ok (798µs)
ancestry nesting at the depth cap is preserved ... ok (81µs)

ok | 4 passed | 0 failed (4ms)
```

Full gate: `./quality.sh` → `ok | 8184 passed (5 steps) | 0 failed | 4 ignored`.

Load path after the change:

```mermaid
flowchart LR
    J[Untrusted model JSON<br/>memetic.ancestry] --> T{depth &gt; 3?}
    T -- "yes" --> Tr[truncate to<br/>DEFAULT_ANCESTRY_DEPTH]
    T -- "no" --> Same[return input as-is<br/>no copy]
    Tr --> N{needs int-id<br/>conversion?}
    Same --> N
    N -- "no" --> Out[bounded memetic]
    N -- "yes" --> C[one deep clone<br/>of bounded tree]
    C --> W[convert snapshots in place<br/>depth-capped walk]
    W --> Out
```

## Test Plan

Added `test/creature/MemeticAncestryDepth.ts`:

- `deeply nested memetic ancestry loads without a stack overflow` — regression
  test: a model JSON with 10 000 nested `ancestry` levels loads and is truncated
  to `DEFAULT_ANCESTRY_DEPTH`. Fatally crashes the runner against the unfixed
  code.
- `deeply nested memetic ancestry still converts UUID keys to int ids` — the
  retained levels are still rewritten from wire UUIDs to runtime integer ids.
- `memetic within the ancestry depth cap round-trips unchanged` — a well-formed
  block with three ancestors survives `fromJSON` → `exportJSON` identical,
  guarding against over-aggressive truncation.
- `ancestry nesting at the depth cap is preserved` — nesting exactly at the cap
  is kept.

Existing coverage kept green: `test/creature/` and `test/blackbox/` (including
`MemeticExportSingleClone.ts`, `CreatureSerialization.ts`,
`test/architecture/ExportSchemaValidation.ts` against the updated
`docs/snapshot-schema.json`).



## Milestone
This PR is part of the **Scan 20260807** milestone and targets the `milestone/scan-20260807` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mskd5y7z-a441e2`<!-- vibe-worker-issue-3682 -->