### PR TITLE
Replace stale hand-maintained src/ tree in CONTRIBUTING.md (Issue #3689)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -573,28 +573,21 @@ for the full policy and canonical examples.
 
 ## 📁 Project Structure
 
-```
-src/                    # Source code
-  architecture/         # Core neural network architecture
-  breed/                # Crossover and breeding algorithms
-  compact/              # Network compaction and optimisation
-  config/               # Configuration and options
-  costs/                # Cost/fitness functions
-  creature/             # Creature behaviour modules
-  discovery/            # Discovery integration (Rust FFI bridge)
-  errors/               # Error types
-  intelligentDesign/    # Intelligent Design squash optimisation
-  methods/              # Activation functions (squash implementations)
-  mutate/               # Mutation operators
-  NEAT/                 # Core NEAT-AI evolutionary loop (selection, speciation)
-  propagate/            # Backpropagation
-  wasm/                 # WASM activation bridge
-test/                   # Tests (mirrors src/ structure)
-bench/                  # Benchmarks
-docs/                   # Extended documentation
-wasm_activation/        # WASM activation module (Rust source + pkg)
-scripts/                # Utility scripts
-```
+Top-level repository directories:
+
+- `src/` — Source code (one subdirectory per subsystem)
+- `test/` — Tests (mirrors `src/` structure)
+- `bench/` — Benchmarks
+- `docs/` — Extended documentation
+- `wasm_activation/pkg/` — Vendored WASM artefacts from NEAT-AI-core (no in-tree
+  Rust source; refreshed via `./build.sh`)
+- `scripts/` — Utility scripts
+
+The per-module layout under `src/` is **not** duplicated here — a
+hand-maintained tree only rots and misleads. Browse `src/` for the current,
+authoritative module layout, where each subdirectory is a subsystem. See the
+[Directory Structure section in AGENTS.md](./AGENTS.md#-directory-structure) for
+the canonical description.
 
 ## 💬 Getting Help
 

--- a/docs/archive/pr-summaries/pr-summary-3689.md
+++ b/docs/archive/pr-summaries/pr-summary-3689.md
@@ -1,0 +1,59 @@
+# Replace the stale hand-maintained `src/` tree in CONTRIBUTING.md (Issue #3689)
+
+## Summary
+
+`CONTRIBUTING.md` hand-maintained a "Project Structure" tree listing 14 `src/`
+subdirectories while the real tree has 29 — omitting `blackbox/`, `cache/`,
+`deprecated/`, `multithreading/`, `neuron/`, `onnx/`, `optimize/`,
+`predictiveCoding/`, `presets/`, `reconstruct/`, `score/`, `transfer/`,
+`upgrade/`, `utils/` and `workers/`. It also annotated `wasm_activation/` as
+"WASM activation module (Rust source + pkg)", which `CONTRIBUTING.md:186-188`
+itself contradicts ("Rust/Cargo is no longer built in-tree") — the directory
+contains only the vendored `pkg/` artefacts. Both defects violate the repo's own
+convention at `AGENTS.md:129-134`: the per-module `src/` layout "is **not**
+duplicated here — a hand-maintained tree only rots and misleads".
+
+The block is now the same top-level-only list AGENTS.md uses, with a corrected
+`wasm_activation/pkg/` annotation and a link to the AGENTS.md "Directory
+Structure" section as the single source of truth. Closes #3689.
+
+## Evidence
+
+Documentation-only change — no web interface to screenshot. The behavioural
+guard is `test/docs/ContributingProjectStructure.ts`, a sibling of the existing
+`test/docs/AgentsDirectoryStructure.ts` (Issue #3285) that reads the real `src/`
+layout from disk rather than grepping for fixed strings.
+
+Before the fix (all three guards fail):
+
+```text
+CONTRIBUTING.md Project Structure embeds a partial src/ tree: 14/29 subsystems
+listed, omitting [blackbox, cache, deprecated, multithreading, neuron, onnx,
+optimize, predictiveCoding, presets, reconstruct, score, transfer, upgrade,
+utils, workers].
+CONTRIBUTING.md Project Structure should reference `src/` as the source layout
+CONTRIBUTING.md must not describe wasm_activation/ as containing Rust source
+FAILED | 0 passed | 3 failed
+```
+
+After the fix:
+
+```text
+ok | 3 passed | 0 failed (2ms)
+```
+
+Full gate: `./quality.sh` → `ok | 8219 passed (5 steps) | 0 failed | 4 ignored`.
+
+## Test Plan
+
+Added `test/docs/ContributingProjectStructure.ts` with three regression tests
+that fail against the unfixed CONTRIBUTING.md:
+
+- **Partial-tree guard** — enumerates the live `src/` subdirectories with
+  `Deno.readDir` and asserts the section names either all of them or none, so a
+  subset that silently omits new subsystems cannot creep back in.
+- **Source-of-truth guard** — asserts the section points at `src/` and links to
+  AGENTS.md rather than restating the layout.
+- **WASM annotation guard** — asserts the section never describes
+  `wasm_activation/` as holding Rust source, and confirms `wasm_activation/src/`
+  genuinely does not exist on disk so the guard stays honest.

--- a/test/docs/ContributingProjectStructure.ts
+++ b/test/docs/ContributingProjectStructure.ts
@@ -1,0 +1,112 @@
+/**
+ * Issue #3689 — guard against a stale, hand-maintained `src/` tree in
+ * CONTRIBUTING.md.
+ *
+ * The "Project Structure" section listed 14 `src/` subdirectories while the
+ * real tree had roughly 33, so a newcomer concluded the codebase had no ONNX,
+ * transfer-learning, presets or predictive-coding modules. It also annotated
+ * `wasm_activation/` as holding Rust source, which CONTRIBUTING.md itself
+ * contradicts ("Rust/Cargo is no longer built in-tree").
+ *
+ * These guards mirror `test/docs/AgentsDirectoryStructure.ts`: read the real
+ * `src/` layout and assert the section never re-introduces a partial per-module
+ * listing, and that the `wasm_activation/` annotation stays truthful.
+ */
+
+import { assert } from "@std/assert";
+
+const HEADING = "## 📁 Project Structure";
+
+/** Extract the body of the "Project Structure" heading up to the next `##`. */
+function projectStructureSection(text: string): string {
+  const start = text.indexOf(HEADING);
+  assert(
+    start !== -1,
+    "CONTRIBUTING.md is missing the Project Structure heading",
+  );
+  const rest = text.slice(start + HEADING.length);
+  const end = rest.indexOf("\n## ");
+  return end === -1 ? rest : rest.slice(0, end);
+}
+
+async function readSection(): Promise<string> {
+  const contributing = await Deno.readTextFile(
+    new URL("../../CONTRIBUTING.md", import.meta.url),
+  );
+  return projectStructureSection(contributing);
+}
+
+Deno.test(
+  "CONTRIBUTING.md Project Structure does not embed a partial src/ module tree",
+  async () => {
+    const section = await readSection();
+
+    // Live subsystem directories directly under src/.
+    const srcRoot = new URL("../../src/", import.meta.url);
+    const liveSubsystems: string[] = [];
+    for await (const entry of Deno.readDir(srcRoot)) {
+      if (entry.isDirectory) liveSubsystems.push(entry.name);
+    }
+    assert(liveSubsystems.length > 0, "expected src/ to contain subsystems");
+
+    const listed = liveSubsystems.filter((name) =>
+      section.includes(`${name}/`)
+    );
+    const omitted = liveSubsystems.filter((name) => !listed.includes(name));
+
+    // A partial listing is exactly the stale-tree failure mode: some subsystems
+    // documented, others silently omitted. Require all-or-nothing.
+    assert(
+      listed.length === 0 || omitted.length === 0,
+      `CONTRIBUTING.md Project Structure embeds a partial src/ tree: ` +
+        `${listed.length}/${liveSubsystems.length} subsystems listed, ` +
+        `omitting [${omitted.sort().join(", ")}]. Point to src/ as the ` +
+        `single source of truth instead of maintaining the list by hand.`,
+    );
+  },
+);
+
+Deno.test(
+  "CONTRIBUTING.md Project Structure points to src/ as source of truth",
+  async () => {
+    const section = await readSection();
+    assert(
+      section.includes("`src/`"),
+      "CONTRIBUTING.md Project Structure should reference `src/` as the source layout",
+    );
+    assert(
+      section.includes("AGENTS.md"),
+      "CONTRIBUTING.md Project Structure should link to the AGENTS.md Directory Structure section",
+    );
+  },
+);
+
+Deno.test(
+  "CONTRIBUTING.md does not claim in-tree Rust source under wasm_activation/",
+  async () => {
+    const section = await readSection();
+    // Rust source is no longer built in-tree; wasm_activation/ holds only the
+    // vendored pkg/ artefacts synced from NEAT-AI-core.
+    assert(
+      !/wasm_activation\/[^\n]*Rust source/i.test(section),
+      "CONTRIBUTING.md must not describe wasm_activation/ as containing Rust source — " +
+        "it holds vendored WASM artefacts from NEAT-AI-core only",
+    );
+
+    const rustSourceDir = new URL(
+      "../../wasm_activation/src/",
+      import.meta.url,
+    );
+    let hasRustSource = false;
+    try {
+      await Deno.stat(rustSourceDir);
+      hasRustSource = true;
+    } catch {
+      hasRustSource = false;
+    }
+    assert(
+      !hasRustSource,
+      "wasm_activation/src/ exists — the docs guard above needs revisiting",
+    );
+  },
+);


### PR DESCRIPTION
# Replace the stale hand-maintained `src/` tree in CONTRIBUTING.md (Issue #3689)

## Summary

`CONTRIBUTING.md` hand-maintained a "Project Structure" tree listing 14 `src/`
subdirectories while the real tree has 29 — omitting `blackbox/`, `cache/`,
`deprecated/`, `multithreading/`, `neuron/`, `onnx/`, `optimize/`,
`predictiveCoding/`, `presets/`, `reconstruct/`, `score/`, `transfer/`,
`upgrade/`, `utils/` and `workers/`. It also annotated `wasm_activation/` as
"WASM activation module (Rust source + pkg)", which `CONTRIBUTING.md:186-188`
itself contradicts ("Rust/Cargo is no longer built in-tree") — the directory
contains only the vendored `pkg/` artefacts. Both defects violate the repo's own
convention at `AGENTS.md:129-134`: the per-module `src/` layout "is **not**
duplicated here — a hand-maintained tree only rots and misleads".

The block is now the same top-level-only list AGENTS.md uses, with a corrected
`wasm_activation/pkg/` annotation and a link to the AGENTS.md "Directory
Structure" section as the single source of truth. Closes #3689.

## Evidence

Documentation-only change — no web interface to screenshot. The behavioural
guard is `test/docs/ContributingProjectStructure.ts`, a sibling of the existing
`test/docs/AgentsDirectoryStructure.ts` (Issue #3285) that reads the real `src/`
layout from disk rather than grepping for fixed strings.

Before the fix (all three guards fail):

```text
CONTRIBUTING.md Project Structure embeds a partial src/ tree: 14/29 subsystems
listed, omitting [blackbox, cache, deprecated, multithreading, neuron, onnx,
optimize, predictiveCoding, presets, reconstruct, score, transfer, upgrade,
utils, workers].
CONTRIBUTING.md Project Structure should reference `src/` as the source layout
CONTRIBUTING.md must not describe wasm_activation/ as containing Rust source
FAILED | 0 passed | 3 failed
```

After the fix:

```text
ok | 3 passed | 0 failed (2ms)
```

Full gate: `./quality.sh` → `ok | 8219 passed (5 steps) | 0 failed | 4 ignored`.

## Test Plan

Added `test/docs/ContributingProjectStructure.ts` with three regression tests
that fail against the unfixed CONTRIBUTING.md:

- **Partial-tree guard** — enumerates the live `src/` subdirectories with
  `Deno.readDir` and asserts the section names either all of them or none, so a
  subset that silently omits new subsystems cannot creep back in.
- **Source-of-truth guard** — asserts the section points at `src/` and links to
  AGENTS.md rather than restating the layout.
- **WASM annotation guard** — asserts the section never describes
  `wasm_activation/` as holding Rust source, and confirms `wasm_activation/src/`
  genuinely does not exist on disk so the guard stays honest.



## Milestone
This PR is part of the **Scan 20260807** milestone and targets the `milestone/scan-20260807` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mskkv9d2-100dfe`<!-- vibe-worker-issue-3689 -->