### PR TITLE
Add @module docs to 17 public src/ modules (Issue #3688)

### DIFF
--- a/docs/archive/pr-summaries/pr-summary-3688.md
+++ b/docs/archive/pr-summaries/pr-summary-3688.md
@@ -1,0 +1,87 @@
+## Summary
+
+Added a leading `/** @module … */` JSDoc block to the seventeen public modules
+under `src/` that went straight from their imports to their first code
+statement, leaving a new reader with nothing that says what the module provides,
+why it exists, or when to reach for it.
+
+Each block was written from the module's actual code, not its filename, and
+states what the signature cannot — for example the wire-schema version contract
+and the UUID-only boundary rule for `DiscoveryWireFormat.ts`, the discovery
+pipeline's entry point and its fail-fast behaviour without the Rust library for
+`DiscoveryRunner.ts`, and the subprocess boundary plus WASM-fallback semantics
+for `RustScorerBridge.ts`. This follows the precedent set by the closed
+`@module` issues #3119–#3123.
+
+This is a documentation-only change — no code, types, or behaviour were
+modified. Closes #3688.
+
+Files documented:
+
+- `src/NEAT/DiscoveryReplayQueue.ts`
+- `src/NEAT/LogApproach.ts`
+- `src/architecture/ErrorGuidedStructuralEvolution/ApplyCoordinatedStructuralCandidate.ts`
+- `src/architecture/ErrorGuidedStructuralEvolution/DiscoveryWireIdentity.ts`
+- `src/compact/CompactUnused.ts`
+- `src/compact/DeadSubgraphPruning.ts`
+- `src/compact/SynapsePruning.ts`
+- `src/config/TrainOptions.ts`
+- `src/discovery/DiscoveryRunner.ts`
+- `src/discovery/DiscoveryWireFormat.ts`
+- `src/discovery/NeuronErrorImpactEstimator.ts`
+- `src/methods/activations/aggregate/MAXIMUM.ts`
+- `src/methods/activations/aggregate/MINIMUM.ts`
+- `src/multithreading/workers/WorkerHandler.ts`
+- `src/multithreading/workers/WorkerProcessor.ts`
+- `src/propagate/sparse/SparseConfig.ts`
+- `src/score/RustScorerBridge.ts`
+
+The sites the issue deliberately excluded under the trivial-surface guard
+(`BIPOLAR`/`LeakyReLU`/`STEP`, `ErrorHelper.ts`, `SynapseState.ts`,
+`UpgradeOne.ts`, and the zero-export `deno/worker.ts`) were left untouched.
+
+## Evidence
+
+Backend/library change only — no web interface to screenshot.
+
+`deno doc` picks up each new block. For example,
+`deno doc src/discovery/DiscoveryWireFormat.ts` now opens with:
+
+```
+@module
+    The wire schema for Discovery payloads that cross a process, worker, cache,
+    disk or Rust FFI boundary — and the translator that produces them.
+
+    TypeScript owns the in-memory candidate shapes (`CandidateNeuron`,
+    `CoordinatedStructuralCandidate`, …), which are addressed by ephemeral
+    runtime integer ids. The `Wire*` types here are their boundary-safe
+    counterparts, addressed by stable neuron UUIDs only; the Rust side and the
+    on-disk caches consume this shape.
+    ...
+```
+
+```mermaid
+flowchart LR
+    Imports[imports] --> Doc["/** @module ... */"] --> Code[first declaration]
+    Doc -.picked up by.-> DenoDoc[deno doc]
+```
+
+`git diff --stat` is additions only — 17 files, 293 insertions, 0 deletions —
+confirming no existing line was altered.
+
+Quality gate: `./quality.sh < /dev/null` passes cleanly —
+`8216 passed | 0 failed | 4 ignored`, covering `deno fmt`, `deno lint`,
+`deno check`, the WASM sync, and the full test suite.
+
+## Test Plan
+
+No unit tests apply. This is a pure documentation change adding JSDoc comments
+with no new or modified runtime behaviour to assert on; per AGENTS.md a test
+that inspected source text for doc comments would be a "how" test, which the
+project explicitly forbids. Verification was:
+
+- `./quality.sh < /dev/null` — full gate green (8216 tests passed, 0 failed).
+- `deno fmt` / `deno lint` — clean across all 524 source files.
+- `deno doc src/discovery/DiscoveryWireFormat.ts` — confirms the `@module` block
+  is surfaced in generated documentation.
+- `git diff --stat` — insertions only, so no existing behaviour was touched.

--- a/src/NEAT/DiscoveryReplayQueue.ts
+++ b/src/NEAT/DiscoveryReplayQueue.ts
@@ -1,3 +1,16 @@
+/**
+ * @module
+ *
+ * Background replay queue for cached discoveries (Issue #997). The evolution
+ * loop hands each newly found fittest creature to {@link DiscoveryReplayQueue}
+ * and carries on; the queue replays previously cached discoveries against that
+ * creature on its own, collecting improved creatures for the next generation.
+ *
+ * Reach for it when discovery work must not block evolution: only one replay
+ * runs at a time, a newer fittest supersedes any creature still waiting, and
+ * the seed warm-up structural lock is honoured through an explicitly supplied
+ * {@link DiscoveryReplayWarmupContext} rather than per-creature tags (#2911).
+ */
 import type { Creature } from "@creature";
 import type { NeatOptions } from "@config/NeatOptions.ts";
 import {

--- a/src/NEAT/LogApproach.ts
+++ b/src/NEAT/LogApproach.ts
@@ -1,3 +1,17 @@
+/**
+ * @module
+ *
+ * Names the ways a creature's fitness can improve, and reports each improvement
+ * once. {@link Approach} is the canonical union of pipeline stages that can
+ * produce a new fittest creature (fine tuning, training, compaction,
+ * backtracking, discovery, replay, …); it is written onto a creature as the
+ * `approach` tag by whichever stage produced it.
+ *
+ * {@link logApproach} turns that tag into a human-readable improvement line
+ * showing the score delta against the previous fittest. It is idempotent — an
+ * `approach-logged` tag stops the same improvement being announced twice as the
+ * creature travels further through the evolution loop.
+ */
 import { addTag, getTag } from "@stsoftware/tags/mod";
 import type { Creature } from "../../mod.ts";
 import { blue, bold, cyan } from "@std/fmt/colors";

--- a/src/architecture/ErrorGuidedStructuralEvolution/ApplyCoordinatedStructuralCandidate.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/ApplyCoordinatedStructuralCandidate.ts
@@ -1,3 +1,21 @@
+/**
+ * @module
+ *
+ * Applies a coordinated structural candidate — a discovery proposal made of
+ * several dependent edits (add/remove neuron, add/remove synapse, set weight,
+ * change squash, set bias) — to a creature as one ordered, all-or-nothing
+ * ablation.
+ *
+ * This is the last step of the Discovery pipeline, where a proposal that has
+ * survived evaluation is finally realised on a clone of the creature. It exists
+ * separately from single-operation appliers because the operations in a
+ * coordinated candidate only make sense together and must be applied in order.
+ *
+ * The module is deliberately conservative: on a forward-only creature it
+ * refuses to add a synapse that would introduce a self-loop or back-connection,
+ * and it cleans up the memetic state of anything it removes so no stale
+ * learning data survives the edit.
+ */
 import type { CreatureExport } from "@architecture/CreatureInterfaces.ts";
 import { CreatureUtil } from "@architecture/CreatureUtils.ts";
 import { assertNoRecurrentSynapseOnForwardOnly } from "@architecture/ForwardOnlyAssertion.ts";

--- a/src/architecture/ErrorGuidedStructuralEvolution/DiscoveryWireIdentity.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/DiscoveryWireIdentity.ts
@@ -1,3 +1,19 @@
+/**
+ * @module
+ *
+ * Translates neuron identity across the Discovery boundary: stable wire UUIDs
+ * (`input-2`, `output-0`, or a hidden neuron's UUID) on one side, ephemeral
+ * runtime integer ids on the other.
+ *
+ * Every payload that leaves the process — Discovery requests, caches, replay
+ * inputs, the Rust FFI — must carry UUIDs only (Issue #1958), while the
+ * in-memory topology is addressed by runtime id. This module is the single
+ * place that maps between the two, so callers resolve identity here rather than
+ * threading ad-hoc lookups through the pipeline.
+ *
+ * Unresolvable references are returned to the caller rather than dropped, so a
+ * bad identifier fails loudly instead of silently degrading a candidate.
+ */
 import type { Creature } from "@creature";
 import type {
   CandidateNeuron,

--- a/src/compact/CompactUnused.ts
+++ b/src/compact/CompactUnused.ts
@@ -1,3 +1,21 @@
+/**
+ * @module
+ *
+ * Shrinks a creature by removing the single hidden neuron that contributes
+ * least to its behaviour, using activation traces rather than topology alone.
+ *
+ * {@link compactUnused} scores every traced hidden neuron by how small an
+ * effect its removal would have (activation range × fan-out weight), removes
+ * the weakest one, and folds its average activation into the downstream
+ * neurons via a constant so the remaining network behaves as closely as
+ * possible to the original. {@link removeNeuron} performs that surgery for a
+ * nominated neuron.
+ *
+ * Reach for this when a creature has grown structure that training no longer
+ * uses: it is one pass of the `compact` approach in the evolution loop, called
+ * repeatedly while each removal keeps the score. Removed neurons' UUIDs are
+ * retired; surviving neurons keep theirs (see AGENTS.md's UUID invariant).
+ */
 import { assert } from "@std/assert";
 import { addTag, removeTag } from "@stsoftware/tags/mod";
 import { Creature, type CreatureTrace, CreatureUtil } from "../../mod.ts";

--- a/src/compact/DeadSubgraphPruning.ts
+++ b/src/compact/DeadSubgraphPruning.ts
@@ -1,3 +1,19 @@
+/**
+ * @module
+ *
+ * Removes structure that cannot possibly affect an output: hidden and constant
+ * neurons with no directed path to any output neuron, plus their synapses.
+ *
+ * Because the removed elements never reached an output, pruning them is
+ * behaviour-preserving for a forward pass — this is a pure size reduction, not
+ * an approximation like `CompactUnused.ts`. Evolution and
+ * Discovery routinely strand small subgraphs (a neuron's last outward synapse
+ * is dropped, its feeders become unreachable), so this runs as clean-up
+ * afterwards.
+ *
+ * Two entry points: one over a {@link CreatureExport} for wire payloads and
+ * ingest paths, and a convenience wrapper for a live {@link Creature}.
+ */
 import type { Creature } from "@creature";
 import type { CreatureExport } from "@architecture/CreatureInterfaces.ts";
 import { normaliseCreatureExport } from "@architecture/NormaliseCreatureExport.ts";

--- a/src/compact/SynapsePruning.ts
+++ b/src/compact/SynapsePruning.ts
@@ -1,3 +1,19 @@
+/**
+ * @module
+ *
+ * Synapse-level clean-up that leaves a forward pass unchanged: dropping
+ * exactly-zero-weight synapses, and merging duplicate synapses that share the
+ * same endpoints by summing their weights and unifying their `type` and tags.
+ *
+ * Duplicate rows arise from legacy wire payloads and from structural edits that
+ * re-add an existing edge; left alone they are rejected by `creatureValidate`
+ * and `Creature.fix()`. Reach for these helpers as an idempotent pre-pass
+ * before `Creature.fromJSON`, or when ingesting export JSON outside `loadFrom`
+ * (which already merges duplicates for forward-only creatures — Issue #2086).
+ *
+ * Each operation comes in two forms: one over a {@link CreatureExport} for wire
+ * payloads, and one over a live creature's runtime synapse arrays.
+ */
 import type { CreatureExport } from "@architecture/CreatureInterfaces.ts";
 import type { Synapse } from "@architecture/Synapse.ts";
 import { normaliseCreatureExport } from "@architecture/NormaliseCreatureExport.ts";

--- a/src/config/TrainOptions.ts
+++ b/src/config/TrainOptions.ts
@@ -1,3 +1,20 @@
+/**
+ * @module
+ *
+ * The public configuration surface for a training run — everything
+ * `Creature.train` / `trainDir` accept beyond the dataset itself.
+ *
+ * {@link TrainArguments} is the fully-resolved shape (every field present) and
+ * extends `BackPropagationArguments`, so learning-rate and gradient settings
+ * sit alongside training-loop settings such as `iterations`, `targetError`,
+ * `log`, cross-validation, data fuzzing/quantisation, predictive coding and
+ * synthetic synapses. {@link TrainOptions} is the caller-facing
+ * `Partial<TrainArguments>`: supply only what you want to override and the
+ * training code fills in the documented defaults.
+ *
+ * This module holds the interface pair and its per-field documentation only —
+ * default values and validation live with the code that consumes them.
+ */
 import type { BackPropagationArguments } from "@propagate/BackPropagation.ts";
 import type { CrossValidationConfig } from "@config/CrossValidationConfig.ts";
 import type { DataFuzzingConfig } from "@config/DataFuzzingConfig.ts";

--- a/src/discovery/DiscoveryRunner.ts
+++ b/src/discovery/DiscoveryRunner.ts
@@ -1,3 +1,24 @@
+/**
+ * @module
+ *
+ * Orchestrates one Discovery run: given a creature and a dataset directory,
+ * it asks the Rust Discovery library for structural hints, turns those hints
+ * into candidate edits, filters and samples them, evaluates the survivors
+ * across a worker pool, and returns the candidates that actually reduced error.
+ *
+ * This is the top of the Discovery pipeline described in
+ * `docs/DISCOVERY_ARCHITECTURE.md`; `discoveryDir()` in the public API is a
+ * thin wrapper over
+ * {@link DiscoveryRunner.discoverDir}. Reach for this module when you need to
+ * run or configure discovery — the candidate generation, filtering, caching and
+ * evaluation steps each live in their own sibling module.
+ *
+ * Discovery is always optional: without the Rust library the run fails fast
+ * with a `DiscoveryError` rather than silently degrading. Every dependency
+ * (worker factory, candidate builder, library probe) is injectable so tests can
+ * drive the pipeline without workers or FFI. The module also re-exports the
+ * pipeline types and formatting helpers that external consumers import.
+ */
 import { assertExists } from "@std/assert";
 import { getLogger } from "@utils/Logger.ts";
 import { format } from "@std/fmt/duration";

--- a/src/discovery/DiscoveryWireFormat.ts
+++ b/src/discovery/DiscoveryWireFormat.ts
@@ -1,3 +1,24 @@
+/**
+ * @module
+ *
+ * The wire schema for Discovery payloads that cross a process, worker, cache,
+ * disk or Rust FFI boundary — and the translator that produces them.
+ *
+ * TypeScript owns the in-memory candidate shapes (`CandidateNeuron`,
+ * `CoordinatedStructuralCandidate`, …), which are addressed by ephemeral
+ * runtime integer ids. The `Wire*` types here are their boundary-safe
+ * counterparts, addressed by stable neuron UUIDs only; the Rust side and the
+ * on-disk caches consume this shape.
+ * {@link buildDiscoveryWireRequest} performs the conversion using the runtime-id
+ * to UUID map from `DiscoveryWireIdentity.ts`.
+ *
+ * {@link DISCOVERY_WIRE_SCHEMA_VERSION} versions that contract — bump it when
+ * the shape changes so stale caches are not read as current.
+ * {@link assertNoLegacyDiscoveryIdFields} enforces the AGENTS.md rule that no
+ * runtime id may leak onto the wire: a payload carrying `fromNeuronId`,
+ * `neuronId` or any sibling throws a `TopologyError` rather than being quietly
+ * accepted.
+ */
 import { TopologyError } from "@errors/TopologyError.ts";
 import { appendAll } from "@utils/ArrayAppend.ts";
 import type {

--- a/src/discovery/NeuronErrorImpactEstimator.ts
+++ b/src/discovery/NeuronErrorImpactEstimator.ts
@@ -1,3 +1,18 @@
+/**
+ * @module
+ *
+ * Estimates, per neuron, the largest share of the creature's total error that
+ * neuron could remove if its own error went to zero — a cheap, purely
+ * structural upper bound computed by walking backwards from the outputs and
+ * splitting each neuron's error share across its inbound synapses in proportion
+ * to their absolute weights.
+ *
+ * Discovery uses these shares to decide where structural change is worth
+ * proposing: a neuron that can only influence a fraction of a percent of the
+ * error is not worth a candidate. Reach for it when ranking neurons by
+ * potential rather than by measured contribution — it needs only the topology
+ * and weights, no forward pass or trace.
+ */
 import type { Creature } from "@creature";
 
 const EPSILON = 1e-9;

--- a/src/methods/activations/aggregate/MAXIMUM.ts
+++ b/src/methods/activations/aggregate/MAXIMUM.ts
@@ -1,3 +1,20 @@
+/**
+ * @module
+ *
+ * The `MAXIMUM` aggregate squash: the neuron outputs the largest of its inbound
+ * synapse values plus its bias, instead of the weighted sum a conventional
+ * activation takes. It is one of NEAT-AI's own aggregate squashes (see
+ * `docs/ACTIVATION_FUNCTIONS.md`), letting evolution express "whichever
+ * upstream signal is strongest wins" as a single neuron rather than a subgraph.
+ *
+ * Backpropagation through a max is the interesting part, and why this module is
+ * large: the gradient belongs to the winning connection, but a losing
+ * connection whose value sits close to the winner still receives a leaked
+ * fraction (the shared runner-up proximity rule, Issue #1874). Tracing and
+ * propagation must agree about that window — `RunnerUpProximity.ts` is its
+ * single source of truth — or `applyLearnings` would disconnect a synapse that
+ * is still learning.
+ */
 import { assert } from "@std/assert";
 import type { DiscoverRecord } from "@architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
 import type { Neuron } from "@architecture/Neuron.ts";

--- a/src/methods/activations/aggregate/MINIMUM.ts
+++ b/src/methods/activations/aggregate/MINIMUM.ts
@@ -1,3 +1,21 @@
+/**
+ * @module
+ *
+ * The `MINIMUM` aggregate squash: the neuron outputs the smallest of its
+ * inbound synapse values plus its bias, instead of the weighted sum a
+ * conventional activation takes. It is the mirror of `MAXIMUM.ts` and one of
+ * NEAT-AI's own aggregate squashes (see `docs/ACTIVATION_FUNCTIONS.md`),
+ * letting evolution express "the weakest upstream signal gates the output" as a
+ * single neuron rather than a subgraph.
+ *
+ * Backpropagation through a min is the interesting part, and why this module is
+ * large: the gradient belongs to the winning connection, but a losing
+ * connection whose value sits close to the winner still receives a leaked
+ * fraction (the shared runner-up proximity rule, Issue #1874). Tracing and
+ * propagation must agree about that window — `RunnerUpProximity.ts` is its
+ * single source of truth — or `applyLearnings` would disconnect a synapse that
+ * is still learning.
+ */
 import { assert } from "@std/assert";
 import type { DiscoverRecord } from "@architecture/ErrorGuidedStructuralEvolution/DiscoverStructure.ts";
 import type { Neuron } from "@architecture/Neuron.ts";

--- a/src/multithreading/workers/WorkerHandler.ts
+++ b/src/multithreading/workers/WorkerHandler.ts
@@ -1,3 +1,21 @@
+/**
+ * @module
+ *
+ * The main thread's half of the worker protocol. A {@link WorkerHandler} owns
+ * one Deno Worker (or an in-process mock when `direct` is set) and exposes the
+ * jobs evolution farms out to it — evaluate, train, discover, and their
+ * variants — as promises.
+ *
+ * {@link RequestData} and {@link ResponseData} are the message contract with
+ * `WorkerProcessor.ts`, which runs the other half inside the worker. Reach for
+ * this module when adding a new kind of worker job: the request/response pair
+ * must be extended on both sides.
+ *
+ * Lifecycle (spawn, in-flight request tracking, termination) is inherited from
+ * `WorkerHandlerBase`. The handler is deliberately loud about start-up
+ * problems: a worker that fails to initialise rejects its pending work with the
+ * captured error rather than hanging or reporting an empty result.
+ */
 import { assert } from "@std/assert";
 import { addTag, getTag } from "@stsoftware/tags/mod";
 import type { CostName } from "@costs";

--- a/src/multithreading/workers/WorkerProcessor.ts
+++ b/src/multithreading/workers/WorkerProcessor.ts
@@ -1,3 +1,20 @@
+/**
+ * @module
+ *
+ * The worker's half of the worker protocol. {@link WorkerProcessor} receives
+ * the `RequestData` messages sent by `WorkerHandler.ts` on the main thread,
+ * runs the actual work inside the worker — dataset load, scoring, training,
+ * discovery — and returns the matching `ResponseData`.
+ *
+ * Reach for this module when adding a new kind of worker job: the handler
+ * defines the request, this defines what happens to it. It also owns the
+ * worker-local state that makes repeat jobs cheap (resolved cost function,
+ * dataset file-list cache, one-time WASM initialisation).
+ *
+ * Discovery results can be very large, so payloads are trimmed to what the main
+ * thread actually reads and the source structures are released for collection
+ * before the response is posted.
+ */
 import { assert } from "@std/assert";
 import { recordDirectory } from "@architecture/ErrorGuidedStructuralEvolution/DiscoverDirectory.ts";
 import { toErrorMessage } from "@utils/ErrorSerialisation.ts";

--- a/src/propagate/sparse/SparseConfig.ts
+++ b/src/propagate/sparse/SparseConfig.ts
@@ -1,3 +1,20 @@
+/**
+ * @module
+ *
+ * Decides which neurons take part in one sparse backpropagation iteration.
+ *
+ * Sparse training updates only a `sparseRatio` subset of neurons per iteration
+ * instead of the whole creature. {@link SparseConfig} resolves that subset once
+ * at construction — the chosen neurons, plus every neuron on a path from one of
+ * them to an output — and then answers the three per-neuron questions the
+ * propagation loop asks: does this neuron need tracing, propagating, or
+ * updating? Neurons on a path must still propagate so gradient reaches the
+ * chosen ones, but only the chosen ones have their weights updated.
+ *
+ * Selection is error-guided when per-neuron errors from the previous iteration
+ * are supplied (Issue #1388), otherwise it is random. Build one config per
+ * iteration; it is immutable once constructed.
+ */
 import type { CreatureExport } from "@architecture/CreatureInterfaces.ts";
 import type { NeuronStateInterface } from "@architecture/CreatureState.ts";
 import type { BackPropagationConfig } from "@propagate/BackPropagation.ts";

--- a/src/score/RustScorerBridge.ts
+++ b/src/score/RustScorerBridge.ts
@@ -1,3 +1,24 @@
+/**
+ * @module
+ *
+ * Bridge to the optional external `rust_scorer` binary — an out-of-process
+ * scorer that can evaluate a creature (or a directory of creatures) faster than
+ * the WASM path for large datasets.
+ *
+ * The boundary is a subprocess, not FFI: the creature is written to a temporary
+ * JSON file and the binary is invoked with absolute paths, because it resolves
+ * relative paths against its own cwd. {@link tryScoreWithRustScorer} returns
+ * `undefined` — meaning "caller should score with WASM" — whenever the scorer
+ * is disabled, absent, or too old to honour the configured cost function
+ * (Issue #2745); a genuinely corrupt dataset still throws rather than being
+ * downgraded to a silent fallback.
+ *
+ * Configuration comes from `NEAT_AI_RUST_SCORER_*` environment variables via
+ * {@link getEnvRustScorerConfig} and is cached for the process. The `__`-prefixed
+ * exports are test seams: under `deno test --parallel` every test file shares
+ * one OS environment, so tests must override module state rather than
+ * `Deno.env` (Issue #3234).
+ */
 import { join, resolve } from "@std/path";
 import type { Creature } from "@creature";
 import type { RequiredRustScorerConfig } from "@config/RustScorerConfig.ts";


### PR DESCRIPTION
## Summary

Added a leading `/** @module … */` JSDoc block to the seventeen public modules
under `src/` that went straight from their imports to their first code
statement, leaving a new reader with nothing that says what the module provides,
why it exists, or when to reach for it.

Each block was written from the module's actual code, not its filename, and
states what the signature cannot — for example the wire-schema version contract
and the UUID-only boundary rule for `DiscoveryWireFormat.ts`, the discovery
pipeline's entry point and its fail-fast behaviour without the Rust library for
`DiscoveryRunner.ts`, and the subprocess boundary plus WASM-fallback semantics
for `RustScorerBridge.ts`. This follows the precedent set by the closed
`@module` issues #3119–#3123.

This is a documentation-only change — no code, types, or behaviour were
modified. Closes #3688.

Files documented:

- `src/NEAT/DiscoveryReplayQueue.ts`
- `src/NEAT/LogApproach.ts`
- `src/architecture/ErrorGuidedStructuralEvolution/ApplyCoordinatedStructuralCandidate.ts`
- `src/architecture/ErrorGuidedStructuralEvolution/DiscoveryWireIdentity.ts`
- `src/compact/CompactUnused.ts`
- `src/compact/DeadSubgraphPruning.ts`
- `src/compact/SynapsePruning.ts`
- `src/config/TrainOptions.ts`
- `src/discovery/DiscoveryRunner.ts`
- `src/discovery/DiscoveryWireFormat.ts`
- `src/discovery/NeuronErrorImpactEstimator.ts`
- `src/methods/activations/aggregate/MAXIMUM.ts`
- `src/methods/activations/aggregate/MINIMUM.ts`
- `src/multithreading/workers/WorkerHandler.ts`
- `src/multithreading/workers/WorkerProcessor.ts`
- `src/propagate/sparse/SparseConfig.ts`
- `src/score/RustScorerBridge.ts`

The sites the issue deliberately excluded under the trivial-surface guard
(`BIPOLAR`/`LeakyReLU`/`STEP`, `ErrorHelper.ts`, `SynapseState.ts`,
`UpgradeOne.ts`, and the zero-export `deno/worker.ts`) were left untouched.

## Evidence

Backend/library change only — no web interface to screenshot.

`deno doc` picks up each new block. For example,
`deno doc src/discovery/DiscoveryWireFormat.ts` now opens with:

```
@module
    The wire schema for Discovery payloads that cross a process, worker, cache,
    disk or Rust FFI boundary — and the translator that produces them.

    TypeScript owns the in-memory candidate shapes (`CandidateNeuron`,
    `CoordinatedStructuralCandidate`, …), which are addressed by ephemeral
    runtime integer ids. The `Wire*` types here are their boundary-safe
    counterparts, addressed by stable neuron UUIDs only; the Rust side and the
    on-disk caches consume this shape.
    ...
```

```mermaid
flowchart LR
    Imports[imports] --> Doc["/** @module ... */"] --> Code[first declaration]
    Doc -.picked up by.-> DenoDoc[deno doc]
```

`git diff --stat` is additions only — 17 files, 293 insertions, 0 deletions —
confirming no existing line was altered.

Quality gate: `./quality.sh < /dev/null` passes cleanly —
`8216 passed | 0 failed | 4 ignored`, covering `deno fmt`, `deno lint`,
`deno check`, the WASM sync, and the full test suite.

## Test Plan

No unit tests apply. This is a pure documentation change adding JSDoc comments
with no new or modified runtime behaviour to assert on; per AGENTS.md a test
that inspected source text for doc comments would be a "how" test, which the
project explicitly forbids. Verification was:

- `./quality.sh < /dev/null` — full gate green (8216 tests passed, 0 failed).
- `deno fmt` / `deno lint` — clean across all 524 source files.
- `deno doc src/discovery/DiscoveryWireFormat.ts` — confirms the `@module` block
  is surfaced in generated documentation.
- `git diff --stat` — insertions only, so no existing behaviour was touched.



## Milestone
This PR is part of the **Scan 20260807** milestone and targets the `milestone/scan-20260807` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mskidsy7-f71396`<!-- vibe-worker-issue-3688 -->