### PR TITLE
Remove dead batch wrapper from DiscoveryPostValidate (Issue #3687)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-3687.md
+++ b/docs/archive/pr-summaries/pr-summary-3687.md
@@ -1,0 +1,73 @@
+# Remove dead batch wrapper and convenience re-exports from DiscoveryPostValidate.ts
+
+## Summary
+
+Removed the unused export `validateDiscoveryCandidatesBatch` (the Issue #1291
+batch wrapper) from `src/discovery/DiscoveryPostValidate.ts`, along with the
+convenience re-export block (`BatchValidationResult`, `BatchValidationStats`,
+`BatchValidatorOptions`, `BatchDiscoveryValidator`) and the now-unused imports
+that only those symbols used. Closes #3687.
+
+`validateAfterDiscoveryOrThrow` — the live symbol every importer of this module
+actually uses — is untouched.
+
+### Why it was safe
+
+An import-graph sweep confirmed every importer of `DiscoveryPostValidate.ts`
+imports only `validateAfterDiscoveryOrThrow`:
+
+- `src/NEAT/ProcessCompletedResults.ts:16`
+- `bench/BatchDiscoveryValidation.ts:20`
+- `test/NEAT/DiscoveryReplayIntegration.ts:28`
+- `test/discovery/DiscoveryPostValidate.ts:4`
+
+Nothing imported `validateDiscoveryCandidatesBatch` or reached
+`BatchDiscoveryValidator` / its types through this module — consumers that need
+them import `@discovery/BatchDiscoveryValidator.ts` directly. There was no
+in-file caller, no string-keyed or reflective reference, and the module is not
+re-exported from the `mod.ts` barrel (the package's single public entry point),
+so no downstream consumer could reach the removed symbols through the published
+API.
+
+The same-named plain wrapper previously at
+`src/discovery/BatchDiscoveryValidator.ts:392` was a separate symbol, already
+removed under Issue #3686 (commit `b7bedd62`); the two were independent.
+
+## Evidence
+
+Backend-only change with no web interface, so no screenshot applies. Evidence is
+the test suite.
+
+```mermaid
+flowchart LR
+    subgraph Before
+        PV1["DiscoveryPostValidate.ts"] --> A1["validateAfterDiscoveryOrThrow<br/>4 importers"]
+        PV1 --> D1["validateDiscoveryCandidatesBatch<br/>no importer"]
+        PV1 --> D2["re-exports:<br/>BatchDiscoveryValidator + 3 types<br/>no importer"]
+        D1 --> BDV1["BatchDiscoveryValidator.ts"]
+        D2 --> BDV1
+    end
+    subgraph After
+        PV2["DiscoveryPostValidate.ts"] --> A2["validateAfterDiscoveryOrThrow<br/>4 importers"]
+        C["Consumers needing batch validation"] --> BDV2["BatchDiscoveryValidator.ts<br/>imported directly"]
+    end
+```
+
+Before the removal, the new surface test failed on the first assertion
+(`Object.hasOwn(surface, "validateDiscoveryCandidatesBatch")` returned `true`);
+after it, all four tests in the file pass.
+
+Full quality gate: `./quality.sh` — **8216 passed | 0 failed | 4 ignored**.
+
+## Test Plan
+
+- Added
+  `test/discovery/DiscoveryPostValidate.ts::"DiscoveryPostValidate exports only the live post-validation helper (Issue #3687)"`
+  — imports the module and asserts the runtime surface: neither
+  `validateDiscoveryCandidatesBatch` nor the `BatchDiscoveryValidator`
+  re-export is present, while `validateAfterDiscoveryOrThrow` remains a
+  function. This fails against the unfixed code and passes after the removal.
+- Existing `validateAfterDiscoveryOrThrow` tests in the same file are unchanged
+  and still pass, confirming the live behaviour is unaffected.
+- `./quality.sh` (lint, format, type-check, WASM sync, full test suite) passes
+  cleanly.

--- a/docs/archive/pr-summaries/pr-summary-3687.md
+++ b/docs/archive/pr-summaries/pr-summary-3687.md
@@ -64,9 +64,9 @@ Full quality gate: `./quality.sh` — **8216 passed | 0 failed | 4 ignored**.
 - Added
   `test/discovery/DiscoveryPostValidate.ts::"DiscoveryPostValidate exports only the live post-validation helper (Issue #3687)"`
   — imports the module and asserts the runtime surface: neither
-  `validateDiscoveryCandidatesBatch` nor the `BatchDiscoveryValidator`
-  re-export is present, while `validateAfterDiscoveryOrThrow` remains a
-  function. This fails against the unfixed code and passes after the removal.
+  `validateDiscoveryCandidatesBatch` nor the `BatchDiscoveryValidator` re-export
+  is present, while `validateAfterDiscoveryOrThrow` remains a function. This
+  fails against the unfixed code and passes after the removal.
 - Existing `validateAfterDiscoveryOrThrow` tests in the same file are unchanged
   and still pass, confirming the live behaviour is unaffected.
 - `./quality.sh` (lint, format, type-check, WASM sync, full test suite) passes

--- a/src/discovery/DiscoveryPostValidate.ts
+++ b/src/discovery/DiscoveryPostValidate.ts
@@ -1,13 +1,6 @@
 import type { Creature } from "@creature";
 import { creatureValidate } from "@architecture/CreatureValidate.ts";
 import { DiscoveryError } from "@errors/DiscoveryError.ts";
-import type { DiscoveryCandidate } from "@discovery/DiscoveryCandidates.ts";
-import {
-  BatchDiscoveryValidator,
-  type BatchValidationResult,
-  type BatchValidationStats,
-  type BatchValidatorOptions,
-} from "@discovery/BatchDiscoveryValidator.ts";
 
 /**
  * Validate a creature immediately after applying discovery changes.
@@ -88,80 +81,3 @@ function sampleForwardOnlyViolations(
   }
   return out;
 }
-
-/**
- * Validate multiple discovery candidates in a batch.
- *
- * This function provides batch validation for discovery candidates, reducing
- * the overhead of individual validation calls by:
- * 1. Grouping candidates by type (structural vs weight-only changes)
- * 2. Validating structural candidates with early-exit on first invalid
- * 3. Caching common validation results across candidates
- *
- * Issue #1291 - Performance: Batch discovery candidate validation
- *
- * @param args - Batch validation arguments
- * @returns Batch validation results with statistics
- */
-export function validateDiscoveryCandidatesBatch(args: {
-  /** The base creature the candidates were derived from */
-  baseCreature: Creature;
-  /** The candidates to validate */
-  candidates: DiscoveryCandidate[];
-  /** Discovery session ID (for log correlation) */
-  discoveryID: string;
-  /** The config feedbackLoop flag for the current run */
-  feedbackLoop: boolean | undefined;
-  /** Whether to exit early on first structural validation failure */
-  earlyExitOnStructuralFailure?: boolean;
-}): {
-  results: BatchValidationResult[];
-  stats: BatchValidationStats;
-  validCandidates: DiscoveryCandidate[];
-  invalidCandidates: DiscoveryCandidate[];
-} {
-  const {
-    baseCreature,
-    candidates,
-    feedbackLoop,
-    earlyExitOnStructuralFailure,
-  } = args;
-
-  const options: BatchValidatorOptions = {
-    feedbackLoop: feedbackLoop ?? false,
-    earlyExitOnStructuralFailure: earlyExitOnStructuralFailure ?? false,
-  };
-
-  const validator = new BatchDiscoveryValidator(options);
-  const results = validator.validateBatch(baseCreature, candidates);
-  const stats = validator.getStats();
-
-  // Separate valid and invalid candidates for convenience
-  const validCandidates: DiscoveryCandidate[] = [];
-  const invalidCandidates: DiscoveryCandidate[] = [];
-
-  for (const result of results) {
-    if (result.valid) {
-      validCandidates.push(result.candidate);
-    } else {
-      invalidCandidates.push(result.candidate);
-    }
-  }
-
-  return {
-    results,
-    stats,
-    validCandidates,
-    invalidCandidates,
-  };
-}
-
-/**
- * Re-export batch validation types for convenience.
- */
-export type {
-  BatchValidationResult,
-  BatchValidationStats,
-  BatchValidatorOptions,
-};
-export { BatchDiscoveryValidator };

--- a/test/discovery/DiscoveryPostValidate.ts
+++ b/test/discovery/DiscoveryPostValidate.ts
@@ -1,4 +1,4 @@
-import { assertThrows } from "@std/assert";
+import { assertEquals, assertThrows } from "@std/assert";
 import { Creature } from "@creature";
 import { Synapse } from "@architecture/Synapse.ts";
 import { validateAfterDiscoveryOrThrow } from "@discovery/DiscoveryPostValidate.ts";
@@ -80,5 +80,32 @@ Deno.test(
       operation: "unit-test",
       feedbackLoop: true,
     });
+  },
+);
+
+Deno.test(
+  "DiscoveryPostValidate exports only the live post-validation helper (Issue #3687)",
+  async () => {
+    const surface: Record<string, unknown> = await import(
+      "@discovery/DiscoveryPostValidate.ts"
+    );
+
+    assertEquals(
+      Object.hasOwn(surface, "validateDiscoveryCandidatesBatch"),
+      false,
+      "The unused batch wrapper must not be exported; callers use BatchDiscoveryValidator directly",
+    );
+    assertEquals(
+      Object.hasOwn(surface, "BatchDiscoveryValidator"),
+      false,
+      "The convenience re-export must not be exported; callers import @discovery/BatchDiscoveryValidator.ts directly",
+    );
+
+    // The live surface stays intact.
+    assertEquals(
+      typeof surface.validateAfterDiscoveryOrThrow,
+      "function",
+      "validateAfterDiscoveryOrThrow must remain exported",
+    );
   },
 );


### PR DESCRIPTION
# Remove dead batch wrapper and convenience re-exports from DiscoveryPostValidate.ts

## Summary

Removed the unused export `validateDiscoveryCandidatesBatch` (the Issue #1291
batch wrapper) from `src/discovery/DiscoveryPostValidate.ts`, along with the
convenience re-export block (`BatchValidationResult`, `BatchValidationStats`,
`BatchValidatorOptions`, `BatchDiscoveryValidator`) and the now-unused imports
that only those symbols used. Closes #3687.

`validateAfterDiscoveryOrThrow` — the live symbol every importer of this module
actually uses — is untouched.

### Why it was safe

An import-graph sweep confirmed every importer of `DiscoveryPostValidate.ts`
imports only `validateAfterDiscoveryOrThrow`:

- `src/NEAT/ProcessCompletedResults.ts:16`
- `bench/BatchDiscoveryValidation.ts:20`
- `test/NEAT/DiscoveryReplayIntegration.ts:28`
- `test/discovery/DiscoveryPostValidate.ts:4`

Nothing imported `validateDiscoveryCandidatesBatch` or reached
`BatchDiscoveryValidator` / its types through this module — consumers that need
them import `@discovery/BatchDiscoveryValidator.ts` directly. There was no
in-file caller, no string-keyed or reflective reference, and the module is not
re-exported from the `mod.ts` barrel (the package's single public entry point),
so no downstream consumer could reach the removed symbols through the published
API.

The same-named plain wrapper previously at
`src/discovery/BatchDiscoveryValidator.ts:392` was a separate symbol, already
removed under Issue #3686 (commit `b7bedd62`); the two were independent.

## Evidence

Backend-only change with no web interface, so no screenshot applies. Evidence is
the test suite.

```mermaid
flowchart LR
    subgraph Before
        PV1["DiscoveryPostValidate.ts"] --> A1["validateAfterDiscoveryOrThrow<br/>4 importers"]
        PV1 --> D1["validateDiscoveryCandidatesBatch<br/>no importer"]
        PV1 --> D2["re-exports:<br/>BatchDiscoveryValidator + 3 types<br/>no importer"]
        D1 --> BDV1["BatchDiscoveryValidator.ts"]
        D2 --> BDV1
    end
    subgraph After
        PV2["DiscoveryPostValidate.ts"] --> A2["validateAfterDiscoveryOrThrow<br/>4 importers"]
        C["Consumers needing batch validation"] --> BDV2["BatchDiscoveryValidator.ts<br/>imported directly"]
    end
```

Before the removal, the new surface test failed on the first assertion
(`Object.hasOwn(surface, "validateDiscoveryCandidatesBatch")` returned `true`);
after it, all four tests in the file pass.

Full quality gate: `./quality.sh` — **8216 passed | 0 failed | 4 ignored**.

## Test Plan

- Added
  `test/discovery/DiscoveryPostValidate.ts::"DiscoveryPostValidate exports only the live post-validation helper (Issue #3687)"`
  — imports the module and asserts the runtime surface: neither
  `validateDiscoveryCandidatesBatch` nor the `BatchDiscoveryValidator` re-export
  is present, while `validateAfterDiscoveryOrThrow` remains a function. This
  fails against the unfixed code and passes after the removal.
- Existing `validateAfterDiscoveryOrThrow` tests in the same file are unchanged
  and still pass, confirming the live behaviour is unaffected.
- `./quality.sh` (lint, format, type-check, WASM sync, full test suite) passes
  cleanly.



## Milestone
This PR is part of the **Scan 20260807** milestone and targets the `milestone/scan-20260807` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mskidsy7-f71396`<!-- vibe-worker-issue-3687 -->