### PR TITLE
Finish the bounded security sweep: local-only worker import() specifiers, coverage ledger, findings filed (Issue #3685)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -47,6 +47,22 @@ opening a PR (see the secure-coding principles section of
   on all three. Security fixes are unaffected — Renovate exempts
   `vulnerabilityAlerts` from `minimumReleaseAge`, so an actively-exploited CVE
   still moves immediately.
+- **Local-only worker `import()` specifiers** (Issue #3685) — the two worker
+  entry points that dynamically import caller-supplied code — the custom cost
+  function (`src/multithreading/workers/WorkerProcessor.ts`) and the RL episode
+  adapter (`src/creature/EpisodeWorkerProcessor.ts`) — run every specifier
+  through `assertLocalModuleSpecifier()` (`src/utils/ModuleSpecifierGuard.ts`)
+  first. Only relative paths, absolute filesystem paths, and `file:` URLs load;
+  `https:`, `http:`, `data:`, `blob:`, `jsr:` and `npm:` are rejected before
+  `import()` runs. Both values are developer configuration today, but neither
+  type nor call graph prevented one arriving from a remote manifest — an
+  experiment description or shared job spec — which would have made remote code
+  executable inside a worker. The guard removes that path rather than relying on
+  the trust argument holding.
+- **Periodic trust-boundary sweep** — coverage per source directory, and the
+  disposition of each swept area, is recorded in
+  [`docs/SECURITY_SWEEP_COVERAGE.md`](./docs/SECURITY_SWEEP_COVERAGE.md) so a
+  later sweep does not re-audit ground already cleared.
 - **Code-owner review of the CI/CD surface** — `.github/CODEOWNERS` requires a
   review from the maintaining team (`@stSoftwareAU/developers`) on any PR that
   edits `.github/workflows/` or `.github/actions/`. Several workflows run with

--- a/docs/README.md
+++ b/docs/README.md
@@ -195,6 +195,9 @@ Project-level policies, audits, and release plumbing.
   contributors (terminology, invariants, testing rules).
 - **[../CONTRIBUTING.md](../CONTRIBUTING.md)** — first-time contributor guide.
 - **[../SECURITY.md](../SECURITY.md)** — security disclosure policy.
+- **[SECURITY_SWEEP_COVERAGE.md](SECURITY_SWEEP_COVERAGE.md)** — which `src/`
+  directories the periodic trust-boundary sweep has audited, and what each pass
+  concluded (Issue #3685).
 - **[REPO_GOVERNANCE.md](REPO_GOVERNANCE.md)** — CI/CD code ownership
   (`.github/CODEOWNERS`) and required branch-protection settings that guard the
   privileged workflows (Issue #3187).

--- a/docs/SECURITY_SWEEP_COVERAGE.md
+++ b/docs/SECURITY_SWEEP_COVERAGE.md
@@ -1,0 +1,178 @@
+# 🔍 Security sweep coverage
+
+This page records which `src/` directories the periodic **trust-boundary sweep**
+has audited, and what each pass concluded. It exists so a later sweep does not
+re-audit ground already cleared — a directory listed here as **clean** was read
+in full under the lens below and needs re-reading only when it changes
+materially.
+
+It is a coverage ledger, not a vulnerability register. Confirmed findings are
+filed as individual GitHub issues and linked from the table; the disclosure
+process for anything found outside this sweep is in
+[`SECURITY.md`](../SECURITY.md).
+
+## 🔬 The lens
+
+Every swept directory is read against the same three questions:
+
+1. **Untrusted input → dangerous sink.** Untrusted input is anything
+   deserialised from a model/creature JSON file, a dataset file on disk, or a
+   network fetch, plus any caller-supplied string that could originate outside
+   the developer's own code. Dangerous sinks are filesystem path construction,
+   `Deno.run` / `Deno.Command`, `eval` / `new Function` / dynamic `import()`,
+   shell strings, and log injection.
+2. **Unbounded allocation or recursion** driven by an externally-supplied value
+   — an allocation size, loop bound, or recursion depth taken straight from
+   parsed file data with no cap.
+3. **Privileged CI context** — anything reading secrets or env, or writing
+   somewhere a CI job trusts.
+
+A value that can only come from developer-written code in-process is **not** a
+finding, but each pass records what it considered and dismissed so the next
+sweep does not relitigate it.
+
+## 📋 Coverage
+
+| Area                                           | Pass                           | Disposition                                                                                                                                                  |
+| ---------------------------------------------- | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `src/wasm/`, `.github/workflows/`, and friends | #3673 (`vibe-msi7zknu-e4a289`) | Findings filed as #3667–#3672; residue tracked on #3673.                                                                                                     |
+| `src/predictiveCoding/`                        | #3685                          | **Clean** — see below.                                                                                                                                       |
+| `src/transfer/`                                | #3685                          | **Finding** → #3714 (unbounded allocation at the checkpoint deserialisation boundary).                                                                       |
+| `src/intelligentDesign/` (incl. `workers/`)    | #3685                          | **Finding** → #3715 (path traversal from an unvalidated neuron `uuid`).                                                                                      |
+| `src/onnx/`                                    | #3685                          | **Clean** — see below. Completes the partial coverage from #3673, which confirmed the absence of an importer but did not read the encoders.                  |
+| `src/multithreading/` worker `import()`        | #3685                          | **Resolved in-tree** — scheme allowlist added; see below.                                                                                                    |
+| `bench/`, `test/`                              | —                              | Deliberately out of scope. Neither ships to consumers, and neither processes untrusted input in production. Include only if a future finding gives a reason. |
+
+## ✅ Cleared areas
+
+### `src/predictiveCoding/` — clean (#3685)
+
+All six files read in full. The directory contains no `Deno.env`, `Deno.Command`
+/ `Deno.run`, `eval`, `new Function`, or dynamic `import()`.
+
+The only dangerous-sink surface is `PredictiveCodingTrainer.ts:139`
+(`Deno.openSync`), whose path is a caller-supplied `string[]` parameter never
+concatenated from parsed data — there is no traversal primitive because no
+segment is joined in from file content.
+
+Allocations were traced to their bounds. `PredictiveCodingTrainer.ts:114-121`
+sizes buffers from `creature.input + creature.output`, which _is_ model-derived,
+but `Creature.fromJSON` hoists `assertValidCreatureShape` (cap
+`MAX_NEURON_COUNT = 1_000_000`, Issue #3672) ahead of any load work, so the
+worst case is a bounded buffer. `PredictiveCodingInference.ts:79/115/164`
+allocate from the already-materialised neuron array, not a raw JSON scalar.
+`config.inferenceSteps` and `options.iterations` are developer-supplied
+in-process. There is no recursion in the directory.
+
+Considered and dismissed: `neuron.squash` is a raw string from creature JSON and
+reaches `Activations.find()` at `PredictionErrorComputation.ts:59`,
+`PredictiveCodingInference.ts:119`, and `PredictiveCodingLearning.ts:112`.
+Activation names _do_ eventually reach `new Function()` bodies in the activation
+compilers, but `Activations.find`
+(`src/methods/activations/Activations.ts:108-113`) resolves against a fixed
+registry and throws `ActivationError` on an unknown name, so no
+attacker-controlled string reaches a compiler on this path.
+
+### `src/onnx/` — clean (#3685)
+
+All five files read in full, with the encoders (`ProtobufEncoder.ts`,
+`OnnxExport.ts`, `OnnxModel.ts`, `ActivationMapping.ts`) as the focus, since
+#3673 had confirmed only the absence of an importer.
+
+**No path construction, because there is no I/O.** The export path performs zero
+filesystem and zero network operations — `exportToOnnx` returns a `Uint8Array`
+and leaves persistence to the caller. There is no write sink to traverse into.
+
+**Creature-supplied names never reach any identifier.** Every ONNX name is
+derived from integer array indices, not from neuron names, uuids, or tags:
+`OnnxExport.ts:120-123`, `:151`, `:169-170`, `:184`, `:199`, `:211-212`.
+Constant names are matched against a fixed allow-list (`OnnxExport.ts:274-289`),
+so an unrecognised name is dropped rather than propagated. The only
+creature-derived values reaching the encoder are `neuron.bias` and
+`synapse.weight`, both written as floats. The single free-form string,
+`options.graphName`, lands only in a protobuf string field (`OnnxModel.ts:232`).
+
+**Allocation is bounded.** Every size derives from an array already materialised
+in memory, never from a count parsed out of a file: `ProtobufEncoder.ts:118` and
+`:136` are driven by accumulated chunk lengths, and the export loops are bounded
+by `creature.input`, `creature.neurons.length`, `inwardConnections(i).length`,
+and `creature.output`. `writeVarint` (`ProtobufEncoder.ts:29-43`) is the only
+value-driven loop; it terminates in at most ten iterations and is only ever fed
+enum constants and hard-coded dimensions. There is no recursion — message
+nesting depth is fixed by the schema shape in code.
+
+## 🔐 Resolved: worker `import()` scheme (#3685)
+
+#3673 flagged `WorkerProcessor.ts:117` and `EpisodeWorkerProcessor.ts:127` as
+taking a caller-supplied module specifier for `await import()` with no scheme
+restriction, and deferred the judgement. **Resolved by adding the allowlist**
+rather than by writing down a trust argument.
+
+The trust argument was available — both values are developer configuration today
+— but it is not durable. Neither the type (`AdapterDescription.url: string`,
+`customCost.filePath: string`) nor the call graph prevents a value arriving from
+a remote manifest such as a downloaded experiment description or a shared job
+spec, and at that point an `https:` or `data:` specifier executes attacker code
+inside the worker. Documenting "this can never come from an untrusted source"
+would have been a claim the code does not enforce.
+
+`assertLocalModuleSpecifier()` (`src/utils/ModuleSpecifierGuard.ts`) now runs
+before either `import()`. Relative paths, absolute filesystem paths (including
+Windows drive letters), and `file:` URLs load; every other scheme — `https:`,
+`http:`, `data:`, `blob:`, `jsr:`, `npm:` — is rejected with a `ValidationError`
+naming the scheme.
+
+```mermaid
+flowchart LR
+    A[Caller config<br/>custom cost / RL adapter] --> B{assertLocalModuleSpecifier}
+    B -- "relative · absolute · file:" --> C["await import()"]
+    B -- "https: http: data:<br/>blob: jsr: npm:" --> D[ValidationError<br/>import never runs]
+```
+
+The two call sites differ in how the rejection surfaces, deliberately:
+
+- **Custom cost** (`WorkerProcessor.loadCustomCostFromFile`) — the guard sits
+  _outside_ the existing try/catch so the typed `ValidationError` reaches the
+  caller instead of being flattened into a generic load failure.
+- **Episode adapter** (`EpisodeWorkerProcessor.handleInit`) — the guard runs
+  first inside `handleInit`, ahead of WASM init, and the rejection travels back
+  over the worker protocol as `initialize: { status: "ERROR" }`, which is that
+  protocol's fail-loud channel.
+
+Regression cover: `test/utils/ModuleSpecifierGuard.ts` for the predicate, plus
+`test/multithreading/WorkerProcessor.ts` and
+`test/creature/EpisodeWorkerProcessorSpecifierGuard_test.ts`, which assert each
+call site rejects a remote specifier _before_ `import()` is invoked and still
+accepts a local one.
+
+## 📝 Observed, not filed
+
+Recorded so a later sweep recognises these as judged rather than missed.
+
+- **`src/transfer/PruningTemplate.ts:123`** — low. Fingerprint allocation is
+  `hiddenNeuronCount × probe.length × 4` bytes, and the same product drives the
+  scan at `:199-206`. Neither operand is capped and neither individually
+  reflects the product, so a large model plus a large probe multiplies out. Both
+  operands are already-materialised in-memory structures, making this
+  amplification rather than a raw unchecked scalar.
+- **Log injection from creature strings** — low. Unvalidated `uuid` / `squash`
+  values are interpolated into log lines with no newline escaping
+  (`ImproveSquash.ts:205-207`, `:421-424`, `:463-466`, `:523-531`;
+  `TacitKnowledge.ts:94-96`, `:159-163`, `:169-172`). A `uuid` containing a
+  newline forges log records. Relevant only where logs are machine-parsed; no
+  code execution. Captured on #3715 alongside the traversal in the same file.
+- **`src/wasm/WasmModuleLoader.ts:507`** — not a finding. This third
+  `await import()` takes a specifier built from a fixed literal relative to
+  `import.meta.url`, not from caller input, so the #3685 allowlist does not
+  apply to it.
+- **`src/intelligentDesign/workers/deno/worker.ts:20`** — not a finding. The
+  specifier is a hard-coded string literal with no interpolation.
+
+## 🔗 Sibling docs
+
+- **[../SECURITY.md](../SECURITY.md)** — vulnerability disclosure policy and the
+  in-repo security automation.
+- **[REPO_GOVERNANCE.md](REPO_GOVERNANCE.md)** — CI/CD code ownership and branch
+  protection.
+- **[../AGENTS.md](../AGENTS.md)** — coding conventions, including the
+  secure-coding principles this sweep applies.

--- a/docs/archive/pr-summaries/pr-summary-3685.md
+++ b/docs/archive/pr-summaries/pr-summary-3685.md
@@ -1,0 +1,114 @@
+# Finish the bounded security sweep (Issue #3685)
+
+## Summary
+
+Completes the `security-scan` sweep that #3673 left bounded by context rather
+than by a clean result. Closes #3685.
+
+Three things landed:
+
+1. **The `await import()` scheme question is resolved with a guard, not a trust
+   argument.** `WorkerProcessor.ts:117` and `EpisodeWorkerProcessor.ts:127` each
+   handed a caller-supplied module specifier straight to `await import()`. Both
+   values are developer configuration today, but neither the type
+   (`AdapterDescription.url: string`, `customCost.filePath: string`) nor the
+   call graph prevents one arriving from a remote manifest — a downloaded
+   experiment description or a shared job spec — at which point an `https:` or
+   `data:` specifier executes attacker code inside the worker. Writing down
+   "this can never come from an untrusted source" would have been a claim the
+   code does not enforce, so the allowlist went in instead.
+
+   New `assertLocalModuleSpecifier()` (`src/utils/ModuleSpecifierGuard.ts`) runs
+   before both imports. Relative paths, absolute filesystem paths (including
+   Windows drive letters), and `file:` URLs load; `https:`, `http:`, `data:`,
+   `blob:`, `jsr:`, and `npm:` are rejected with a `ValidationError` naming the
+   scheme.
+
+2. **The three unswept directories plus the ONNX encoders were audited.**
+   `src/predictiveCoding/` and `src/onnx/` came back clean; `src/transfer/` and
+   `src/intelligentDesign/` each produced one confirmed finding, filed as
+   individual issues with `file:line` evidence:
+
+   - **#3714** — `importCheckpoint()` uses the raw `checkpoint.creature.input` /
+     `.output` counts as loop bounds before `assertValidCreatureShape` runs, so
+     a hostile checkpoint exhausts memory at `src/transfer/Checkpoint.ts:147`
+     and `:324` rather than hitting the `MAX_NEURON_COUNT` cap. Same hazard
+     #3672 fixed for `Creature.fromJSON`; this entry point was not covered.
+     Reproduced — see Evidence.
+   - **#3715** — `ImproveSquash.ts:461-470` and `:533-539` build a write path
+     from an unvalidated creature neuron `uuid`, and `SafeWrite`'s
+     `ensureDirSync` creates the escaping directories rather than rejecting
+     them, so a `uuid` ending in `/../../a` writes outside `outputDir`.
+
+3. **Coverage is recorded so the next sweep does not redo it.** New
+   `docs/SECURITY_SWEEP_COVERAGE.md` names every directory explicitly with its
+   disposition, carries the reasoning that cleared the clean ones, and lists
+   what was considered and dismissed — including three low-severity items judged
+   not worth their own issue. That is what makes the acceptance criterion
+   checkable: the next `security-scan` run's coverage diff comes back empty.
+
+## Evidence
+
+Backend/library change — no web interface to screenshot.
+
+**The two checkpoint findings were reproduced, not inferred.** Against the
+current tree, with a scratch script deleted before commit:
+
+| Loop                                                  | Payload              | Result                                    |
+| ----------------------------------------------------- | -------------------- | ----------------------------------------- |
+| `Checkpoint.ts:147` → `NormaliseCreatureExport.ts:65` | `input: 50_000_000`  | `Map maximum size exceeded` after 6332 ms |
+| `Checkpoint.ts:324-332` (remap path)                  | `output: 20_000_000` | `Set maximum size exceeded` after 1794 ms |
+
+In both cases the failure is memory exhaustion after seconds of burn, not the
+intended `ValidationError` — confirming the shape cap runs too late. Full detail
+is on #3714.
+
+The guard's control flow:
+
+```mermaid
+flowchart LR
+    A[Caller config<br/>custom cost / RL adapter] --> B{assertLocalModuleSpecifier}
+    B -- "relative · absolute · file:" --> C["await import()"]
+    B -- "https: http: data:<br/>blob: jsr: npm:" --> D[ValidationError<br/>import never runs]
+```
+
+The two call sites surface a rejection differently, deliberately:
+
+- **Custom cost** — the guard sits _outside_ the existing try/catch so the typed
+  `ValidationError` reaches the caller rather than being flattened into a
+  generic load failure.
+- **Episode adapter** — the guard runs first inside `handleInit`, ahead of WASM
+  init, and the rejection travels back over the worker protocol as
+  `initialize: { status: "ERROR" }`, that protocol's fail-loud channel.
+
+**Quality gate:** `./quality.sh` passes clean —
+`8214 passed | 0 failed |
+4 ignored`.
+
+## Test Plan
+
+Added, all behavioural — each calls the real function and asserts on the
+outcome:
+
+- `test/utils/ModuleSpecifierGuard.ts` (9 tests) — the predicate itself: accepts
+  relative, absolute, and `file:` specifiers (including a Windows drive letter,
+  which must not be read as a `c:` scheme); rejects `https:`, `http:`, `data:`,
+  `blob:`, `jsr:`, `npm:`, blank, non-string, and a scheme hidden behind
+  surrounding whitespace; asserts the error names the rejected scheme and
+  carries `reason === "OTHER"`.
+- `test/multithreading/WorkerProcessor.ts` (2 tests added) — drives
+  `WorkerProcessor.process()` with a remote `customCostData` filePath and
+  asserts a `ValidationError` mentioning `custom cost function`. The paired test
+  proves a _relative_ specifier still reaches `import()`: it fails with
+  `Failed to load custom cost function`, not a `ValidationError`, so the guard
+  is not simply rejecting everything.
+- `test/creature/EpisodeWorkerProcessorSpecifierGuard_test.ts` (2 tests) — same
+  shape for the episode adapter over the worker protocol: remote URLs return
+  `status: "ERROR"` naming `episode adapter`; a `file:` URL fails with a module
+  resolution error instead, proving local specifiers pass.
+
+Existing coverage confirmed unaffected:
+`test/creature/evolveRL_parallel_test.ts` and `test/costs/` (which use `file://`
+and absolute paths) still pass.
+
+No existing tests were removed, disabled, or modified.

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -549,6 +549,7 @@
     "UNSERIALISABLE",
     "unsquash",
     "unsquashed",
+    "unswept",
     "upgrader",
     "upsert",
     "upserts",
@@ -575,6 +576,7 @@
     "xychart",
     "xychart",
     "yaxis",
+    "zknu",
     "ünter",
     "Δeffect",
     "Δerr",
@@ -594,6 +596,7 @@
     "unadded",
     "mintable",
     "tokenlessly",
-    "trojanised"
+    "trojanised",
+    "relitigate"
   ]
 }

--- a/src/creature/EpisodeWorkerProcessor.ts
+++ b/src/creature/EpisodeWorkerProcessor.ts
@@ -32,6 +32,7 @@ import { Creature } from "@creature";
 import { runEpisode } from "@creature/EpisodeRunner.ts";
 import { initialiseWasmActivationFromPayload } from "@workers/WasmWorkerInit.ts";
 import type { WasmActivationInitPayload } from "@workers/WasmActivationPayload.ts";
+import { assertLocalModuleSpecifier } from "@utils/ModuleSpecifierGuard.ts";
 
 /**
  * Resolve a class-shaped export from a dynamically-imported module.
@@ -113,6 +114,12 @@ export class EpisodeWorkerProcessor {
     start: number,
   ): Promise<EpisodeInitResponse> {
     try {
+      // Issue #3685: reject any non-local adapter URL before it reaches
+      // `import()`, so an adapter description sourced from a remote manifest
+      // cannot execute remote code inside the worker. Checked first — ahead of
+      // WASM init — so a hostile specifier costs nothing.
+      assertLocalModuleSpecifier(description.url, "episode adapter");
+
       // Initialise WASM activation in the worker so `creature.activate()`
       // calls inside `runEpisode()` find a loaded module. Mirrors the
       // dataset worker bootstrap.

--- a/src/multithreading/workers/WorkerProcessor.ts
+++ b/src/multithreading/workers/WorkerProcessor.ts
@@ -27,6 +27,7 @@ import type {
 } from "@multithreading/workers/WorkerHandler.ts";
 import { getLogger } from "@utils/Logger.ts";
 import { clearForGc } from "@utils/ReleasableRef.ts";
+import { assertLocalModuleSpecifier } from "@utils/ModuleSpecifierGuard.ts";
 import { DatasetFileListCache } from "@architecture/DatasetFileListCache.ts";
 
 type DiscoverResponsePayload = NonNullable<ResponseData["discover"]>;
@@ -110,6 +111,12 @@ export class WorkerProcessor {
   private async loadCustomCostFromFile(
     filePath: string,
   ): Promise<CostInterface> {
+    // Issue #3685: only local specifiers may be imported, so a config value
+    // that ever came from a remote manifest cannot execute remote code here.
+    // Deliberately outside the try/catch below so the typed ValidationError
+    // reaches the caller instead of being flattened into a load failure.
+    assertLocalModuleSpecifier(filePath, "custom cost function");
+
     try {
       // Dynamic import of user-provided custom cost function file.
       // JSR Warning: This dynamic import is intentional and loads external user files at runtime.

--- a/src/utils/ModuleSpecifierGuard.ts
+++ b/src/utils/ModuleSpecifierGuard.ts
@@ -1,0 +1,63 @@
+/**
+ * Dynamic-import specifier guard (Issue #3685).
+ *
+ * Two worker entry points hand a caller-supplied specifier straight to
+ * `await import()`: the custom cost function
+ * (`WorkerProcessor.loadCustomCostFromFile`) and the episode adapter
+ * (`EpisodeWorkerProcessor.handleInit`). Both are developer configuration
+ * today, but nothing in the type system stops a value sourced from a remote
+ * manifest — a downloaded experiment description, a shared job spec — from
+ * reaching them, at which point an `https:` or `data:` specifier would execute
+ * attacker-supplied code inside the worker.
+ *
+ * The guard closes that off: only local module specifiers load. Anything
+ * carrying a remote or inline-code scheme is rejected before `import()` runs.
+ *
+ * @module ModuleSpecifierGuard
+ */
+
+import { ValidationError } from "@errors/ValidationError.ts";
+
+/**
+ * Leading URL scheme, e.g. `https:` in `https://example/a.ts`.
+ *
+ * The scheme must be at least two characters so a Windows drive letter
+ * (`C:\adapters\A.ts`) is read as a filesystem path rather than a `c:` scheme.
+ */
+const SCHEME_PATTERN = /^([A-Za-z][A-Za-z0-9+.-]+):/;
+
+/** The only scheme permitted on an absolute module URL. */
+const ALLOWED_SCHEME = "file:";
+
+/**
+ * Assert that `specifier` is a local module specifier — a relative or absolute
+ * filesystem path, or a `file:` URL — and is therefore safe to pass to
+ * `await import()`.
+ *
+ * @param specifier The module specifier about to be imported.
+ * @param context Short description of the call site, included in the error.
+ * @throws {ValidationError} When the specifier is blank, not a string, or
+ *   carries any scheme other than `file:`.
+ */
+export function assertLocalModuleSpecifier(
+  specifier: string,
+  context: string,
+): void {
+  if (typeof specifier !== "string" || specifier.trim().length === 0) {
+    throw new ValidationError(
+      `${context}: module specifier must be a non-empty string.`,
+      "OTHER",
+    );
+  }
+
+  const trimmed = specifier.trim();
+  const scheme = SCHEME_PATTERN.exec(trimmed)?.[1].toLowerCase();
+  if (scheme !== undefined && `${scheme}:` !== ALLOWED_SCHEME) {
+    throw new ValidationError(
+      `${context}: module specifier "${trimmed}" uses the "${scheme}:" ` +
+        `scheme; only relative/absolute paths and "${ALLOWED_SCHEME}" URLs ` +
+        `may be imported.`,
+      "OTHER",
+    );
+  }
+}

--- a/test/creature/EpisodeWorkerProcessorSpecifierGuard_test.ts
+++ b/test/creature/EpisodeWorkerProcessorSpecifierGuard_test.ts
@@ -1,0 +1,42 @@
+/**
+ * Issue #3685: the episode adapter URL reaches `await import()` inside the
+ * worker. An adapter description sourced from a remote manifest must not be
+ * able to execute remote code, so anything but a local specifier is rejected
+ * before the import runs.
+ */
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { EpisodeWorkerProcessor } from "@creature/EpisodeWorkerProcessor.ts";
+
+async function initWith(url: string) {
+  const processor = new EpisodeWorkerProcessor();
+  const response = await processor.process({
+    taskID: 1,
+    initialize: { adapter: { url } },
+  });
+  assertEquals("initialize" in response, true);
+  return (response as { initialize: { status: string; error?: string } })
+    .initialize;
+}
+
+Deno.test("EpisodeWorkerProcessor: rejects remote adapter URLs", async () => {
+  for (
+    const url of [
+      "https://evil.example/adapter.ts",
+      "http://evil.example/adapter.ts",
+      "data:text/javascript,export default class {}",
+      "npm:evil-adapter",
+    ]
+  ) {
+    const result = await initWith(url);
+    assertEquals(result.status, "ERROR");
+    assertStringIncludes(result.error ?? "", "episode adapter");
+  }
+});
+
+Deno.test("EpisodeWorkerProcessor: a local adapter URL passes the guard", async () => {
+  // The module does not exist, so init still fails — but with a module
+  // resolution error rather than the scheme guard, proving `file:` is allowed.
+  const result = await initWith("file:///definitely/not/a/real/module.ts");
+  assertEquals(result.status, "ERROR");
+  assertEquals((result.error ?? "").includes("episode adapter"), false);
+});

--- a/test/creature/EpisodeWorkerProcessorSpecifierGuard_test.ts
+++ b/test/creature/EpisodeWorkerProcessorSpecifierGuard_test.ts
@@ -19,15 +19,14 @@ async function initWith(url: string) {
 }
 
 Deno.test("EpisodeWorkerProcessor: rejects remote adapter URLs", async () => {
-  for (
-    const url of [
-      "https://evil.example/adapter.ts",
-      "http://evil.example/adapter.ts",
-      "data:text/javascript,export default class {}",
-      "npm:evil-adapter",
-    ]
-  ) {
-    const result = await initWith(url);
+  const results = await Promise.all([
+    "https://evil.example/adapter.ts",
+    "http://evil.example/adapter.ts",
+    "data:text/javascript,export default class {}",
+    "npm:evil-adapter",
+  ].map(initWith));
+
+  for (const result of results) {
     assertEquals(result.status, "ERROR");
     assertStringIncludes(result.error ?? "", "episode adapter");
   }

--- a/test/multithreading/WorkerProcessor.ts
+++ b/test/multithreading/WorkerProcessor.ts
@@ -145,17 +145,15 @@ Deno.test(
 Deno.test("WorkerProcessor: rejects a remote custom cost specifier before import", async () => {
   const processor = new WorkerProcessor();
 
-  for (
-    const filePath of [
-      "https://evil.example/cost.ts",
-      "http://evil.example/cost.ts",
-      "data:text/javascript,export default class {}",
-    ]
-  ) {
-    const error = await assertRejects(
+  const attempts = [
+    "https://evil.example/cost.ts",
+    "http://evil.example/cost.ts",
+    "data:text/javascript,export default class {}",
+  ].map((filePath, index) =>
+    assertRejects(
       () =>
         processor.process({
-          taskID: 1,
+          taskID: index + 1,
           initialize: {
             dataSetDir: ".test/does-not-matter",
             costName: "MSE",
@@ -163,7 +161,10 @@ Deno.test("WorkerProcessor: rejects a remote custom cost specifier before import
           },
         }),
       ValidationError,
-    );
+    )
+  );
+
+  for (const error of await Promise.all(attempts)) {
     assertStringIncludes(error.message, "custom cost function");
   }
 });

--- a/test/multithreading/WorkerProcessor.ts
+++ b/test/multithreading/WorkerProcessor.ts
@@ -4,10 +4,17 @@
  * Issue #1698: Validates buildDiscoverResponsePayload and
  * clearDiscoverResultForGC helper functions.
  */
-import { assertEquals, assertExists } from "@std/assert";
+import {
+  assertEquals,
+  assertExists,
+  assertRejects,
+  assertStringIncludes,
+} from "@std/assert";
+import { ValidationError } from "@errors/ValidationError.ts";
 import {
   buildDiscoverResponsePayload,
   clearDiscoverResultForGC,
+  WorkerProcessor,
 } from "@multithreading/workers/WorkerProcessor.ts";
 import type { DiscoverResult } from "@architecture/ErrorGuidedStructuralEvolution/DiscoverResult.ts";
 
@@ -129,3 +136,57 @@ Deno.test(
     assertEquals(payload.heapAbortedAtExtensionBoundary, false);
   },
 );
+
+/**
+ * Issue #3685: the custom-cost specifier reaches `await import()`, so a
+ * config value sourced from a remote manifest must not be able to execute
+ * remote code inside the worker.
+ */
+Deno.test("WorkerProcessor: rejects a remote custom cost specifier before import", async () => {
+  const processor = new WorkerProcessor();
+
+  for (
+    const filePath of [
+      "https://evil.example/cost.ts",
+      "http://evil.example/cost.ts",
+      "data:text/javascript,export default class {}",
+    ]
+  ) {
+    const error = await assertRejects(
+      () =>
+        processor.process({
+          taskID: 1,
+          initialize: {
+            dataSetDir: ".test/does-not-matter",
+            costName: "MSE",
+            customCostData: JSON.stringify({ filePath }),
+          },
+        }),
+      ValidationError,
+    );
+    assertStringIncludes(error.message, "custom cost function");
+  }
+});
+
+Deno.test("WorkerProcessor: a relative custom cost specifier passes the guard", async () => {
+  const processor = new WorkerProcessor();
+
+  // The path does not exist, so `import()` fails — but the failure is the
+  // load error, not the scheme guard, proving a local specifier is accepted.
+  const error = await assertRejects(
+    () =>
+      processor.process({
+        taskID: 2,
+        initialize: {
+          dataSetDir: ".test/does-not-matter",
+          costName: "MSE",
+          customCostData: JSON.stringify({
+            filePath: "./no/such/CustomCost.ts",
+          }),
+        },
+      }),
+    Error,
+  );
+  assertEquals(error instanceof ValidationError, false);
+  assertStringIncludes(error.message, "Failed to load custom cost function");
+});

--- a/test/utils/ModuleSpecifierGuard.ts
+++ b/test/utils/ModuleSpecifierGuard.ts
@@ -1,0 +1,81 @@
+import { assert, assertStringIncludes, assertThrows } from "@std/assert";
+import { ValidationError } from "@errors/ValidationError.ts";
+import { assertLocalModuleSpecifier } from "@utils/ModuleSpecifierGuard.ts";
+
+Deno.test("ModuleSpecifierGuard accepts relative specifiers", () => {
+  assertLocalModuleSpecifier("./MyAdapter.ts", "adapter");
+  assertLocalModuleSpecifier("../costs/MyCost.ts", "cost");
+  assertLocalModuleSpecifier(".test/costs/customCost/cost.ts", "cost");
+});
+
+Deno.test("ModuleSpecifierGuard accepts absolute filesystem paths", () => {
+  assertLocalModuleSpecifier("/tmp/adapters/MyAdapter.ts", "adapter");
+  assertLocalModuleSpecifier("C:\\adapters\\MyAdapter.ts", "adapter");
+});
+
+Deno.test("ModuleSpecifierGuard accepts file: URLs", () => {
+  assertLocalModuleSpecifier("file:///tmp/adapters/MyAdapter.ts", "adapter");
+  assertLocalModuleSpecifier("FILE:///tmp/adapters/MyAdapter.ts", "adapter");
+});
+
+Deno.test("ModuleSpecifierGuard rejects remote schemes", () => {
+  for (
+    const specifier of [
+      "https://evil.example/adapter.ts",
+      "http://evil.example/adapter.ts",
+      "data:text/javascript,export default class {}",
+      "blob:https://evil.example/1234",
+      "jsr:@evil/adapter",
+      "npm:evil-adapter",
+    ]
+  ) {
+    const error = assertThrows(
+      () => assertLocalModuleSpecifier(specifier, "adapter"),
+      ValidationError,
+    );
+    assertStringIncludes(error.message, "adapter");
+  }
+});
+
+Deno.test("ModuleSpecifierGuard names the rejected scheme in the error", () => {
+  const error = assertThrows(
+    () => assertLocalModuleSpecifier("https://evil.example/a.ts", "adapter"),
+    ValidationError,
+  );
+  assertStringIncludes(error.message, "https:");
+});
+
+Deno.test("ModuleSpecifierGuard rejects empty and blank specifiers", () => {
+  for (const specifier of ["", "   "]) {
+    assertThrows(
+      () => assertLocalModuleSpecifier(specifier, "adapter"),
+      ValidationError,
+    );
+  }
+});
+
+Deno.test("ModuleSpecifierGuard rejects non-string specifiers", () => {
+  assertThrows(
+    () =>
+      assertLocalModuleSpecifier(
+        undefined as unknown as string,
+        "adapter",
+      ),
+    ValidationError,
+  );
+});
+
+Deno.test("ModuleSpecifierGuard rejects a scheme hidden by surrounding whitespace", () => {
+  assertThrows(
+    () => assertLocalModuleSpecifier("  https://evil.example/a.ts ", "adapter"),
+    ValidationError,
+  );
+});
+
+Deno.test("ModuleSpecifierGuard error is a ValidationError with OTHER reason", () => {
+  const error = assertThrows(
+    () => assertLocalModuleSpecifier("https://evil.example/a.ts", "adapter"),
+    ValidationError,
+  );
+  assert(error.reason === "OTHER");
+});


### PR DESCRIPTION
# Finish the bounded security sweep (Issue #3685)

## Summary

Completes the `security-scan` sweep that #3673 left bounded by context rather
than by a clean result. Closes #3685.

Three things landed:

1. **The `await import()` scheme question is resolved with a guard, not a trust
   argument.** `WorkerProcessor.ts:117` and `EpisodeWorkerProcessor.ts:127` each
   handed a caller-supplied module specifier straight to `await import()`. Both
   values are developer configuration today, but neither the type
   (`AdapterDescription.url: string`, `customCost.filePath: string`) nor the
   call graph prevents one arriving from a remote manifest — a downloaded
   experiment description or a shared job spec — at which point an `https:` or
   `data:` specifier executes attacker code inside the worker. Writing down
   "this can never come from an untrusted source" would have been a claim the
   code does not enforce, so the allowlist went in instead.

   New `assertLocalModuleSpecifier()` (`src/utils/ModuleSpecifierGuard.ts`) runs
   before both imports. Relative paths, absolute filesystem paths (including
   Windows drive letters), and `file:` URLs load; `https:`, `http:`, `data:`,
   `blob:`, `jsr:`, and `npm:` are rejected with a `ValidationError` naming the
   scheme.

2. **The three unswept directories plus the ONNX encoders were audited.**
   `src/predictiveCoding/` and `src/onnx/` came back clean; `src/transfer/` and
   `src/intelligentDesign/` each produced one confirmed finding, filed as
   individual issues with `file:line` evidence:

   - **#3714** — `importCheckpoint()` uses the raw `checkpoint.creature.input` /
     `.output` counts as loop bounds before `assertValidCreatureShape` runs, so
     a hostile checkpoint exhausts memory at `src/transfer/Checkpoint.ts:147`
     and `:324` rather than hitting the `MAX_NEURON_COUNT` cap. Same hazard
     #3672 fixed for `Creature.fromJSON`; this entry point was not covered.
     Reproduced — see Evidence.
   - **#3715** — `ImproveSquash.ts:461-470` and `:533-539` build a write path
     from an unvalidated creature neuron `uuid`, and `SafeWrite`'s
     `ensureDirSync` creates the escaping directories rather than rejecting
     them, so a `uuid` ending in `/../../a` writes outside `outputDir`.

3. **Coverage is recorded so the next sweep does not redo it.** New
   `docs/SECURITY_SWEEP_COVERAGE.md` names every directory explicitly with its
   disposition, carries the reasoning that cleared the clean ones, and lists
   what was considered and dismissed — including three low-severity items judged
   not worth their own issue. That is what makes the acceptance criterion
   checkable: the next `security-scan` run's coverage diff comes back empty.

## Evidence

Backend/library change — no web interface to screenshot.

**The two checkpoint findings were reproduced, not inferred.** Against the
current tree, with a scratch script deleted before commit:

| Loop                                                  | Payload              | Result                                    |
| ----------------------------------------------------- | -------------------- | ----------------------------------------- |
| `Checkpoint.ts:147` → `NormaliseCreatureExport.ts:65` | `input: 50_000_000`  | `Map maximum size exceeded` after 6332 ms |
| `Checkpoint.ts:324-332` (remap path)                  | `output: 20_000_000` | `Set maximum size exceeded` after 1794 ms |

In both cases the failure is memory exhaustion after seconds of burn, not the
intended `ValidationError` — confirming the shape cap runs too late. Full detail
is on #3714.

The guard's control flow:

```mermaid
flowchart LR
    A[Caller config<br/>custom cost / RL adapter] --> B{assertLocalModuleSpecifier}
    B -- "relative · absolute · file:" --> C["await import()"]
    B -- "https: http: data:<br/>blob: jsr: npm:" --> D[ValidationError<br/>import never runs]
```

The two call sites surface a rejection differently, deliberately:

- **Custom cost** — the guard sits _outside_ the existing try/catch so the typed
  `ValidationError` reaches the caller rather than being flattened into a
  generic load failure.
- **Episode adapter** — the guard runs first inside `handleInit`, ahead of WASM
  init, and the rejection travels back over the worker protocol as
  `initialize: { status: "ERROR" }`, that protocol's fail-loud channel.

**Quality gate:** `./quality.sh` passes clean —
`8214 passed | 0 failed |
4 ignored`.

## Test Plan

Added, all behavioural — each calls the real function and asserts on the
outcome:

- `test/utils/ModuleSpecifierGuard.ts` (9 tests) — the predicate itself: accepts
  relative, absolute, and `file:` specifiers (including a Windows drive letter,
  which must not be read as a `c:` scheme); rejects `https:`, `http:`, `data:`,
  `blob:`, `jsr:`, `npm:`, blank, non-string, and a scheme hidden behind
  surrounding whitespace; asserts the error names the rejected scheme and
  carries `reason === "OTHER"`.
- `test/multithreading/WorkerProcessor.ts` (2 tests added) — drives
  `WorkerProcessor.process()` with a remote `customCostData` filePath and
  asserts a `ValidationError` mentioning `custom cost function`. The paired test
  proves a _relative_ specifier still reaches `import()`: it fails with
  `Failed to load custom cost function`, not a `ValidationError`, so the guard
  is not simply rejecting everything.
- `test/creature/EpisodeWorkerProcessorSpecifierGuard_test.ts` (2 tests) — same
  shape for the episode adapter over the worker protocol: remote URLs return
  `status: "ERROR"` naming `episode adapter`; a `file:` URL fails with a module
  resolution error instead, proving local specifiers pass.

Existing coverage confirmed unaffected:
`test/creature/evolveRL_parallel_test.ts` and `test/costs/` (which use `file://`
and absolute paths) still pass.

No existing tests were removed, disabled, or modified.



## Milestone
This PR is part of the **Scan 20260807** milestone and targets the `milestone/scan-20260807` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mskfyyid-74b569`<!-- vibe-worker-issue-3685 -->