### PR TITLE
Stop deno-outdated.yml persisting the job token (Issue #3683)

### DIFF
--- a/.github/workflows/deno-outdated.yml
+++ b/.github/workflows/deno-outdated.yml
@@ -28,6 +28,13 @@ jobs:
       - name: Checkout
         # actions/checkout@v6.0.2
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          # No step pushes over the checkout credential — create-pull-request
+          # authenticates with its own token: input — so the token need not be
+          # persisted to .git/config, where the following `deno outdated` step
+          # (which resolves third-party registry metadata) could read it
+          # (Issue #3683).
+          persist-credentials: false
 
       - name: Setup Deno
         # denoland/setup-deno@v2.0.4

--- a/docs/archive/pr-summaries/pr-summary-3683.md
+++ b/docs/archive/pr-summaries/pr-summary-3683.md
@@ -1,0 +1,74 @@
+# PR Summary — Issue #3683
+
+## Summary
+
+`.github/workflows/deno-outdated.yml` held the last `actions/checkout` in the
+repository that did not set `persist-credentials: false`. Without the flag,
+`actions/checkout` writes the job token into `.git/config` as an
+`http.extraheader`, where any later step in the job can read it. That is a poor
+place to leave a credential here: the job grants `contents: write` **and**
+`pull-requests: write`, the very next step runs
+`deno outdated --update --latest --minimum-dependency-age=…` (which resolves
+third-party JSR/npm metadata from registries this repo does not control), and
+the job also holds `secrets.ACTIONS_PUSH`, an org-level PAT.
+
+The change is a functional no-op: no step in the job pushes over the persisted
+credential — `peter-evans/create-pull-request` authenticates with its own
+`token:` input.
+
+A repo-wide sweep test was added alongside the existing per-workflow assertions
+so a newly added workflow cannot reintroduce credential persistence without a
+matching test. Closes #3683.
+
+## Evidence
+
+Backend/CI-only change — no web interface to screenshot. Evidence is the test
+sweep.
+
+Before the fix, the new sweep test failed with exactly one offender:
+
+```text
+error: AssertionError: Values are not equal: every actions/checkout must set
+persist-credentials: false … Offending checkouts:
+  deno-outdated.yml job "outdated" step "Checkout"
+```
+
+After the fix, all 19 `actions/checkout` steps across the 15 workflows carry the
+flag:
+
+```text
+deno test --allow-read test/ci/WorkflowPersistCredentialsFalse.ts
+ok | 13 passed | 0 failed (9ms)
+```
+
+Note the issue text estimated 18 checkouts; the actual parsed count is 19 — the
+sweep test asserts "no offenders" rather than a hard-coded total, so it does not
+rot as workflows are added or removed.
+
+Where the token used to land, and where it no longer does:
+
+```mermaid
+flowchart TD
+    CO["actions/checkout"] -->|"persist-credentials: true (was)"| GC[".git/config<br/>http.extraheader = job token"]
+    CO -->|"persist-credentials: false (now)"| NOGC["no credential on disk"]
+    GC -.->|"readable by"| DO["deno outdated<br/>resolves third-party<br/>JSR / npm metadata"]
+    DO --> CPR["create-pull-request<br/>authenticates via its own token: input"]
+    NOGC --> DO2["deno outdated"] --> CPR
+```
+
+## Test Plan
+
+- Added `test/ci/WorkflowPersistCredentialsFalse.ts` →
+  `workflow-conventions: every actions/checkout sets persist-credentials: false (Issue #3683)`.
+  It parses every `.github/workflows/*.y*ml` file, collects each
+  `actions/checkout` step across all jobs, and fails with a named list of any
+  step lacking `persist-credentials: false`. Written test-first: it failed on
+  `deno-outdated.yml` before the workflow change and passes after.
+- Existing per-workflow assertions in the same file (Issues #2727, #3349–#3358)
+  are unchanged and still pass.
+- `./quality.sh --skip-wasm --skip-discovery` — lint, format, type-check and the
+  full suite pass (8184 tests). An earlier run of the same gate flaked on two
+  unrelated tests (`test/upgrade/PopulateFixForwardOnly.ts`,
+  `test/score/RustScorerIntegration.ts`); both pass in isolation and passed on
+  the re-run, and neither is reachable from this change, which touches only a
+  YAML workflow and a filesystem-reading CI test.

--- a/test/ci/WorkflowPersistCredentialsFalse.ts
+++ b/test/ci/WorkflowPersistCredentialsFalse.ts
@@ -361,6 +361,72 @@ Deno.test(
   },
 );
 
+/**
+ * Issue #3683 — repo-wide sweep. The per-workflow tests above each pin one
+ * known job; this one closes the gap they leave, so a newly added workflow
+ * cannot reintroduce credential persistence without a matching test.
+ *
+ * Every `actions/checkout` step in `.github/workflows/` must set
+ * `persist-credentials: false`. No workflow in this repo pushes over the
+ * checkout credential — the two that do push (`quality.yml`,
+ * `update-package-version.yml`) re-introduce `secrets.ACTIONS_PUSH` via a
+ * per-command `http.<url>.extraheader`, and `deno-outdated.yml` lets
+ * `peter-evans/create-pull-request` authenticate with its own `token:` input.
+ */
+Deno.test(
+  "workflow-conventions: every actions/checkout sets persist-credentials: false (Issue #3683)",
+  async () => {
+    const offenders: string[] = [];
+    let checkoutCount = 0;
+
+    const workflowDir = join(REPO_ROOT, ".github/workflows");
+    const fileNames: string[] = [];
+    for await (const entry of Deno.readDir(workflowDir)) {
+      if (entry.isFile && /\.ya?ml$/.test(entry.name)) {
+        fileNames.push(entry.name);
+      }
+    }
+    fileNames.sort();
+
+    assert(
+      fileNames.length > 0,
+      "expected at least one workflow under .github/workflows/",
+    );
+
+    const workflows = await Promise.all(
+      fileNames.map((fileName) =>
+        readWorkflow(`.github/workflows/${fileName}`)
+      ),
+    );
+
+    for (const [index, wf] of workflows.entries()) {
+      const fileName = fileNames[index];
+      for (const [jobName, job] of Object.entries(wf.jobs ?? {})) {
+        for (const step of job.steps ?? []) {
+          if (!isCheckoutStep(step)) continue;
+          checkoutCount++;
+          if (step.with?.["persist-credentials"] === false) continue;
+          offenders.push(
+            `${fileName} job "${jobName}" step "${step.name ?? "<unnamed>"}"`,
+          );
+        }
+      }
+    }
+
+    assert(
+      checkoutCount > 0,
+      "expected at least one actions/checkout step across the workflows",
+    );
+    assertEquals(
+      offenders,
+      [],
+      "every actions/checkout must set persist-credentials: false so the job " +
+        "token is never written to .git/config where a later step could read " +
+        `it. Offending checkouts:\n  ${offenders.join("\n  ")}`,
+    );
+  },
+);
+
 function isGitPushStep(step: Step): boolean {
   if (typeof step.run !== "string") return false;
   return /\bgit\b/.test(step.run) && /\bpush\s+origin\b/.test(step.run);


### PR DESCRIPTION
# PR Summary — Issue #3683

## Summary

`.github/workflows/deno-outdated.yml` held the last `actions/checkout` in the
repository that did not set `persist-credentials: ***REDACTED*** Without the flag,
`actions/checkout` writes the job token into `.git/config` as an
`http.extraheader`, where any later step in the job can read it. That is a poor
place to leave a credential here: the job grants `contents: write` **and**
`pull-requests: write`, the very next step runs
`deno outdated --update --latest --minimum-dependency-age=…` (which resolves
third-party JSR/npm metadata from registries this repo does not control), and
the job also holds `secrets.ACTIONS_PUSH`, an org-level PAT.

The change is a functional no-op: no step in the job pushes over the persisted
credential — `peter-evans/create-pull-request` authenticates with its own
`token:***REDACTED*** input.

A repo-wide sweep test was added alongside the existing per-workflow assertions
so a newly added workflow cannot reintroduce credential persistence without a
matching test. Closes #3683.

## Evidence

Backend/CI-only change — no web interface to screenshot. Evidence is the test
sweep.

Before the fix, the new sweep test failed with exactly one offender:

```text
error: AssertionError: Values are not equal: every actions/checkout must set
persist-credentials: ***REDACTED*** … Offending checkouts:
  deno-outdated.yml job "outdated" step "Checkout"
```

After the fix, all 19 `actions/checkout` steps across the 15 workflows carry the
flag:

```text
deno test --allow-read test/ci/WorkflowPersistCredentialsFalse.ts
ok | 13 passed | 0 failed (9ms)
```

Note the issue text estimated 18 checkouts; the actual parsed count is 19 — the
sweep test asserts "no offenders" rather than a hard-coded total, so it does not
rot as workflows are added or removed.

Where the token used to land, and where it no longer does:

```mermaid
flowchart TD
    CO["actions/checkout"] -->|"persist-credentials: ***REDACTED*** (was)"| GC[".git/config<br/>http.extraheader = job token"]
    CO -->|"persist-credentials: ***REDACTED*** (now)"| NOGC["no credential on disk"]
    GC -.->|"readable by"| DO["deno outdated<br/>resolves third-party<br/>JSR / npm metadata"]
    DO --> CPR["create-pull-request<br/>authenticates via its own token: ***REDACTED***
    NOGC --> DO2["deno outdated"] --> CPR
```

## Test Plan

- Added `test/ci/WorkflowPersistCredentialsFalse.ts` →
  `workflow-conventions: every actions/checkout sets persist-credentials: ***REDACTED*** (Issue #3683)`.
  It parses every `.github/workflows/*.y*ml` file, collects each
  `actions/checkout` step across all jobs, and fails with a named list of any
  step lacking `persist-credentials: ***REDACTED*** Written test-first: it failed on
  `deno-outdated.yml` before the workflow change and passes after.
- Existing per-workflow assertions in the same file (Issues #2727, #3349–#3358)
  are unchanged and still pass.
- `./quality.sh --skip-wasm --skip-discovery` — lint, format, type-check and the
  full suite pass (8184 tests). An earlier run of the same gate flaked on two
  unrelated tests (`test/upgrade/PopulateFixForwardOnly.ts`,
  `test/score/RustScorerIntegration.ts`); both pass in isolation and passed on
  the re-run, and neither is reachable from this change, which touches only a
  YAML workflow and a filesystem-reading CI test.



## Milestone
This PR is part of the **Scan 20260807** milestone and targets the `milestone/scan-20260807` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mskd5y7z-a441e2`<!-- vibe-worker-issue-3683 -->