### PR TITLE
Document SOFTMAX in the activations strategy table (Issue #3690)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -499,6 +499,8 @@ function's practical usefulness.
 
 Add an entry to `src/methods/activations/README.md` following the existing
 format — include priority, invertibility, and backpropagation strategy.
+`test/docs/ActivationStrategyTable.ts` fails when that table and the registry in
+`src/methods/activations/Activations.ts` disagree.
 
 ## 🎨 Code Style
 

--- a/docs/archive/pr-summaries/pr-summary-3690.md
+++ b/docs/archive/pr-summaries/pr-summary-3690.md
@@ -1,0 +1,73 @@
+# PR Summary — Issue #3690
+
+## Summary
+
+The backpropagation-strategy table in `src/methods/activations/README.md`
+documented 38 activations while `src/methods/activations/Activations.ts`
+registers 39 — `SOFTMAX` appeared nowhere, despite being the output activation
+the `CROSS_ENTROPY` coupling selects. Closes #3690.
+
+Changes:
+
+- Added the `SOFTMAX` row to the strategy table, plus a note explaining why it
+  is the odd one out: true softmax is a vector operation, so `unSquash()`
+  inverts the per-neuron logistic surrogate rather than the normalised vector
+  (`softmaxNormalise()` does the vector form); `calculateError()` returns the
+  softmax + cross-entropy gradient (`target − activation`) with no derivative
+  scaling; and its `⬇ 0` priority means "chosen explicitly on an output layer",
+  not "deprecated or unsuitable" like the other zero-priority rows.
+- Extended the Invertible legend with `⚠️` (surrogate-only inversion) so the new
+  row's marker is defined.
+- Added an `[!IMPORTANT]` note naming `Activations.ts` as the authoritative list
+  that the table documents.
+- `CONTRIBUTING.md` step 4 now points at the guard test.
+
+## Evidence
+
+Documentation change with no web interface to screenshot. The evidence is the
+new guard test, which fails against the unfixed README and passes after it.
+
+Before the README fix:
+
+```text
+activations README documents every registered squash ... FAILED
+  [Diff] Actual / Expected
+  -   [ "SOFTMAX" ]
+  +   []
+activations README names the registry as authoritative ... FAILED
+FAILED | 1 passed | 2 failed
+```
+
+After:
+
+```text
+activations README documents every registered squash ... ok
+activations README has no rows for unregistered squashes ... ok
+activations README names the registry as authoritative ... ok
+ok | 3 passed | 0 failed
+```
+
+Full gate: `./quality.sh < /dev/null` →
+`ok | 8222 passed (5 steps) | 0 failed |
+4 ignored (1m11s)`.
+
+```mermaid
+flowchart LR
+    A["Activations.ts registry<br/>39 squashes"] -->|authoritative| B["README strategy table"]
+    A --> C["test/docs/<br/>ActivationStrategyTable.ts"]
+    B --> C
+    C -->|"missing row / orphan row"| D["❌ quality gate fails"]
+    C -->|"in sync"| E["✅ passes"]
+```
+
+## Test Plan
+
+- Added `test/docs/ActivationStrategyTable.ts`:
+  - `activations README documents every registered squash` — every canonical
+    name from `Activations.list()` has a table row (regression test for the
+    missing `SOFTMAX` entry).
+  - `activations README has no rows for unregistered squashes` — the reverse
+    direction, so a removed or renamed squash cannot leave a stale row.
+  - `activations README names the registry as authoritative` — the README points
+    readers at `Activations.ts`.
+- No existing tests modified or removed.

--- a/src/methods/activations/README.md
+++ b/src/methods/activations/README.md
@@ -56,6 +56,12 @@ This README captures:
 
 ## 📊 Squash Function Summary
 
+> [!IMPORTANT]
+> The registry in [`Activations.ts`](./Activations.ts) is the **authoritative**
+> list of squash functions; this table documents it. When you add or remove an
+> activation there, add or remove its row here in the same change —
+> `test/docs/ActivationStrategyTable.ts` fails when the two drift apart.
+
 | Activation      | Invertible | Derivative-Based Error              | Foggy Glasses Error            | Priority | Recommendation | Why?                                                                                             | 🐇🦥 |
 | :-------------- | :--------- | :---------------------------------- | :----------------------------- | :------: | :------------- | :----------------------------------------------------------------------------------------------- | :--- |
 | LeakyReLU       | ✅         | ❌ Overshoots easily if slope small | ✅ Inversion is trivial        |    10    | 🎯 UnSquash    | Always use unSquash — it's fast, safe, and avoids giant updates from small slopes.               | 🟩   |
@@ -109,12 +115,6 @@ This README captures:
 > zero-priority rows: SOFTMAX is neither deprecated nor unsuitable, it is simply
 > chosen explicitly on a multi-class output layer rather than by random
 > mutation.
-
-> [!IMPORTANT]
-> The registry in [`Activations.ts`](./Activations.ts) is the **authoritative**
-> list of squash functions; this table documents it. When you add or remove an
-> activation there, add or remove its row here in the same change —
-> `test/docs/ActivationStrategyTable.ts` fails when the two drift apart.
 
 ---
 

--- a/src/methods/activations/README.md
+++ b/src/methods/activations/README.md
@@ -34,6 +34,7 @@ This README captures:
 
 - 🧠 **Invertible**:\
   ✅ = squash function can be reliably inverted (used for Foggy Glasses)\
+  ⚠️ = only a surrogate is invertible, not the true function (see SOFTMAX)\
   ❌ = inversion undefined, unreliable, or non-existent
 
 - 🔁 **Priority**:\
@@ -95,6 +96,25 @@ This README captures:
 | SQUARE          | ✅         | ⚠️ Slope zero at x=0                | ✅ Square root to invert       |    1     | 🟰 Either      | Use derivative when abs(x) > 0; fallback near zero. Safe zone fades outside [-5, 5].             | 🟩   |
 | BIPOLAR_SIGMOID | ✅         | ✅ Stable in centre, fades at edges | ✅ Invertible                  |    1     | 🟰 Either      | Use derivative for mid-range; fallback to unSquash + clamp to avoid huge errors near ±1.         | 🟩   |
 | BIPOLAR         | ❌         | ❌ Often flat                       | ⚠️ Roughly invertible          |   ⬇ 0    | 🟰 Either      | ❌ Harsh transition, poor learning, rarely used in practice                                      | 🟩   |
+| SOFTMAX         | ⚠️         | ✅ Cross-entropy shortcut           | ⚠️ Inverts the surrogate only  |   ⬇ 0    | 🚀 Derivative  | Output-layer only, paired with `CROSS_ENTROPY` — see the note below.                             | ❓   |
+
+> [!NOTE]
+> **SOFTMAX is the odd one out.** True softmax is a _vector_ operation, so it is
+> not element-wise invertible: `unSquash()` inverts the per-neuron logistic
+> surrogate (`softmax([x, 0])₀`), not the normalised vector — vector
+> normalisation lives in `softmaxNormalise()`. `calculateError()` returns the
+> canonical softmax + cross-entropy gradient (`target − activation`) with no
+> derivative scaling, because the softmax Jacobian cancels against the
+> cross-entropy loss. Its priority is `⬇ 0` for a different reason to the other
+> zero-priority rows: SOFTMAX is neither deprecated nor unsuitable, it is simply
+> chosen explicitly on a multi-class output layer rather than by random
+> mutation.
+
+> [!IMPORTANT]
+> The registry in [`Activations.ts`](./Activations.ts) is the **authoritative**
+> list of squash functions; this table documents it. When you add or remove an
+> activation there, add or remove its row here in the same change —
+> `test/docs/ActivationStrategyTable.ts` fails when the two drift apart.
 
 ---
 

--- a/test/docs/ActivationStrategyTable.ts
+++ b/test/docs/ActivationStrategyTable.ts
@@ -1,0 +1,94 @@
+/**
+ * Issue #3690 — `src/methods/activations/README.md` presents its
+ * backpropagation-strategy table as the full per-squash reference (CONTRIBUTING
+ * step 4 requires every new activation to add a row), but the table had drifted
+ * behind the registry in `src/methods/activations/Activations.ts`: SOFTMAX was
+ * registered yet undocumented.
+ *
+ * These tests pin the table to the registry in both directions:
+ *
+ *   1. Every activation the registry knows about has a row.
+ *   2. Every row names an activation the registry actually knows about, so a
+ *      removed or renamed squash cannot leave a stale row behind.
+ *
+ * Names are compared case-insensitively — the table's display casing (e.g.
+ * "Complement") is cosmetic; the registry's canonical name is authoritative.
+ */
+
+import { assert, assertEquals } from "@std/assert";
+import { fromFileUrl, resolve } from "@std/path";
+import { Activations } from "@methods/activations/Activations.ts";
+
+const REPO_ROOT = resolve(fromFileUrl(import.meta.url), "..", "..", "..");
+const README = `${REPO_ROOT}/src/methods/activations/README.md`;
+
+/** Canonical registry names (aliases resolve to the same instance). */
+function registeredNames(): Set<string> {
+  return new Set(Activations.list().map((activation) => activation.getName()));
+}
+
+/**
+ * Activation names in the first column of the strategy table. Header and
+ * separator rows are skipped; a row qualifies only when it has the table's full
+ * column count, so incidental pipes in prose are ignored.
+ */
+function documentedNames(markdown: string): string[] {
+  const names: string[] = [];
+  for (const line of markdown.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith("|")) continue;
+    const cells = trimmed.split("|").slice(1, -1).map((c) => c.trim());
+    if (cells.length < 7) continue;
+    const name = cells[0];
+    if (name === "" || name === "Activation") continue;
+    if (/^:?-+:?$/.test(name)) continue;
+    names.push(name);
+  }
+  return names;
+}
+
+Deno.test("activations README documents every registered squash", async () => {
+  const markdown = await Deno.readTextFile(README);
+  const documented = new Set(
+    documentedNames(markdown).map((n) => n.toLowerCase()),
+  );
+
+  const missing = [...registeredNames()]
+    .filter((name) => !documented.has(name.toLowerCase()))
+    .sort();
+
+  assertEquals(
+    missing,
+    [],
+    `src/methods/activations/README.md strategy table is missing rows for: ${
+      missing.join(", ")
+    }`,
+  );
+});
+
+Deno.test("activations README has no rows for unregistered squashes", async () => {
+  const markdown = await Deno.readTextFile(README);
+  const registered = new Set(
+    [...registeredNames()].map((n) => n.toLowerCase()),
+  );
+
+  const orphans = documentedNames(markdown)
+    .filter((name) => !registered.has(name.toLowerCase()))
+    .sort();
+
+  assertEquals(
+    orphans,
+    [],
+    `src/methods/activations/README.md documents squashes absent from the registry: ${
+      orphans.join(", ")
+    }`,
+  );
+});
+
+Deno.test("activations README names the registry as authoritative", async () => {
+  const markdown = await Deno.readTextFile(README);
+  assert(
+    markdown.includes("Activations.ts"),
+    "README must point readers at src/methods/activations/Activations.ts as the authoritative list",
+  );
+});


### PR DESCRIPTION
# PR Summary — Issue #3690

## Summary

The backpropagation-strategy table in `src/methods/activations/README.md`
documented 38 activations while `src/methods/activations/Activations.ts`
registers 39 — `SOFTMAX` appeared nowhere, despite being the output activation
the `CROSS_ENTROPY` coupling selects. Closes #3690.

Changes:

- Added the `SOFTMAX` row to the strategy table, plus a note explaining why it
  is the odd one out: true softmax is a vector operation, so `unSquash()`
  inverts the per-neuron logistic surrogate rather than the normalised vector
  (`softmaxNormalise()` does the vector form); `calculateError()` returns the
  softmax + cross-entropy gradient (`target − activation`) with no derivative
  scaling; and its `⬇ 0` priority means "chosen explicitly on an output layer",
  not "deprecated or unsuitable" like the other zero-priority rows.
- Extended the Invertible legend with `⚠️` (surrogate-only inversion) so the new
  row's marker is defined.
- Added an `[!IMPORTANT]` note naming `Activations.ts` as the authoritative list
  that the table documents.
- `CONTRIBUTING.md` step 4 now points at the guard test.

## Evidence

Documentation change with no web interface to screenshot. The evidence is the
new guard test, which fails against the unfixed README and passes after it.

Before the README fix:

```text
activations README documents every registered squash ... FAILED
  [Diff] Actual / Expected
  -   [ "SOFTMAX" ]
  +   []
activations README names the registry as authoritative ... FAILED
FAILED | 1 passed | 2 failed
```

After:

```text
activations README documents every registered squash ... ok
activations README has no rows for unregistered squashes ... ok
activations README names the registry as authoritative ... ok
ok | 3 passed | 0 failed
```

Full gate: `./quality.sh < /dev/null` →
`ok | 8222 passed (5 steps) | 0 failed |
4 ignored (1m11s)`.

```mermaid
flowchart LR
    A["Activations.ts registry<br/>39 squashes"] -->|authoritative| B["README strategy table"]
    A --> C["test/docs/<br/>ActivationStrategyTable.ts"]
    B --> C
    C -->|"missing row / orphan row"| D["❌ quality gate fails"]
    C -->|"in sync"| E["✅ passes"]
```

## Test Plan

- Added `test/docs/ActivationStrategyTable.ts`:
  - `activations README documents every registered squash` — every canonical
    name from `Activations.list()` has a table row (regression test for the
    missing `SOFTMAX` entry).
  - `activations README has no rows for unregistered squashes` — the reverse
    direction, so a removed or renamed squash cannot leave a stale row.
  - `activations README names the registry as authoritative` — the README points
    readers at `Activations.ts`.
- No existing tests modified or removed.
