### PR TITLE
🟠 docs/api/CREATURE.md says exportJSON() emits runtime ids — contradicting the UUID-only invariant (Issue #3693)

### DIFF
--- a/docs/api/CREATURE.md
+++ b/docs/api/CREATURE.md
@@ -73,8 +73,8 @@ new Creature(input: number, output: number, options?: {
 | `propagate`          | `(expected: Float32Array, config: BackPropagationConfig, sparseConfig: SparseConfig): void` | Backpropagation — propagates errors backwards through the network.                                    |
 | `propagateUpdate`    | `(config: BackPropagationConfig, sparseConfig: SparseConfig): void`                         | Updates weights/biases based on propagated errors.                                                    |
 | `record`             | `(expected: Float32Array): Map<number, DiscoverRecord>`                                     | Records expected outputs for discovery analysis. The map key is the runtime neuron `id` (a `number`). |
-| `exportJSON`         | `(): CreatureExport`                                                                        | Canonical serialisation: wire UUIDs plus resolved runtime ids (`id` / `fromId` / `toId`).             |
-| `exportSnapshotJSON` | `(): CreatureExport`                                                                        | Wire-only snapshot: same topology as `exportJSON` but omits numeric ids (sharing / schema checks).    |
+| `exportJSON`         | `(): CreatureExport`                                                                        | Canonical external serialisation: the UUID-only wire format (no `id` / `fromId` / `toId`).            |
+| `exportSnapshotJSON` | `(): CreatureExport`                                                                        | Equivalent to `exportJSON`; retained for backward compatibility.                                      |
 | `traceJSON`          | `(): CreatureTrace`                                                                         | Exports with detailed trace information from last activation.                                         |
 | `loadFrom`           | `(json: CreatureInternal \| CreatureExport, validate: boolean): void`                       | Loads creature structure from a JSON object.                                                          |
 | `connect`            | `(from: number, to: number, weight: number, type?: SynapseType): Synapse`                   | Creates a synapse between two neurons.                                                                |
@@ -82,6 +82,13 @@ new Creature(input: number, output: number, options?: {
 | `shallowClone`       | `(): Creature`                                                                              | Fast clone without JSON serialisation overhead.                                                       |
 | `dispose`            | `(): void`                                                                                  | Releases all resources and memory.                                                                    |
 | `clearCache`         | `(from?: number, to?: number): void`                                                        | Clears internal synapse connection caches.                                                            |
+
+> [!CAUTION]
+> Both export methods emit the **UUID-only** wire format. The runtime integer
+> `id` / `fromId` / `toId` are in-memory implementation details and must never
+> cross a process, machine, disk, cache, or FFI boundary — see
+> [Neuron UUID stability](../../AGENTS.md#-neuron-uuid-stability-critical-invariant)
+> for the invariant and why it is load-bearing.
 
 ### ⚡ Static Methods
 
@@ -292,9 +299,12 @@ import { CreatureUtil, randomConnectMissing } from "@stsoftware/neat-ai";
 
 - `CreatureUtil` — utility class with helpers for working with creatures (UUID
   assignment, structural normalisation).
-- `randomConnectMissing(creature)` — connects neurons that lack required inward
-  or outward connections by inserting random synapses. Used during topology
-  repair after structural mutation.
+- `randomConnectMissing(creature)` — input-side repair only: every input neuron
+  with no outgoing synapse gains one to a randomly chosen neuron (weight scale
+  `0.1`). Returns a new, validated creature, or the original unchanged when no
+  input is missing. Neurons lacking inward connections and hidden neurons with
+  no outgoing synapse are left alone, and nothing inside the library calls it —
+  it is a helper for consumers repairing their own creatures.
 
 ---
 

--- a/docs/archive/pr-summaries/pr-summary-3693.md
+++ b/docs/archive/pr-summaries/pr-summary-3693.md
@@ -1,0 +1,92 @@
+# PR Summary — docs/api/CREATURE.md serialisation claims (Issue #3693)
+
+## Summary
+
+`docs/api/CREATURE.md` inverted the repository's most safety-critical
+serialisation contract. The method table described `exportJSON` as "Canonical
+serialisation: wire UUIDs plus resolved runtime ids (`id` / `fromId` / `toId`)"
+and `exportSnapshotJSON` as differing by omitting those numeric ids. Both claims
+are false: `src/creature/CreatureSerialization.ts:195` implements `exportJSON`
+as `buildCreatureExportJSON(creature, false)` — UUID-only — and
+`exportSnapshotJSON` (`:210`) simply delegates to `exportJSON`, retained for
+backward compatibility. `AGENTS.md` rule 4 of the Neuron UUID stability
+invariant states the same, and rule 3 forbids numeric ids from crossing any
+process, machine, disk, cache or FFI boundary (Issue #2090 showed hash-colliding
+integer ids silently corrupting creatures). A reader acting on the old wording
+would persist or match by numeric id — exactly the failure the invariant exists
+to prevent.
+
+The same document's `randomConnectMissing(creature)` bullet claimed it "connects
+neurons that lack required inward or outward connections … Used during topology
+repair after structural mutation". `src/reconstruct/ConnectMissing.ts:18-45`
+only connects **input** neurons that have no outgoing synapse, returns the
+creature unchanged when none is missing, and is exported from `mod.ts` for
+consumers — nothing under `src/` calls it.
+
+Both entries now match the source, with the export rows pointing at the
+AGENTS.md invariant rather than restating it. Closes #3693.
+
+## Evidence
+
+Documentation-only change plus a new guard test — no web interface to
+screenshot. Each corrected claim is anchored to the live API in
+`test/docs/CreatureApiSerialisationClaims.ts`, following the existing
+`test/docs/` fact-check convention: the behaviour half fails if an export ever
+regains numeric ids, the doc half fails if the prose is reverted.
+
+Before the doc fix (TDD — the guard reproduced all three stale claims):
+
+```text
+error: AssertionError: exportJSON must be documented as UUID-only, got:
+  | `exportJSON` | `(): CreatureExport` | Canonical serialisation: wire UUIDs plus resolved runtime ids (`id` / `fromId` / `toId`). |
+error: AssertionError: exportSnapshotJSON must be documented as equivalent, got:
+  | `exportSnapshotJSON` | `(): CreatureExport` | Wire-only snapshot: same topology as `exportJSON` but omits numeric ids (sharing / schema checks). |
+error: AssertionError: randomConnectMissing must be documented as input-side, got:
+  - `randomConnectMissing(creature)` — connects neurons that lack required inward or outward connections … Used during topology repair after structural mutation.
+FAILED | 0 passed | 3 failed
+```
+
+After the doc fix, the full gate is green:
+
+```text
+./quality.sh
+ok | 8226 passed (5 steps) | 0 failed | 4 ignored (2m30s)
+```
+
+Where the documented claim now comes from:
+
+```mermaid
+flowchart LR
+    Src["CreatureSerialization.ts<br/>exportJSON → includeIds=false<br/>exportSnapshotJSON → exportJSON"]
+    Inv["AGENTS.md<br/>Neuron UUID stability rule 4"]
+    Guard["test/docs/<br/>CreatureApiSerialisationClaims.ts"]
+    Doc["docs/api/CREATURE.md<br/>UUID-only wire format"]
+
+    Src --> Guard
+    Inv --> Doc
+    Guard --> Doc
+    Guard -. "fails on drift in either" .-> Src
+```
+
+## Test Plan
+
+Added `test/docs/CreatureApiSerialisationClaims.ts` (three tests, each pairing a
+behaviour assertion with the doc claim it underwrites):
+
+- `CREATURE.md: exportJSON is documented as the UUID-only wire format` — asserts
+  a live `exportJSON()` carries `uuid` / `fromUUID` / `toUUID` and no `id` /
+  `fromId` / `toId`, then that the table row says UUID-only and never claims
+  runtime ids.
+- `CREATURE.md: exportSnapshotJSON is documented as equivalent to exportJSON` —
+  asserts the two produce an identical payload, then that the row states
+  equivalence rather than a difference.
+- `CREATURE.md: randomConnectMissing is documented as input-side only` — asserts
+  an already-connected creature is returned unchanged (same instance), then that
+  the bullet describes input neurons and drops both the "inward or outward" and
+  "topology repair after structural mutation" claims.
+
+Existing coverage left untouched and still passing:
+`test/architecture/ExportNoIntegerIds.ts` (the `exportJSON` /
+`exportSnapshotJSON` no-integer-id contract), `test/docs/ModExportBanners.ts`
+(`randomConnectMissing` touches unconnected inputs only), and
+`test/docs/ApiReferenceSplit.ts` (the new `../../AGENTS.md` link resolves).

--- a/test/docs/CreatureApiSerialisationClaims.ts
+++ b/test/docs/CreatureApiSerialisationClaims.ts
@@ -1,0 +1,126 @@
+/**
+ * Issue #3693 — fact-check guard for the serialisation and
+ * `randomConnectMissing` claims in `docs/api/CREATURE.md`.
+ *
+ * The method table claimed `exportJSON` emits "wire UUIDs plus resolved runtime
+ * ids (`id` / `fromId` / `toId`)" and that `exportSnapshotJSON` differs by
+ * omitting them. Both inverted the repo's most safety-critical serialisation
+ * contract (AGENTS.md "Neuron UUID stability", rule 4): `exportJSON` is
+ * UUID-only and `exportSnapshotJSON` is its backward-compatible equivalent.
+ * A second bullet claimed `randomConnectMissing` repairs neurons lacking
+ * "inward or outward" connections during topology repair; it only connects
+ * input neurons that have no outgoing synapse.
+ *
+ * Each documented claim is anchored to the live API here, so neither half can
+ * drift: the behaviour assertions fail if the exports ever regain numeric ids,
+ * and the doc assertions fail if the corrected prose is reverted.
+ */
+
+import { assert, assertEquals } from "@std/assert";
+import { fromFileUrl, join } from "@std/path";
+import { Creature, randomConnectMissing } from "../../mod.ts";
+
+const REPO_ROOT = fromFileUrl(new URL("../../", import.meta.url));
+const CREATURE_DOC = join(REPO_ROOT, "docs", "api", "CREATURE.md");
+
+async function readDocLines(): Promise<string[]> {
+  return (await Deno.readTextFile(CREATURE_DOC)).split("\n");
+}
+
+/**
+ * Extracts the claim documenting `symbol` — its method-table row when it has
+ * one, otherwise its bullet with wrapped continuation lines folded in. Scoping
+ * to a single claim keeps assertions from bleeding into a neighbouring entry,
+ * and folding the wrap keeps them alive across a `deno fmt` reflow.
+ */
+function claimFor(lines: string[], symbol: string): string {
+  const row = lines.findIndex((line) => line.startsWith(`| \`${symbol}\``));
+  const start = row >= 0
+    ? row
+    : lines.findIndex((line) => line.startsWith(`- \`${symbol}\``));
+  assert(start >= 0, `CREATURE.md must document ${symbol}`);
+
+  const block = [lines[start]];
+  if (lines[start].startsWith("- ")) {
+    for (let i = start + 1; i < lines.length; i++) {
+      const line = lines[i];
+      if (!line.startsWith("  ")) break; // end of the wrapped bullet
+      block.push(line);
+    }
+  }
+  return block.join(" ").replace(/\s+/g, " ");
+}
+
+Deno.test("CREATURE.md: exportJSON is documented as the UUID-only wire format", async () => {
+  const creature = new Creature(2, 1, { layers: [{ count: 2 }] });
+  const exported = creature.exportJSON();
+
+  // Behaviour anchor for the documented claim.
+  for (const neuron of exported.neurons) {
+    assert(neuron.uuid, "every exported neuron carries a uuid");
+    assertEquals(neuron.id, undefined, "exportJSON omits the runtime id");
+  }
+  for (const synapse of exported.synapses) {
+    assert(synapse.fromUUID && synapse.toUUID, "endpoints are uuid strings");
+    assertEquals(synapse.fromId, undefined, "exportJSON omits fromId");
+    assertEquals(synapse.toId, undefined, "exportJSON omits toId");
+  }
+
+  const claim = claimFor(await readDocLines(), "exportJSON");
+  assert(
+    /UUID-only/i.test(claim),
+    `exportJSON must be documented as UUID-only, got: ${claim}`,
+  );
+  assert(
+    !/runtime ids/i.test(claim),
+    `exportJSON must not be documented as emitting runtime ids, got: ${claim}`,
+  );
+});
+
+Deno.test("CREATURE.md: exportSnapshotJSON is documented as equivalent to exportJSON", async () => {
+  const creature = new Creature(3, 2, { layers: [{ count: 2 }] });
+
+  // Behaviour anchor: the two produce the same wire payload.
+  assertEquals(
+    JSON.stringify(creature.exportSnapshotJSON()),
+    JSON.stringify(creature.exportJSON()),
+    "exportSnapshotJSON is equivalent to exportJSON",
+  );
+
+  const claim = claimFor(await readDocLines(), "exportSnapshotJSON");
+  assert(
+    /equivalent/i.test(claim),
+    `exportSnapshotJSON must be documented as equivalent, got: ${claim}`,
+  );
+  assert(
+    !/omits numeric ids/i.test(claim),
+    `exportSnapshotJSON must not be documented as differing, got: ${claim}`,
+  );
+});
+
+Deno.test("CREATURE.md: randomConnectMissing is documented as input-side only", async () => {
+  // Behaviour anchor: an already-connected creature is returned untouched.
+  const connected = new Creature(3, 1);
+  assertEquals(
+    randomConnectMissing(connected),
+    connected,
+    "a creature with no unconnected input is returned unchanged",
+  );
+
+  const bullet = claimFor(
+    await readDocLines(),
+    "randomConnectMissing(creature)",
+  );
+  assert(
+    /input neuron/i.test(bullet),
+    `randomConnectMissing must be documented as input-side, got: ${bullet}`,
+  );
+  assert(
+    !/inward or outward/i.test(bullet),
+    `randomConnectMissing does not repair inward/outward gaps, got: ${bullet}`,
+  );
+  assert(
+    !/topology repair after structural mutation/i.test(bullet),
+    `randomConnectMissing has no topology-repair caller, got: ${bullet}`,
+  );
+});


### PR DESCRIPTION
# PR Summary — docs/api/CREATURE.md serialisation claims (Issue #3693)

## Summary

`docs/api/CREATURE.md` inverted the repository's most safety-critical
serialisation contract. The method table described `exportJSON` as "Canonical
serialisation: wire UUIDs plus resolved runtime ids (`id` / `fromId` / `toId`)"
and `exportSnapshotJSON` as differing by omitting those numeric ids. Both claims
are false: `src/creature/CreatureSerialization.ts:195` implements `exportJSON`
as `buildCreatureExportJSON(creature, false)` — UUID-only — and
`exportSnapshotJSON` (`:210`) simply delegates to `exportJSON`, retained for
backward compatibility. `AGENTS.md` rule 4 of the Neuron UUID stability
invariant states the same, and rule 3 forbids numeric ids from crossing any
process, machine, disk, cache or FFI boundary (Issue #2090 showed hash-colliding
integer ids silently corrupting creatures). A reader acting on the old wording
would persist or match by numeric id — exactly the failure the invariant exists
to prevent.

The same document's `randomConnectMissing(creature)` bullet claimed it "connects
neurons that lack required inward or outward connections … Used during topology
repair after structural mutation". `src/reconstruct/ConnectMissing.ts:18-45`
only connects **input** neurons that have no outgoing synapse, returns the
creature unchanged when none is missing, and is exported from `mod.ts` for
consumers — nothing under `src/` calls it.

Both entries now match the source, with the export rows pointing at the
AGENTS.md invariant rather than restating it. Closes #3693.

## Evidence

Documentation-only change plus a new guard test — no web interface to
screenshot. Each corrected claim is anchored to the live API in
`test/docs/CreatureApiSerialisationClaims.ts`, following the existing
`test/docs/` fact-check convention: the behaviour half fails if an export ever
regains numeric ids, the doc half fails if the prose is reverted.

Before the doc fix (TDD — the guard reproduced all three stale claims):

```text
error: AssertionError: exportJSON must be documented as UUID-only, got:
  | `exportJSON` | `(): CreatureExport` | Canonical serialisation: wire UUIDs plus resolved runtime ids (`id` / `fromId` / `toId`). |
error: AssertionError: exportSnapshotJSON must be documented as equivalent, got:
  | `exportSnapshotJSON` | `(): CreatureExport` | Wire-only snapshot: same topology as `exportJSON` but omits numeric ids (sharing / schema checks). |
error: AssertionError: randomConnectMissing must be documented as input-side, got:
  - `randomConnectMissing(creature)` — connects neurons that lack required inward or outward connections … Used during topology repair after structural mutation.
FAILED | 0 passed | 3 failed
```

After the doc fix, the full gate is green:

```text
./quality.sh
ok | 8226 passed (5 steps) | 0 failed | 4 ignored (2m30s)
```

Where the documented claim now comes from:

```mermaid
flowchart LR
    Src["CreatureSerialization.ts<br/>exportJSON → includeIds=false<br/>exportSnapshotJSON → exportJSON"]
    Inv["AGENTS.md<br/>Neuron UUID stability rule 4"]
    Guard["test/docs/<br/>CreatureApiSerialisationClaims.ts"]
    Doc["docs/api/CREATURE.md<br/>UUID-only wire format"]

    Src --> Guard
    Inv --> Doc
    Guard --> Doc
    Guard -. "fails on drift in either" .-> Src
```

## Test Plan

Added `test/docs/CreatureApiSerialisationClaims.ts` (three tests, each pairing a
behaviour assertion with the doc claim it underwrites):

- `CREATURE.md: exportJSON is documented as the UUID-only wire format` — asserts
  a live `exportJSON()` carries `uuid` / `fromUUID` / `toUUID` and no `id` /
  `fromId` / `toId`, then that the table row says UUID-only and never claims
  runtime ids.
- `CREATURE.md: exportSnapshotJSON is documented as equivalent to exportJSON` —
  asserts the two produce an identical payload, then that the row states
  equivalence rather than a difference.
- `CREATURE.md: randomConnectMissing is documented as input-side only` — asserts
  an already-connected creature is returned unchanged (same instance), then that
  the bullet describes input neurons and drops both the "inward or outward" and
  "topology repair after structural mutation" claims.

Existing coverage left untouched and still passing:
`test/architecture/ExportNoIntegerIds.ts` (the `exportJSON` /
`exportSnapshotJSON` no-integer-id contract), `test/docs/ModExportBanners.ts`
(`randomConnectMissing` touches unconnected inputs only), and
`test/docs/ApiReferenceSplit.ts` (the new `../../AGENTS.md` link resolves).



## Milestone
This PR is part of the **Scan 20260807** milestone and targets the `milestone/scan-20260807` feature branch.

---

🤖 Processed by: VibeCoderST
🏷️ Run id: `vibe-mskni9sd-bb640f`<!-- vibe-worker-issue-3693 -->