### PR TITLE
🟢 Unvalidated `deno.json` version echoed into `$GITHUB_OUTPUT` allows step-output injection in a `contents: write` job (.github/workflows/github-release.yml:36) (Issue #3684)

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -34,6 +34,17 @@ jobs:
         run: |
           set -Eeuo pipefail
           VERSION=$(jq -r .version deno.json)
+          # deno.json is outside the CODEOWNERS gate (Issue #3669), so its
+          # `version` is untrusted here. $GITHUB_OUTPUT is a line-oriented
+          # key=value file: a newline in the value injects extra step outputs
+          # into a job holding contents: write, which controls the tag and
+          # release created below (Issue #3684). Accept only a plain semver
+          # token, and do not echo the rejected value back — that would be a
+          # second injection point, into the workflow-command stream.
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::deno.json version is not a plain semver token; refusing to write step output" >&2
+            exit 1
+          fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub Release

--- a/.github/workflows/update-package-version.yml
+++ b/.github/workflows/update-package-version.yml
@@ -71,6 +71,13 @@ jobs:
             echo "Could not determine base version, skipping update"
             echo "needs_update=false" >> "$GITHUB_OUTPUT"
           elif [ "$CURRENT_VERSION" = "$BASE_VERSION" ]; then
+            # Same guard as github-release.yml: deno.json is outside the
+            # CODEOWNERS gate, and $GITHUB_OUTPUT is line-oriented, so a
+            # newline in the version injects extra step outputs (Issue #3684).
+            if [[ ! "$BASE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
+              echo "::error::deno.json version is not a plain semver token; refusing to write step output" >&2
+              exit 1
+            fi
             echo "Version unchanged, will update patch version"
             echo "needs_update=true" >> "$GITHUB_OUTPUT"
             echo "base_version=$BASE_VERSION" >> "$GITHUB_OUTPUT"

--- a/docs/archive/pr-summaries/pr-summary-3684.md
+++ b/docs/archive/pr-summaries/pr-summary-3684.md
@@ -1,0 +1,78 @@
+# Validate `deno.json`'s version before it reaches `$GITHUB_OUTPUT` (Issue #3684)
+
+## Summary
+
+`.github/workflows/github-release.yml` read `version` out of `deno.json` and
+echoed it straight into `$GITHUB_OUTPUT`. That file is line-oriented
+`key=value`, so a `version` containing a newline injects arbitrary extra step
+outputs — in a job holding `contents: write`, whose next step consumes
+`steps.version.outputs.version` as the release `tag_name` and `name`.
+`deno.json` sits outside the CODEOWNERS gate (Issue #3669), so the edit that
+carries the newline is not force-reviewed.
+
+Both steps that echo a `deno.json`-derived version into `$GITHUB_OUTPUT` now
+reject anything that is not a plain semver token before writing:
+
+- `github-release.yml` → the `version` step (`version=`).
+- `update-package-version.yml` → the `check_version` step (`base_version=`),
+  which derives its value from the base branch's `deno.json` the same way.
+
+The guard fails the step loudly with a `::error::` annotation and writes **no**
+step output. It deliberately does not echo the rejected value back — a newline
+in an annotation is a second injection point, into the workflow-command stream.
+
+`publish.yml` was checked as the issue asks: it reads `.version` from
+`deno.json`, but only ever writes the literals `publish=true` / `publish=false`
+to `$GITHUB_OUTPUT`, so it does not carry this injection and is unchanged.
+
+Closes #3684.
+
+## Evidence
+
+Backend/CI-only change — no web surface to screenshot. The evidence is the new
+test suite, which executes the committed run blocks rather than inspecting them.
+
+```mermaid
+flowchart LR
+    A[deno.json version] --> B{semver token?}
+    B -- no --> C["::error:: + exit 1<br/>nothing written"]
+    B -- yes --> D["version=… → $GITHUB_OUTPUT"]
+    D --> E["tag_name: v… (contents: write)"]
+```
+
+`test/ci/WorkflowVersionOutputInjection.ts` parses each workflow, pulls out the
+real `run:` block by step id, and runs it under `bash` in a temp directory with
+a crafted `deno.json` and a throwaway `$GITHUB_OUTPUT`, asserting on the exit
+code and on the exact bytes the step wrote. `update-package-version.yml`'s step
+shells out to `git` and `deno`, so both are stubbed on `PATH` to drive the base
+and current version values.
+
+Against the unfixed workflows, 8 of the 16 cases fail; with the guard in place
+all 16 pass, alongside the 2 existing `WorkflowVersionCheckStrictMode.ts` cases
+that pin `set -Eeuo pipefail` (Issue #3003) in the same block:
+
+```text
+ok | 254 passed | 0 failed (2s)   # deno test "test/ci/*.ts"
+actionlint .github/workflows/github-release.yml .github/workflows/update-package-version.yml → clean
+```
+
+## Test Plan
+
+New file `test/ci/WorkflowVersionOutputInjection.ts`:
+
+- **Rejects (regression cases for #3684)** — `github-release.yml`: a
+  newline-injected version (`1.2.3\nevil=pwned`), shell-significant characters
+  (`1.2.3; touch pwned`), a command substitution (`$(touch pwned)`), an absent
+  `version` field, an empty version, `latest`, and `1.2`. Each asserts a
+  non-zero exit, an empty `$GITHUB_OUTPUT`, and — for the injection cases — that
+  no `pwned` file was created.
+- **Still works** — the repository's own current version, plus `1.2.3`, `0.0.0`,
+  `10.20.30-rc.1` and `1.2.3+build.5`, each producing exactly
+  `version=<value>\n`.
+- **`update-package-version.yml`** — an unchanged semver emits
+  `needs_update=true` + `base_version=1.2.3`; a newline-injected base version
+  fails with no output written; an unknown base version and an already-bumped PR
+  version both still emit `needs_update=false`.
+
+Unchanged: `test/ci/WorkflowVersionCheckStrictMode.ts` still passes, so `-E` in
+`set -Eeuo pipefail` remains pinned.

--- a/test/ci/WorkflowVersionOutputInjection.ts
+++ b/test/ci/WorkflowVersionOutputInjection.ts
@@ -1,0 +1,305 @@
+/**
+ * Issue #3684 — the workflow steps that read `deno.json`'s `version` and echo
+ * it into `$GITHUB_OUTPUT` must validate the value first.
+ *
+ * `$GITHUB_OUTPUT` is a line-oriented `key=value` file. `deno.json` sits
+ * outside the CODEOWNERS gate (Issue #3669), so a merged commit can put a
+ * newline into `version`, and an unvalidated `echo "version=$VERSION"` then
+ * injects arbitrary extra step outputs. In `github-release.yml` those outputs
+ * feed `tag_name`/`name` of the release in a job holding `contents: write`.
+ *
+ * These tests execute the committed run blocks themselves under `bash`, with a
+ * crafted `deno.json` and a throwaway `$GITHUB_OUTPUT`, and assert on the exit
+ * code and on the bytes the step actually wrote. Deleting or weakening the
+ * guard turns them red.
+ */
+
+import { assert, assertEquals, assertStringIncludes } from "@std/assert";
+import { fromFileUrl, join } from "@std/path";
+import { parse } from "@std/yaml";
+
+const REPO_ROOT = fromFileUrl(new URL("../../", import.meta.url));
+const RELEASE_WORKFLOW = ".github/workflows/github-release.yml";
+const VERSION_BUMP_WORKFLOW = ".github/workflows/update-package-version.yml";
+
+interface Step {
+  id?: string;
+  run?: string;
+}
+
+interface Job {
+  steps?: Step[];
+}
+
+interface Workflow {
+  jobs?: Record<string, Job>;
+}
+
+/** The `run:` script of the step with the given `id`, as committed. */
+async function stepRunBlock(relPath: string, stepId: string): Promise<string> {
+  const wf = parse(
+    await Deno.readTextFile(join(REPO_ROOT, relPath)),
+  ) as Workflow;
+  for (const job of Object.values(wf.jobs ?? {})) {
+    for (const step of job.steps ?? []) {
+      if (step.id !== stepId) continue;
+      assert(
+        typeof step.run === "string",
+        `${relPath} step "${stepId}" has no run: block`,
+      );
+      return step.run;
+    }
+  }
+  throw new Error(`${relPath} has no step with id "${stepId}"`);
+}
+
+interface StepResult {
+  code: number;
+  stderr: string;
+  /** Raw contents of the step's `$GITHUB_OUTPUT` file. */
+  outputs: string;
+}
+
+/** Run a workflow shell block in `cwd` with a scratch `$GITHUB_OUTPUT`. */
+async function runStep(
+  run: string,
+  cwd: string,
+  env: Record<string, string> = {},
+): Promise<StepResult> {
+  const outputPath = join(cwd, "github_output");
+  await Deno.writeTextFile(outputPath, "");
+  const { code, stderr } = await new Deno.Command("bash", {
+    args: ["-c", run],
+    cwd,
+    clearEnv: true,
+    env: {
+      PATH: Deno.env.get("PATH") ?? "/usr/bin:/bin",
+      HOME: cwd,
+      GITHUB_OUTPUT: outputPath,
+      ...env,
+    },
+    stdout: "null",
+    stderr: "piped",
+  }).output();
+  return {
+    code,
+    stderr: new TextDecoder().decode(stderr),
+    outputs: await Deno.readTextFile(outputPath),
+  };
+}
+
+async function withTempDir<T>(fn: (dir: string) => Promise<T>): Promise<T> {
+  const dir = await Deno.makeTempDir({ prefix: "issue3684-" });
+  try {
+    return await fn(dir);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+}
+
+/** Run `github-release.yml`'s version step against a crafted `deno.json`. */
+async function runReleaseVersionStep(
+  denoJson: Record<string, unknown>,
+  inspect: (result: StepResult, cwd: string) => Promise<void> | void,
+): Promise<void> {
+  const run = await stepRunBlock(RELEASE_WORKFLOW, "version");
+  await withTempDir(async (cwd) => {
+    await Deno.writeTextFile(
+      join(cwd, "deno.json"),
+      JSON.stringify(denoJson),
+    );
+    await inspect(await runStep(run, cwd), cwd);
+  });
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await Deno.lstat(path);
+    return true;
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) return false;
+    throw error;
+  }
+}
+
+Deno.test(
+  "github-release version step emits the repository's real version (Issue #3684)",
+  async () => {
+    const repoVersion = JSON.parse(
+      await Deno.readTextFile(join(REPO_ROOT, "deno.json")),
+    ).version;
+    await runReleaseVersionStep({ version: repoVersion }, (result) => {
+      assertEquals(result.code, 0, result.stderr);
+      assertEquals(result.outputs, `version=${repoVersion}\n`);
+    });
+  },
+);
+
+for (const version of ["1.2.3", "0.0.0", "10.20.30-rc.1", "1.2.3+build.5"]) {
+  Deno.test(
+    `github-release version step accepts semver "${version}" (Issue #3684)`,
+    async () => {
+      await runReleaseVersionStep({ version }, (result) => {
+        assertEquals(result.code, 0, result.stderr);
+        assertEquals(result.outputs, `version=${version}\n`);
+      });
+    },
+  );
+}
+
+Deno.test(
+  "github-release version step refuses a newline-injected version (Issue #3684)",
+  async () => {
+    await runReleaseVersionStep(
+      { version: "1.2.3\nevil=pwned" },
+      (result) => {
+        assert(
+          result.code !== 0,
+          "a version containing a newline must fail the step",
+        );
+        assertEquals(
+          result.outputs,
+          "",
+          "no step output may be written for a rejected version",
+        );
+        assertStringIncludes(result.stderr, "::error::");
+      },
+    );
+  },
+);
+
+Deno.test(
+  "github-release version step refuses shell-significant characters (Issue #3684)",
+  async () => {
+    await runReleaseVersionStep(
+      { version: "1.2.3; touch pwned" },
+      async (result, cwd) => {
+        assert(result.code !== 0, "a version with `;` must fail the step");
+        assertEquals(result.outputs, "");
+        assertEquals(
+          await exists(join(cwd, "pwned")),
+          false,
+          "the rejected version must not reach a shell as code",
+        );
+      },
+    );
+  },
+);
+
+Deno.test(
+  "github-release version step refuses a command substitution (Issue #3684)",
+  async () => {
+    await runReleaseVersionStep(
+      { version: "$(touch pwned)" },
+      async (result, cwd) => {
+        assert(result.code !== 0, "a `$(...)` version must fail the step");
+        assertEquals(result.outputs, "");
+        assertEquals(await exists(join(cwd, "pwned")), false);
+      },
+    );
+  },
+);
+
+for (
+  const [label, denoJson] of [
+    ["an absent version field", {}],
+    ["an empty version", { version: "" }],
+    ["a non-semver version", { version: "latest" }],
+    ["a two-part version", { version: "1.2" }],
+  ] as const
+) {
+  Deno.test(
+    `github-release version step refuses ${label} (Issue #3684)`,
+    async () => {
+      await runReleaseVersionStep(denoJson, (result) => {
+        assert(result.code !== 0, `${label} must fail the step`);
+        assertEquals(result.outputs, "");
+      });
+    },
+  );
+}
+
+/**
+ * `update-package-version.yml`'s `check_version` step derives `BASE_VERSION`
+ * from the base branch's `deno.json` and echoes it into `$GITHUB_OUTPUT` the
+ * same way, so it carries the same injection. The step shells out to `git` and
+ * `deno`; both are stubbed on `PATH` so the test drives the two version values
+ * directly.
+ */
+async function runCheckVersionStep(
+  baseVersion: string,
+  currentVersion: string,
+): Promise<StepResult> {
+  const run = await stepRunBlock(VERSION_BUMP_WORKFLOW, "check_version");
+  return await withTempDir(async (cwd) => {
+    const bin = join(cwd, "bin");
+    await Deno.mkdir(bin);
+    await Deno.writeTextFile(
+      join(bin, "git"),
+      "#!/usr/bin/env bash\nexit 0\n",
+    );
+    // The step runs `deno eval` twice: once for the base version (a script
+    // naming /tmp/base_deno.json) and once for the current version.
+    await Deno.writeTextFile(
+      join(bin, "deno"),
+      "#!/usr/bin/env bash\n" +
+        'if [[ "$*" == */tmp/base_deno.json* ]]; then\n' +
+        '  printf "%s\\n" "$STUB_BASE_VERSION"\n' +
+        "else\n" +
+        '  printf "%s\\n" "$STUB_CURRENT_VERSION"\n' +
+        "fi\n",
+    );
+    await Deno.chmod(join(bin, "git"), 0o755);
+    await Deno.chmod(join(bin, "deno"), 0o755);
+    return await runStep(run, cwd, {
+      PATH: `${bin}:${Deno.env.get("PATH") ?? "/usr/bin:/bin"}`,
+      BASE_REF: "Develop",
+      STUB_BASE_VERSION: baseVersion,
+      STUB_CURRENT_VERSION: currentVersion,
+    });
+  });
+}
+
+Deno.test(
+  "update-package-version emits base_version for an unchanged semver (Issue #3684)",
+  async () => {
+    const result = await runCheckVersionStep("1.2.3", "1.2.3");
+    assertEquals(result.code, 0, result.stderr);
+    assertEquals(result.outputs, "needs_update=true\nbase_version=1.2.3\n");
+  },
+);
+
+Deno.test(
+  "update-package-version refuses a newline-injected base version (Issue #3684)",
+  async () => {
+    const result = await runCheckVersionStep(
+      "1.2.3\nevil=pwned",
+      "1.2.3\nevil=pwned",
+    );
+    assert(result.code !== 0, "an injected base version must fail the step");
+    assertEquals(
+      result.outputs,
+      "",
+      "no step output may be written for a rejected base version",
+    );
+    assertStringIncludes(result.stderr, "::error::");
+  },
+);
+
+Deno.test(
+  "update-package-version still skips when the base version is unknown (Issue #3684)",
+  async () => {
+    const result = await runCheckVersionStep("", "1.2.3");
+    assertEquals(result.code, 0, result.stderr);
+    assertEquals(result.outputs, "needs_update=false\n");
+  },
+);
+
+Deno.test(
+  "update-package-version still skips when the PR already bumped the version (Issue #3684)",
+  async () => {
+    const result = await runCheckVersionStep("1.2.3", "1.2.4");
+    assertEquals(result.code, 0, result.stderr);
+    assertEquals(result.outputs, "needs_update=false\n");
+  },
+);


### PR DESCRIPTION
# Validate `deno.json`'s version before it reaches `$GITHUB_OUTPUT` (Issue #3684)

## Summary

`.github/workflows/github-release.yml` read `version` out of `deno.json` and
echoed it straight into `$GITHUB_OUTPUT`. That file is line-oriented
`key=value`, so a `version` containing a newline injects arbitrary extra step
outputs — in a job holding `contents: write`, whose next step consumes
`steps.version.outputs.version` as the release `tag_name` and `name`.
`deno.json` sits outside the CODEOWNERS gate (Issue #3669), so the edit that
carries the newline is not force-reviewed.

Both steps that echo a `deno.json`-derived version into `$GITHUB_OUTPUT` now
reject anything that is not a plain semver token before writing:

- `github-release.yml` → the `version` step (`version=`).
- `update-package-version.yml` → the `check_version` step (`base_version=`),
  which derives its value from the base branch's `deno.json` the same way.

The guard fails the step loudly with a `::error::` annotation and writes **no**
step output. It deliberately does not echo the rejected value back — a newline
in an annotation is a second injection point, into the workflow-command stream.

`publish.yml` was checked as the issue asks: it reads `.version` from
`deno.json`, but only ever writes the literals `publish=true` / `publish=false`
to `$GITHUB_OUTPUT`, so it does not carry this injection and is unchanged.

Closes #3684.

## Evidence

Backend/CI-only change — no web surface to screenshot. The evidence is the new
test suite, which executes the committed run blocks rather than inspecting them.

```mermaid
flowchart LR
    A[deno.json version] --> B{semver token?}
    B -- no --> C["::error:: + exit 1<br/>nothing written"]
    B -- yes --> D["version=… → $GITHUB_OUTPUT"]
    D --> E["tag_name: v… (contents: write)"]
```

`test/ci/WorkflowVersionOutputInjection.ts` parses each workflow, pulls out the
real `run:` block by step id, and runs it under `bash` in a temp directory with
a crafted `deno.json` and a throwaway `$GITHUB_OUTPUT`, asserting on the exit
code and on the exact bytes the step wrote. `update-package-version.yml`'s step
shells out to `git` and `deno`, so both are stubbed on `PATH` to drive the base
and current version values.

Against the unfixed workflows, 8 of the 16 cases fail; with the guard in place
all 16 pass, alongside the 2 existing `WorkflowVersionCheckStrictMode.ts` cases
that pin `set -Eeuo pipefail` (Issue #3003) in the same block:

```text
ok | 254 passed | 0 failed (2s)   # deno test "test/ci/*.ts"
actionlint .github/workflows/github-release.yml .github/workflows/update-package-version.yml → clean
```

## Test Plan

New file `test/ci/WorkflowVersionOutputInjection.ts`:

- **Rejects (regression cases for #3684)** — `github-release.yml`: a
  newline-injected version (`1.2.3\nevil=pwned`), shell-significant characters
  (`1.2.3; touch pwned`), a command substitution (`$(touch pwned)`), an absent
  `version` field, an empty version, `latest`, and `1.2`. Each asserts a
  non-zero exit, an empty `$GITHUB_OUTPUT`, and — for the injection cases — that
  no `pwned` file was created.
- **Still works** — the repository's own current version, plus `1.2.3`, `0.0.0`,
  `10.20.30-rc.1` and `1.2.3+build.5`, each producing exactly
  `version=<value>\n`.
- **`update-package-version.yml`** — an unchanged semver emits
  `needs_update=true` + `base_version=1.2.3`; a newline-injected base version
  fails with no output written; an unknown base version and an already-bumped PR
  version both still emit `needs_update=false`.

Unchanged: `test/ci/WorkflowVersionCheckStrictMode.ts` still passes, so `-E` in
`set -Eeuo pipefail` remains pinned.



## Milestone
This PR is part of the **Scan 20260807** milestone and targets the `milestone/scan-20260807` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mskfyyid-74b569`<!-- vibe-worker-issue-3684 -->