### PR TITLE
Transfer: validate creature shape at the importCheckpoint boundary (#3714)

### DIFF
--- a/docs/api/INTEROP.md
+++ b/docs/api/INTEROP.md
@@ -119,6 +119,12 @@ const creature = importCheckpoint(checkpoint, {
 
 **Returns:** `Creature` — a creature adapted to the target task.
 
+**Throws:** `ValidationError` when the checkpoint's `creature.input` /
+`creature.output`, or an explicitly supplied `targetInputCount` /
+`targetOutputCount`, is not an integer in `[1, 1_000_000]`. A checkpoint is
+untrusted input — it is read off disk or the network — so the shape is checked
+at the boundary before anything is allocated (Issue #3714).
+
 ### `createSeededPopulation(options)`
 
 Creates an initial population mixing pre-trained creatures with randomly

--- a/docs/archive/pr-summaries/pr-summary-3714.md
+++ b/docs/archive/pr-summaries/pr-summary-3714.md
@@ -1,0 +1,103 @@
+# Validate creature shape at the `importCheckpoint()` boundary (#3714)
+
+## Summary
+
+`importCheckpoint()` is a public deserialisation boundary — the checkpoint it is
+handed is read off disk or the network. It used the raw
+`checkpoint.creature.input` / `.output` counts as loop bounds before
+`Creature.fromJSON` could apply `assertValidCreatureShape`, so a hostile count
+burnt seconds of CPU and then died with `RangeError: Map maximum size exceeded`
+instead of failing fast with a `ValidationError`. Two loops were reachable:
+`normaliseCreatureExport`'s `json.input` pre-fill, and the output back-fill in
+`remapCreatureForTask` driven by `targetOutputCount`.
+
+The fix hoists `assertValidCreatureShape` to the first statement of
+`importCheckpoint`, and validates the resolved target counts (so an explicitly
+supplied `targetInputCount` / `targetOutputCount` is checked too) before
+`normaliseCreatureExport` runs. This places the guard at the deserialisation
+boundary, matching what Issue #3672 did for `Creature.fromJSON`.
+
+Also fixed alongside (noted in the issue, availability only, same file):
+`remapCreatureForTask` dereferenced `metadata.sourceInputIds` /
+`sourceOutputIds` with no presence check, so a checkpoint omitting those fields
+threw a raw `TypeError` out of a public API. Missing arrays now mean "nothing to
+map by position", and the positional-overlap loops are additionally capped by
+the actual array length so a mismatched `sourceInputCount` cannot insert
+`undefined` map keys.
+
+Closes #3714.
+
+## Evidence
+
+Backend/library change — no web interface to screenshot. Verified by the test
+suite.
+
+Order of operations after the change:
+
+```mermaid
+flowchart TD
+    A[importCheckpoint checkpoint, options] --> B{assertValidCreatureShape<br/>creature.input / creature.output}
+    B -- invalid --> X[ValidationError — nothing allocated]
+    B -- valid --> C{assertValidCreatureShape<br/>resolved target counts}
+    C -- invalid --> X
+    C -- valid --> D[normaliseCreatureExport<br/>input pre-fill loop]
+    D --> E{counts match and no mapping?}
+    E -- yes --> F[Creature.fromJSON]
+    E -- no --> G[remapCreatureForTask<br/>output back-fill loop]
+    G --> F
+    F --> H[freeze flags + WASM compile gate]
+```
+
+Before the fix (issue reproduction, both hostile cases):
+
+```text
+importCheckpoint - rejects fifty million input before allocating
+error: AssertionError: Expected error to be instance of "ValidationError", but was "RangeError".
+importCheckpoint - rejects fifty million output on the remap path
+error: AssertionError: Expected error to be instance of "ValidationError", but was "RangeError".
+importCheckpoint - metadata without id arrays does not throw TypeError
+error: TypeError: Cannot read properties of undefined (reading '0')
+      inputMap.set(metadata.sourceInputIds[i], i);
+
+FAILED | 29 passed | 9 failed (45s)
+```
+
+After the fix — the same suite plus the pre-existing checkpoint tests, and the
+45 seconds of allocation burn is gone:
+
+```text
+deno test test/transfer/CheckpointImportShapeValidation.ts test/transfer/Checkpoint.ts
+ok | 55 passed | 0 failed (497ms)
+```
+
+Full gate:
+
+```text
+./quality.sh < /dev/null
+ok | 8262 passed (5 steps) | 0 failed | 4 ignored (8m3s)
+```
+
+## Test Plan
+
+New regression suite `test/transfer/CheckpointImportShapeValidation.ts`:
+
+- `importCheckpoint - rejects <count> input before allocating` — hostile
+  `creature.input` (negative, zero, fractional, numeric string, `NaN`,
+  `Infinity`, `MAX_NEURON_COUNT + 1`, 50 million) throws `ValidationError`
+  naming `input`. The 50-million case is the issue's own reproduction and
+  previously threw `RangeError` after ~6 s.
+- `importCheckpoint - rejects <count> output on the remap path` — same counts on
+  `creature.output` with an `outputIdMapping` supplied, which is the remap path
+  that pushes one neuron per `targetOutputCount`.
+- `importCheckpoint - rejects <count> targetInputCount` /
+  `targetOutputCount` — explicitly supplied target counts are validated too.
+- `importCheckpoint - rejects a missing input/output count` — `undefined` on the
+  checkpoint is hostile; `undefined` in the options legitimately means "not
+  supplied" and falls back to the source count.
+- `importCheckpoint - metadata without id arrays does not throw TypeError` —
+  a checkpoint with `sourceInputIds` / `sourceOutputIds` removed imports
+  cleanly.
+- `importCheckpoint - a valid checkpoint still round-trips` — the happy path is
+  unchanged.
+
+Existing `test/transfer/Checkpoint.ts` (19 tests) passes unmodified.

--- a/docs/archive/pr-summaries/pr-summary-3714.md
+++ b/docs/archive/pr-summaries/pr-summary-3714.md
@@ -89,14 +89,13 @@ New regression suite `test/transfer/CheckpointImportShapeValidation.ts`:
 - `importCheckpoint - rejects <count> output on the remap path` — same counts on
   `creature.output` with an `outputIdMapping` supplied, which is the remap path
   that pushes one neuron per `targetOutputCount`.
-- `importCheckpoint - rejects <count> targetInputCount` /
-  `targetOutputCount` — explicitly supplied target counts are validated too.
+- `importCheckpoint - rejects <count> targetInputCount` / `targetOutputCount` —
+  explicitly supplied target counts are validated too.
 - `importCheckpoint - rejects a missing input/output count` — `undefined` on the
   checkpoint is hostile; `undefined` in the options legitimately means "not
   supplied" and falls back to the source count.
-- `importCheckpoint - metadata without id arrays does not throw TypeError` —
-  a checkpoint with `sourceInputIds` / `sourceOutputIds` removed imports
-  cleanly.
+- `importCheckpoint - metadata without id arrays does not throw TypeError` — a
+  checkpoint with `sourceInputIds` / `sourceOutputIds` removed imports cleanly.
 - `importCheckpoint - a valid checkpoint still round-trips` — the happy path is
   unchanged.
 

--- a/src/transfer/Checkpoint.ts
+++ b/src/transfer/Checkpoint.ts
@@ -11,6 +11,7 @@ import { Creature } from "@creature";
 import type { CreatureExport } from "@architecture/CreatureInterfaces.ts";
 import { normaliseCreatureExport } from "@architecture/NormaliseCreatureExport.ts";
 import { exportJSON } from "@creature/CreatureSerialization.ts";
+import { assertValidCreatureShape } from "@creature/CreatureShapeValidation.ts";
 import { nextNeuronId } from "@architecture/NeuronId.ts";
 import type {
   CheckpointInterface,
@@ -139,15 +140,36 @@ export interface CheckpointImportOptions {
  * Handles UUID mapping when source and target tasks have different
  * input/output configurations. Hidden layer topology and weights are
  * preserved from the checkpoint.
+ *
+ * @throws {ValidationError} When the checkpoint's `creature.input` /
+ *   `creature.output`, or an explicitly supplied `targetInputCount` /
+ *   `targetOutputCount`, is not an integer in `[1, MAX_NEURON_COUNT]`
+ *   (Issue #3714).
  */
 export function importCheckpoint(
   checkpoint: CheckpointInterface,
   options?: CheckpointImportOptions,
 ): Creature {
-  normaliseCreatureExport(checkpoint.creature);
+  // Issue #3714: a checkpoint is untrusted input — it is read off disk or the
+  // network — and its counts drive allocation loops in `normaliseCreatureExport`
+  // and `remapCreatureForTask` well before `Creature.fromJSON` gets to apply
+  // the same guard. Validate at the deserialisation boundary, matching #3672.
   const sourceCreature = checkpoint.creature;
+  assertValidCreatureShape(
+    sourceCreature?.input,
+    sourceCreature?.output,
+    "importCheckpoint",
+  );
+
   const targetInputCount = options?.targetInputCount ?? sourceCreature.input;
   const targetOutputCount = options?.targetOutputCount ?? sourceCreature.output;
+  assertValidCreatureShape(
+    targetInputCount,
+    targetOutputCount,
+    "importCheckpoint target",
+  );
+
+  normaliseCreatureExport(sourceCreature);
 
   // If input/output counts match and no mapping needed, simple import
   if (
@@ -266,6 +288,12 @@ function remapCreatureForTask(
   inputIdMapping?: Map<number, number>,
   outputIdMapping?: Map<number, number>,
 ): CreatureExport {
+  // Issue #3714: `metadata` comes from the same untrusted payload, so a
+  // checkpoint that omits the id arrays must not throw a raw TypeError out of
+  // a public API. Missing arrays simply mean "nothing to map by position".
+  const metadataInputIds = metadata?.sourceInputIds ?? [];
+  const metadataOutputIds = metadata?.sourceOutputIds ?? [];
+
   // Build input UUID mapping (source UUID -> target UUID)
   const inputMap = new Map<number, number>();
   if (inputIdMapping) {
@@ -275,11 +303,12 @@ function remapCreatureForTask(
   } else {
     // Default: map by position for overlapping inputs
     const overlapInputs = Math.min(
-      metadata.sourceInputCount,
+      metadata?.sourceInputCount ?? metadataInputIds.length,
       targetInputCount,
+      metadataInputIds.length,
     );
     for (let i = 0; i < overlapInputs; i++) {
-      inputMap.set(metadata.sourceInputIds[i], i);
+      inputMap.set(metadataInputIds[i], i);
     }
   }
 
@@ -292,17 +321,18 @@ function remapCreatureForTask(
   } else {
     // Default: map by position for overlapping outputs
     const overlapOutputs = Math.min(
-      metadata.sourceOutputCount,
+      metadata?.sourceOutputCount ?? metadataOutputIds.length,
       targetOutputCount,
+      metadataOutputIds.length,
     );
     for (let i = 0; i < overlapOutputs; i++) {
-      outputMap.set(metadata.sourceOutputIds[i], metadata.sourceOutputIds[i]);
+      outputMap.set(metadataOutputIds[i], metadataOutputIds[i]);
     }
   }
 
   // Collect the set of source input UUIDs to know which synapses to remap
-  const sourceInputIds = new Set(metadata.sourceInputIds);
-  const sourceOutputIds = new Set(metadata.sourceOutputIds);
+  const sourceInputIds = new Set(metadataInputIds);
+  const sourceOutputIds = new Set(metadataOutputIds);
 
   // Remap neurons: keep hidden neurons as-is, remap outputs
   const remappedNeurons = source.neurons.map((n) => {

--- a/test/transfer/CheckpointImportShapeValidation.ts
+++ b/test/transfer/CheckpointImportShapeValidation.ts
@@ -1,0 +1,159 @@
+/**
+ * Issue #3714: `importCheckpoint()` is a public deserialisation boundary — the
+ * checkpoint it is handed comes off disk or the network. It used the raw
+ * `checkpoint.creature.input` / `.output` counts as loop bounds (via
+ * `normaliseCreatureExport` and the output back-fill in `remapCreatureForTask`)
+ * before `Creature.fromJSON` could apply `assertValidCreatureShape`, so a
+ * hostile count burnt seconds of CPU and exhausted memory instead of raising a
+ * `ValidationError`.
+ *
+ * These tests pin the boundary check that now runs first, and the presence
+ * checks on the untrusted `metadata` id arrays.
+ *
+ * Note: without the fix the hostile cases throw `RangeError` (map/set maximum
+ * size exceeded) after seconds of allocation rather than failing fast.
+ */
+
+import { assert, assertEquals, assertThrows } from "@std/assert";
+import { Creature } from "@creature";
+import { exportCheckpoint, importCheckpoint } from "@transfer/Checkpoint.ts";
+import { MAX_NEURON_COUNT } from "@creature/CreatureShapeValidation.ts";
+import { ValidationError } from "@errors/ValidationError.ts";
+import type { CheckpointInterface } from "@transfer/CheckpointInterface.ts";
+import { initWasmForTests } from "../_initWasm.ts";
+
+/** A checkpoint carrying an arbitrary (possibly hostile) input/output shape. */
+function shapedCheckpoint(
+  input: unknown,
+  output: unknown,
+): CheckpointInterface {
+  return {
+    version: "1.0.0",
+    creature: {
+      input,
+      output,
+      neurons: [
+        { type: "output", uuid: "output-0", bias: 0, squash: "IDENTITY" },
+      ],
+      // A synapse without `fromId` defeats the `isResolvedIds` early return,
+      // so `normaliseCreatureExport` runs its `json.input` pre-fill loop.
+      synapses: [{ fromUUID: "input-0", toUUID: "output-0", weight: 0.1 }],
+    },
+    metadata: {},
+  } as unknown as CheckpointInterface;
+}
+
+/**
+ * Counts that must be rejected wherever they appear. `undefined` is only
+ * hostile on the checkpoint itself — on the options it means "not supplied"
+ * and legitimately falls back to the source creature's count.
+ */
+const HOSTILE_COUNTS: [string, unknown][] = [
+  ["negative", -1],
+  ["zero", 0],
+  ["fractional", 1.5],
+  ["numeric string", "2"],
+  ["NaN", Number.NaN],
+  ["Infinity", Number.POSITIVE_INFINITY],
+  ["above the ceiling", MAX_NEURON_COUNT + 1],
+  ["fifty million", 50_000_000],
+];
+
+Deno.test("importCheckpoint - rejects a missing input count", () => {
+  const error = assertThrows(
+    () => importCheckpoint(shapedCheckpoint(undefined, 1)),
+    ValidationError,
+  );
+  assert(error.message.includes("input"), error.message);
+});
+
+Deno.test("importCheckpoint - rejects a missing output count", () => {
+  const error = assertThrows(
+    () => importCheckpoint(shapedCheckpoint(2, undefined)),
+    ValidationError,
+  );
+  assert(error.message.includes("output"), error.message);
+});
+
+for (const [label, value] of HOSTILE_COUNTS) {
+  Deno.test(`importCheckpoint - rejects ${label} input before allocating`, () => {
+    const error = assertThrows(
+      () => importCheckpoint(shapedCheckpoint(value, 1)),
+      ValidationError,
+    );
+    assert(
+      error.message.includes("input"),
+      `message should name the offending field: ${error.message}`,
+    );
+  });
+
+  Deno.test(`importCheckpoint - rejects ${label} output on the remap path`, () => {
+    const error = assertThrows(
+      () =>
+        importCheckpoint(shapedCheckpoint(2, value), {
+          outputIdMapping: new Map(),
+        }),
+      ValidationError,
+    );
+    assert(
+      error.message.includes("output"),
+      `message should name the offending field: ${error.message}`,
+    );
+  });
+
+  Deno.test(`importCheckpoint - rejects ${label} targetInputCount`, () => {
+    const error = assertThrows(
+      () =>
+        importCheckpoint(shapedCheckpoint(2, 1), {
+          targetInputCount: value as number,
+        }),
+      ValidationError,
+    );
+    assert(
+      error.message.includes("input"),
+      `message should name the offending field: ${error.message}`,
+    );
+  });
+
+  Deno.test(`importCheckpoint - rejects ${label} targetOutputCount`, () => {
+    const error = assertThrows(
+      () =>
+        importCheckpoint(shapedCheckpoint(2, 1), {
+          targetOutputCount: value as number,
+        }),
+      ValidationError,
+    );
+    assert(
+      error.message.includes("output"),
+      `message should name the offending field: ${error.message}`,
+    );
+  });
+}
+
+Deno.test("importCheckpoint - metadata without id arrays does not throw TypeError", async () => {
+  await initWasmForTests();
+  const creature = new Creature(3, 2, { layers: [{ count: 4 }] });
+  const checkpoint = exportCheckpoint(creature);
+
+  // A checkpoint produced elsewhere may omit these optional-in-practice fields.
+  delete (checkpoint.metadata as { sourceInputIds?: number[] }).sourceInputIds;
+  delete (checkpoint.metadata as { sourceOutputIds?: number[] })
+    .sourceOutputIds;
+
+  const imported = importCheckpoint(checkpoint, { targetOutputCount: 3 });
+
+  assertEquals(imported.input, 3);
+  assertEquals(imported.output, 3);
+});
+
+Deno.test("importCheckpoint - a valid checkpoint still round-trips", async () => {
+  await initWasmForTests();
+  const creature = new Creature(3, 2, { layers: [{ count: 4 }] });
+  const checkpoint = exportCheckpoint(creature);
+
+  const imported = importCheckpoint(checkpoint);
+
+  assertEquals(imported.input, 3);
+  assertEquals(imported.output, 2);
+  assertEquals(imported.neurons.length, creature.neurons.length);
+});


### PR DESCRIPTION
# Validate creature shape at the `importCheckpoint()` boundary (#3714)

## Summary

`importCheckpoint()` is a public deserialisation boundary — the checkpoint it is
handed is read off disk or the network. It used the raw
`checkpoint.creature.input` / `.output` counts as loop bounds before
`Creature.fromJSON` could apply `assertValidCreatureShape`, so a hostile count
burnt seconds of CPU and then died with `RangeError: Map maximum size exceeded`
instead of failing fast with a `ValidationError`. Two loops were reachable:
`normaliseCreatureExport`'s `json.input` pre-fill, and the output back-fill in
`remapCreatureForTask` driven by `targetOutputCount`.

The fix hoists `assertValidCreatureShape` to the first statement of
`importCheckpoint`, and validates the resolved target counts (so an explicitly
supplied `targetInputCount` / `targetOutputCount` is checked too) before
`normaliseCreatureExport` runs. This places the guard at the deserialisation
boundary, matching what Issue #3672 did for `Creature.fromJSON`.

Also fixed alongside (noted in the issue, availability only, same file):
`remapCreatureForTask` dereferenced `metadata.sourceInputIds` /
`sourceOutputIds` with no presence check, so a checkpoint omitting those fields
threw a raw `TypeError` out of a public API. Missing arrays now mean "nothing to
map by position", and the positional-overlap loops are additionally capped by
the actual array length so a mismatched `sourceInputCount` cannot insert
`undefined` map keys.

Closes #3714.

## Evidence

Backend/library change — no web interface to screenshot. Verified by the test
suite.

Order of operations after the change:

```mermaid
flowchart TD
    A[importCheckpoint checkpoint, options] --> B{assertValidCreatureShape<br/>creature.input / creature.output}
    B -- invalid --> X[ValidationError — nothing allocated]
    B -- valid --> C{assertValidCreatureShape<br/>resolved target counts}
    C -- invalid --> X
    C -- valid --> D[normaliseCreatureExport<br/>input pre-fill loop]
    D --> E{counts match and no mapping?}
    E -- yes --> F[Creature.fromJSON]
    E -- no --> G[remapCreatureForTask<br/>output back-fill loop]
    G --> F
    F --> H[freeze flags + WASM compile gate]
```

Before the fix (issue reproduction, both hostile cases):

```text
importCheckpoint - rejects fifty million input before allocating
error: AssertionError: Expected error to be instance of "ValidationError", but was "RangeError".
importCheckpoint - rejects fifty million output on the remap path
error: AssertionError: Expected error to be instance of "ValidationError", but was "RangeError".
importCheckpoint - metadata without id arrays does not throw TypeError
error: TypeError: Cannot read properties of undefined (reading '0')
      inputMap.set(metadata.sourceInputIds[i], i);

FAILED | 29 passed | 9 failed (45s)
```

After the fix — the same suite plus the pre-existing checkpoint tests, and the
45 seconds of allocation burn is gone:

```text
deno test test/transfer/CheckpointImportShapeValidation.ts test/transfer/Checkpoint.ts
ok | 55 passed | 0 failed (497ms)
```

Full gate:

```text
./quality.sh < /dev/null
ok | 8262 passed (5 steps) | 0 failed | 4 ignored (8m3s)
```

## Test Plan

New regression suite `test/transfer/CheckpointImportShapeValidation.ts`:

- `importCheckpoint - rejects <count> input before allocating` — hostile
  `creature.input` (negative, zero, fractional, numeric string, `NaN`,
  `Infinity`, `MAX_NEURON_COUNT + 1`, 50 million) throws `ValidationError`
  naming `input`. The 50-million case is the issue's own reproduction and
  previously threw `RangeError` after ~6 s.
- `importCheckpoint - rejects <count> output on the remap path` — same counts on
  `creature.output` with an `outputIdMapping` supplied, which is the remap path
  that pushes one neuron per `targetOutputCount`.
- `importCheckpoint - rejects <count> targetInputCount` /
  `targetOutputCount` — explicitly supplied target counts are validated too.
- `importCheckpoint - rejects a missing input/output count` — `undefined` on the
  checkpoint is hostile; `undefined` in the options legitimately means "not
  supplied" and falls back to the source count.
- `importCheckpoint - metadata without id arrays does not throw TypeError` —
  a checkpoint with `sourceInputIds` / `sourceOutputIds` removed imports
  cleanly.
- `importCheckpoint - a valid checkpoint still round-trips` — the happy path is
  unchanged.

Existing `test/transfer/Checkpoint.ts` (19 tests) passes unmodified.



## Milestone
This PR is part of the **Scan 20260807** milestone and targets the `milestone/scan-20260807` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mskp45vt-b8d72a`<!-- vibe-worker-issue-3714 -->