### PR TITLE
Docs: discovery analysis is GPU-only, not CPU-fallback (#3692)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,8 +123,11 @@ but replaces unconditional mutation acceptance with MCMC").
   ([NEAT-AI-Discovery](https://github.com/stSoftwareAU/NEAT-AI-Discovery)) for
   GPU (Graphics Processing Unit) accelerated structural analysis
 - **wgpu** for cross-platform GPU compute shaders (Metal on macOS, Vulkan on
-  Linux, DX12 (DirectX 12) on Windows) with CPU (Central Processing Unit)
-  fallback
+  Linux, DX12 (DirectX 12) on Windows). Discovery analysis is **GPU-only** —
+  there is no CPU (Central Processing Unit) path; without an adapter,
+  `analyzeParallel()` returns a failure and discovery yields no proposals while
+  evolution continues (see
+  [`docs/GPU_ACCELERATION.md`](./docs/GPU_ACCELERATION.md))
 
 ### 📂 Directory Structure
 

--- a/docs/DISCOVERY_ARCHITECTURE.md
+++ b/docs/DISCOVERY_ARCHITECTURE.md
@@ -67,9 +67,9 @@ flowchart LR
         R3["Focus ranker"]:::rust
     end
 
-    subgraph compute["wgpu compute backend"]
+    subgraph compute["wgpu compute backend (GPU-only)"]
         G1["Metal (macOS)<br/>Vulkan (Linux)<br/>DirectX 12 (Windows)"]:::gpu
-        G2["CPU fallback"]:::gpu
+        G2["No adapter →<br/>analysis refused"]:::gpu
     end
 
     subgraph back["Result path"]
@@ -82,7 +82,6 @@ flowchart LR
     R2 --> G1
     R2 --> G2
     G1 --> D1
-    G2 --> D1
     R1 --> D1
     R3 --> D1
     D1 --> D2 --> H1
@@ -659,8 +658,9 @@ is flagged with warnings.
 
 ### 📦 Library Management
 
-- `isRustDiscoveryEnabled()` checks library availability. GPU is optional — the
-  Rust library falls back to CPU when no compatible GPU is present.
+- `isRustDiscoveryEnabled()` checks library availability only; it does not check
+  for a GPU. Analysis is GPU-only, so this returning `true` does not mean
+  proposals will be produced.
 - `isRustLibraryAvailable()` checks library loading only.
 - `isRustGpuAvailable()` checks whether a GPU backend (Metal/Vulkan/DX12) is
   available for acceleration.
@@ -669,9 +669,10 @@ is flagged with warnings.
 - Library loading is dynamic via Deno FFI (`.dylib` / `.so` / `.dll`).
 
 > [!NOTE]
-> `isRustDiscoveryEnabled()` requires the native library to be loadable. GPU
-> acceleration is automatic via wgpu (Metal on macOS, Vulkan on Linux, DX12 on
-> Windows) but not required — CPU fallback is always available.
+> `isRustDiscoveryEnabled()` requires the native library to be loadable. Backend
+> selection is automatic via wgpu (Metal on macOS, Vulkan on Linux, DX12 on
+> Windows), but an adapter **is** required: without one, `analyzeParallel()`
+> refuses every pass and discovery yields no proposals.
 
 ### 🧠 Analysis memory controls
 
@@ -906,7 +907,7 @@ flowchart LR
 - [TS_RUST_MIGRATION.md](TS_RUST_MIGRATION.md) — which subsystems live in
   TypeScript versus Rust / WASM today.
 - [GPU_ACCELERATION.md](GPU_ACCELERATION.md) — `wgpu` GPU backend selection and
-  CPU fallback.
+  the GPU-only analysis requirement.
 - [EXTERNAL_NEAT_AI_CORE.md](EXTERNAL_NEAT_AI_CORE.md) — vendored WASM artefact
   workflow.
 - [CONFIGURATION_GUIDE.md](CONFIGURATION_GUIDE.md) — All configuration options

--- a/docs/DISCOVERY_DIR.md
+++ b/docs/DISCOVERY_DIR.md
@@ -29,19 +29,23 @@ pipeline internals see [DISCOVERY_ARCHITECTURE.md](DISCOVERY_ARCHITECTURE.md).
   `cargo build --release` and either:
   - copy the resulting `libneat_ai_discovery` artefact into `~/.cargo/lib`, or
   - set `NEAT_AI_DISCOVERY_LIB_PATH=/absolute/path/to/libneat_ai_discovery.*`.
+- A GPU adapter. Discovery's synapse/neuron analysis is **GPU-only** — see
+  [GPU_ACCELERATION.md](GPU_ACCELERATION.md).
 - Discovery-aware builds of `NEAT-AI`. `discoveryDir()` internally calls
   `isRustDiscoveryEnabled()` and skips the discovery phase when the Rust module
   cannot be loaded, so a missing library degrades gracefully rather than
   throwing. The guard returns `true` only when the native library loads; GPU
-  availability is probed for telemetry but does **not** gate discovery (the Rust
-  library handles CPU fallback internally), and the result is cached after the
-  first call for low overhead. The implementation lives in
+  availability is probed separately and is **not** part of that gate, and the
+  result is cached after the first call for low overhead. The implementation
+  lives in
   [`RustDiscoveryLibrary.ts`](../src/architecture/ErrorGuidedStructuralEvolution/RustDiscoveryLibrary.ts).
 
 > [!NOTE]
 > If `isRustDiscoveryEnabled()` returns `false`, the Rust library is not
-> available and the discovery phase is skipped. When the library is available,
-> GPU acceleration is automatic (Metal/Vulkan/DX12 via wgpu) with CPU fallback.
+> available and the discovery phase is skipped. When the library is available
+> but no GPU adapter is, discovery is still _enabled_ — but every analysis pass
+> returns "GPU adapter not available" and yields no proposals. Both cases leave
+> evolution itself running normally.
 
 When the analyser is available, neuron discovery currently explores industry
 standard squashes including ReLU, GELU, ELU, SELU, Softplus, LOGISTIC (sigmoid),
@@ -475,7 +479,7 @@ multiple times.
 - [TS_RUST_MIGRATION.md](TS_RUST_MIGRATION.md) — which subsystems live in
   TypeScript versus Rust / WebAssembly (WASM).
 - [GPU_ACCELERATION.md](GPU_ACCELERATION.md) — `wgpu` GPU backend selection
-  (Metal / Vulkan / DirectX 12) and CPU fallback.
+  (Metal / Vulkan / DirectX 12) and the GPU-only analysis requirement.
 - [EXTERNAL_NEAT_AI_CORE.md](EXTERNAL_NEAT_AI_CORE.md) — vendored WASM artefact
   workflow.
 - [`AGENTS.md`](../AGENTS.md) §"Neuron UUID stability" — wire-format invariant

--- a/docs/GPU_ACCELERATION.md
+++ b/docs/GPU_ACCELERATION.md
@@ -1,12 +1,13 @@
 # 🖥️ GPU Acceleration for Discovery
 
-> **TL;DR** — Discovery's heavy synapse/neuron analysis runs on a Graphics
-> Processing Unit (GPU) when one is available, via the cross-platform `wgpu`
-> abstraction. `wgpu` selects Metal on macOS, Vulkan on Linux, DirectX 12 (DX12)
-> on Windows, and falls back to a Central Processing Unit (CPU) path when no
-> compatible GPU is found. The acceleration is part of the **Discovery Foreign
-> Function Interface (FFI)** surface — see
-> [DISCOVERY_GUIDE.md](./DISCOVERY_GUIDE.md) for the end-to-end workflow.
+> **TL;DR** — Discovery's synapse/neuron analysis runs **only** on a Graphics
+> Processing Unit (GPU), via the cross-platform `wgpu` abstraction. `wgpu`
+> selects Metal on macOS, Vulkan on Linux, and DirectX 12 (DX12) on Windows.
+> **There is no Central Processing Unit (CPU) fallback for analysis:** on a host
+> with no compatible GPU adapter, `analyzeParallel()` returns a failure and
+> discovery produces no proposals — evolution itself carries on unaffected. The
+> analysis is part of the **Discovery Foreign Function Interface (FFI)** surface
+> — see [DISCOVERY_GUIDE.md](./DISCOVERY_GUIDE.md) for the end-to-end workflow.
 > Acronyms used here: **GPU** (Graphics Processing Unit), **CPU** (Central
 > Processing Unit), **FFI** (Foreign Function Interface), **WGSL** (WebGPU
 > Shading Language), **DX12** (Microsoft DirectX 12), **API** (Application
@@ -27,16 +28,22 @@
 
 ## 🔍 Overview
 
-The NEAT-AI Discovery Rust library supports **cross-platform GPU acceleration**
-via the [`wgpu`](https://wgpu.rs/) crate. The wgpu abstraction layer
-automatically selects the best available GPU backend for the current platform:
+The NEAT-AI Discovery Rust library runs its structural analysis on the GPU via
+the [`wgpu`](https://wgpu.rs/) crate. The wgpu abstraction layer automatically
+selects the best available GPU backend for the current platform:
 
 - **macOS**: Metal
 - **Linux**: Vulkan
 - **Windows**: DX12
 
-When no compatible GPU is detected, discovery gracefully falls back to CPU
-computation. GPU accelerates analysis but is not required.
+> [!IMPORTANT]
+> **A GPU adapter is required for discovery analysis.** The Rust crate
+> hard-requires a GPU for synapse/neuron analysis; it has no CPU implementation
+> of those kernels. On a host with no compatible adapter, `analyzeParallel()`
+> refuses the call with
+> `Rust synapse/neuron analysis unavailable (GPU adapter not available)` and
+> discovery contributes **no proposals** for that pass. Evolution — mutation,
+> breeding, training, scoring — is unaffected and continues normally.
 
 ### 🧭 Backend Compatibility Matrix
 
@@ -44,13 +51,13 @@ The table below mirrors the backends advertised by the
 [NEAT-AI-Discovery](https://github.com/stSoftwareAU/NEAT-AI-Discovery) README
 and the `getGpuBackendInfo()` runtime probe.
 
-| Backend | Platform                         | Selected by `wgpu` when           | Status                            |
-| :------ | :------------------------------- | :-------------------------------- | :-------------------------------- |
-| Metal   | macOS (Apple Silicon, Intel)     | Default on macOS                  | ✅ Supported (primary dev target) |
-| Vulkan  | Linux (most distros)             | Default on Linux                  | ✅ Supported                      |
-| DX12    | Windows 10/11                    | Default on Windows                | ✅ Supported                      |
-| Gl      | Cross-platform (OpenGL fallback) | When no native API is usable      | ⚠️ Last-resort fallback           |
-| CPU     | All                              | No compatible GPU adapter present | ✅ Always available (slower)      |
+| Backend  | Platform                         | Selected by `wgpu` when           | Status                            |
+| :------- | :------------------------------- | :-------------------------------- | :-------------------------------- |
+| Metal    | macOS (Apple Silicon, Intel)     | Default on macOS                  | ✅ Supported (primary dev target) |
+| Vulkan   | Linux (most distros)             | Default on Linux                  | ✅ Supported                      |
+| DX12     | Windows 10/11                    | Default on Windows                | ✅ Supported                      |
+| Gl       | Cross-platform (OpenGL fallback) | When no native API is usable      | ⚠️ Last-resort fallback           |
+| _(none)_ | All                              | No compatible GPU adapter present | ❌ Analysis is skipped, not run   |
 
 > [!NOTE]
 > The set of backends is determined entirely by the `wgpu` crate version pinned
@@ -60,23 +67,24 @@ and the `getGpuBackendInfo()` runtime probe.
 <!-- -->
 
 > [!NOTE]
-> GPU acceleration is automatic and requires no platform-specific configuration.
-> The `wgpu` abstraction handles backend selection. Use `getGpuBackendInfo()` to
-> check which backend was selected.
+> Backend selection is automatic and requires no platform-specific
+> configuration. The `wgpu` abstraction handles it. Use `getGpuBackendInfo()` to
+> check which backend was selected — or why none was.
 
 ### 🛤️ Discovery → GPU Pipeline
 
 ```mermaid
 flowchart LR
-    NEAT[NEAT-AI<br/>TypeScript] -->|Discovery FFI| Rust[NEAT-AI-Discovery<br/>Rust library]
+    NEAT[NEAT-AI<br/>TypeScript] --> Guard{GPU adapter<br/>available?}
+    Guard -->|no| Skip[analyzeParallel returns failure<br/>no proposals this pass]
+    Guard -->|yes| Rust[NEAT-AI-Discovery<br/>Rust library]
     Rust -->|wgpu adapter| Pick{wgpu backend<br/>selection}
     Pick -->|macOS| Metal[Metal compute shaders]
     Pick -->|Linux| Vulkan[Vulkan compute shaders]
     Pick -->|Windows| DX12[DX12 compute shaders]
-    Pick -->|no GPU| CPUFallback[CPU fallback]
     Metal & Vulkan & DX12 -->|WGSL kernels| Results[Helpful / harmful synapse<br/>+ neuron stats]
-    CPUFallback --> Results
-    Results -->|gpuUsed flag| NEAT
+    Results -->|synapse.gpuUsed / neuron.gpuUsed| NEAT
+    Skip -->|warning logged| NEAT
 ```
 
 ## ⚡ Current GPU Implementation
@@ -99,23 +107,19 @@ flowchart LR
 ### 🌐 Cross-Platform Backend Selection
 
 The wgpu library automatically selects the best available backend. No
-platform-specific code is needed in the TypeScript layer:
+platform-specific code and no configuration are needed in the TypeScript layer —
+use `getGpuBackendInfo()` to query which backend was selected:
 
 ```typescript
-// GPU is preferred but not required — CPU fallback is automatic
-requireGpu: false;
-```
-
-Use the `getGpuBackendInfo()` function to query which backend was selected:
-
-```typescript
-import { getGpuBackendInfo } from "./RustDiscovery.ts";
+import { getGpuBackendInfo } from "@stsoftware/neat-ai";
 
 const info = getGpuBackendInfo();
 if (info.available) {
   console.log(`GPU: ${info.backendName} (${info.adapterName})`);
 } else {
-  console.log(`CPU fallback: ${info.reason}`);
+  console.warn(
+    `No GPU adapter (${info.reason}) — discovery analysis is skipped`,
+  );
 }
 ```
 
@@ -131,54 +135,47 @@ Rust synapse analysis using GPU (X helpful, Y harmful candidates)
 Rust neuron analysis using GPU (Z candidates)
 ```
 
-If you see "CPU fallback" instead, the GPU was not available — discovery still
-works, just without GPU acceleration.
+On a host with no adapter you instead get a warning naming the refusal, once per
+analysis scope, and that pass yields no candidates:
 
-### Method 2: Enable Debug Mode
-
-Set the environment variable to see detailed GPU diagnostics:
-
-```bash
-export NEAT_AI_DISCOVERY_GPU_DEBUG=1
+```
+Rust synapse analysis unavailable (Rust synapse/neuron analysis unavailable (GPU adapter not available)) for focus neuron(s): …
+Rust neuron analysis unavailable (Rust synapse/neuron analysis unavailable (GPU adapter not available)) for focus neuron(s): …
 ```
 
-This will print:
+### Method 2: Query Backend Info
 
-- GPU adapter information
-- Device initialisation status
-- Backend selection details
-- Any fallback to CPU
-
-> [!TIP]
-> Enable `NEAT_AI_DISCOVERY_GPU_DEBUG=1` during initial setup to confirm that
-> the correct GPU backend is being selected. You can disable it once GPU usage
-> is verified.
-
-### Method 3: Check Return Values
-
-The Rust analysis functions return a `gpuUsed` boolean field indicating whether
-GPU was actually used:
+`getGpuBackendInfo()` is exported from the package entry point and never throws
+— without the Rust library, or without `--allow-ffi`, it reports
+`{ available: false, reason }`:
 
 ```typescript
-const result = analyzeSynapses(input);
-if (result.gpuUsed) {
-  console.log("GPU acceleration is active!");
-} else {
-  console.info("Using CPU fallback — discovery still works");
-}
-```
+import { getGpuBackendInfo, type GpuBackendInfo } from "@stsoftware/neat-ai";
 
-### Method 4: Query Backend Info
-
-Use `getGpuBackendInfo()` for detailed backend information:
-
-```typescript
-const info = getGpuBackendInfo();
+const info: GpuBackendInfo = getGpuBackendInfo();
 // info.available: boolean
 // info.backendName: "Metal" | "Vulkan" | "Dx12" | "Gl" | undefined
 // info.adapterName: e.g. "Apple M1 Pro" | undefined
 // info.reason: string (when unavailable) | undefined
 ```
+
+### Method 3: Check Return Values
+
+`analyzeParallel()` (`RustDiscoveryOperations.ts`) is the analysis entry point.
+It reports GPU usage on the **nested** synapse and neuron branches of the
+converted result, not at the top level:
+
+```typescript
+const converted = convertParallelAnalysisResult(analyzeParallel(input));
+console.info(
+  `synapse GPU: ${converted.synapse?.gpuUsed}, neuron GPU: ${converted.neuron?.gpuUsed}`,
+);
+```
+
+Both entry points are internal to
+`src/architecture/ErrorGuidedStructuralEvolution/` — library consumers observe
+the same outcome through discovery's own logging (Method 1) and the backend
+probe (Method 2).
 
 ## 📊 Performance Considerations
 
@@ -222,7 +219,7 @@ The implementation uses GPU for:
 
 ### ❌ GPU Not Being Used
 
-If you see "CPU fallback" in logs:
+If the logs report that analysis is unavailable:
 
 1. **Check GPU Drivers**: Ensure Vulkan drivers are installed (Linux) or that
    Metal is supported (macOS)
@@ -235,9 +232,12 @@ If you see "CPU fallback" in logs:
 4. **Query Backend**: Use `getGpuBackendInfo()` to see the specific reason GPU
    is unavailable
 
-> [!NOTE]
-> Discovery works without GPU — it just runs slower using CPU computation. GPU
-> acceleration is automatic when available but never required.
+> [!WARNING]
+> Discovery analysis does **not** run without a GPU. A GPU-less host is not
+> "slower discovery" — it is **no discovery proposals at all**, reported as a
+> warning per pass. Provision a GPU, or accept that the discovery phase
+> contributes nothing on that host and disable it with `discoverySampleRate: -1`
+> to save the recording overhead.
 
 ### 🐌 Performance Issues
 
@@ -250,24 +250,25 @@ If GPU is active but still slow:
 
 ## ⚙️ Configuration
 
-### 🔓 CPU Fallback (Default)
+**There is nothing to configure.** GPU acceleration has no `NeatOptions` key:
+backend selection is automatic, and a GPU adapter is mandatory for analysis
+either way.
 
-GPU acceleration is preferred but not required on all platforms:
+### 🧩 About the internal `requireGpu` field
 
-```typescript
-requireGpu: false; // Uses GPU if available, falls back to CPU otherwise
-```
+`requireGpu` is an optional field on `RustParallelAnalysisInput`
+(`RustDiscoveryTypes.ts`) — the internal FFI payload. It is **not** user
+configuration, and no production code sets it, so the guard in
+`analyzeParallel()` is always armed. Two things worth knowing if you meet the
+name in the source:
 
-Discovery will use the best available GPU via wgpu's automatic backend
-selection, and fall back to CPU when no compatible GPU is present.
-
-### 🔒 Requiring GPU
-
-To force GPU and fail if unavailable (not recommended for cross-platform):
-
-```typescript
-requireGpu: true; // Will fail if no GPU is available
-```
+- Leaving it unset (the shipped behaviour) makes `analyzeParallel()` check the
+  adapter first and return a graceful failure when there is none. The guard
+  exists because the Rust library would otherwise `assert!`-panic the thread
+  (Issue #2115).
+- Setting it to `false` only bypasses that TypeScript guard. It does **not** buy
+  a CPU path: the call reaches Rust, which still has no CPU kernels and returns
+  a structured error with `errorKind: "GpuPermanent"` (Issue #2116).
 
 ## 🔬 Technical Details
 
@@ -292,9 +293,12 @@ Data is transferred to GPU as:
 
 ## 📅 History
 
+- **9 Aug 2026**: Documented the real behaviour (#3692) — discovery analysis is
+  GPU-only, there is no CPU fallback, and `getGpuBackendInfo()` is exported from
+  the package entry point so the probe samples above are runnable.
 - **18 Mar 2026**: Cross-platform GPU support via wgpu abstraction (#1864).
-  Automatic backend selection (Metal/Vulkan/DX12), CPU fallback, and backend
-  detection via `getGpuBackendInfo()`.
+  Automatic backend selection (Metal/Vulkan/DX12) and backend detection via
+  `getGpuBackendInfo()`.
 - **2 Jan 2025**: Initial GPU batching improvements for synapse evaluation.
 - GPU acceleration is actively maintained as part of the NEAT-AI-Discovery Rust
   module.

--- a/docs/README.md
+++ b/docs/README.md
@@ -65,8 +65,8 @@ Activation, gradient flow, and the GPU/WASM compute layer.
 - **[BACKPROP_ELASTICITY.md](BACKPROP_ELASTICITY.md)** — why NEAT-AI prefers
   minimum-change weight updates and how it avoids pushing saturated activations
   further into saturation.
-- **[GPU_ACCELERATION.md](GPU_ACCELERATION.md)** — Metal/Vulkan/DX12
-  acceleration via `wgpu`, with a CPU fallback.
+- **[GPU_ACCELERATION.md](GPU_ACCELERATION.md)** — Metal/Vulkan/DX12 backend
+  selection via `wgpu`, and why discovery analysis is GPU-only.
 - **[WASM_RESIDENT_TOPOLOGY.md](WASM_RESIDENT_TOPOLOGY.md)** — feasibility
   analysis for keeping the entire creature topology resident inside the WASM
   module.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -94,10 +94,10 @@ diagnostics.
 - **Segfault / "Killed: 9" loading the library** — `arm64` vs `x86_64` (or
   `glibc` vs `musl`) mismatch; rebuild on the target machine. →
   [Architecture mismatch errors](troubleshooting/DISCOVERY.md#-architecture-mismatch-errors-arm64-vs-x86).
-- **`ℹ️  No GPU detected — discovery will use CPU fallback`** — no compatible
-  `wgpu` adapter (Metal / Vulkan / DirectX 12). This is **non-fatal**: the GPU
-  probe is informational only and does not gate discovery, which continues on
-  CPU. → [No GPU detected](troubleshooting/DISCOVERY.md#-no-gpu-detected).
+- **`⚠️  No GPU detected`** — no compatible `wgpu` adapter (Metal / Vulkan /
+  DirectX 12). Evolution continues, but discovery analysis is **GPU-only**, so
+  every analysis pass is refused and no proposals are produced. →
+  [No GPU detected](troubleshooting/DISCOVERY.md#-no-gpu-detected).
 - **Library cannot be found at the default locations** — set
   `NEAT_AI_DISCOVERY_LIB_PATH` to an absolute path. →
   [Setting NEAT_AI_DISCOVERY_LIB_PATH](troubleshooting/DISCOVERY.md#-setting-neat_ai_discovery_lib_path).

--- a/docs/TS_RUST_MIGRATION.md
+++ b/docs/TS_RUST_MIGRATION.md
@@ -35,23 +35,23 @@ The work is informed by the WASM performance research series (#1630–#1633,
 
 ## 🦀 Where things live today (May 2026)
 
-| Subsystem                             | Lives in             | Reason / evidence                                                |
-| ------------------------------------- | -------------------- | ---------------------------------------------------------------- |
-| Activation functions (squashes)       | Rust → WASM          | Vendored from NEAT-AI-core; see audit #2369                      |
-| Forward pass (accumulate)             | Rust → WASM          | Numerically heavy inner loop                                     |
-| Topological backprop loop             | Rust → WASM only     | TS fallback removed in #2442                                     |
-| Elastic error distribution            | Rust → WASM only     | Migrated #1377 (#1519/#1526); TS fallback removed in #2442       |
-| Predictive coding (inference + learn) | Rust → WASM          | `wasm_activation/src/pc_inference.rs`, `pc_learning.rs`          |
-| Score computation                     | Rust → WASM          | Cache-aware incremental scorer (#1011/#1078)                     |
-| Training state                        | Rust → WASM          | `wasm_activation/src/training_state.rs`                          |
-| Topology validation, cycle detection  | Rust → WASM          | Core-owned operation per `AGENTS.md` §"No TS fallbacks"          |
-| Discovery recording (Parquet)         | Rust extension (FFI) | `recordDiscovery()` writes Parquet via Rust                      |
-| Discovery analysis (GPU/CPU)          | Rust extension (FFI) | `analyzeParallel()` — wgpu (Metal/Vulkan/DX12) with CPU fallback |
-| Discovery focus ranking               | Rust extension (FFI) | `rankFocusNeurons()`                                             |
-| NEAT loop / breeding / mutation       | TypeScript           | Orchestration; non-numerical                                     |
-| Cache-dominated paths (LRU)           | TypeScript           | Already faster than any WASM path (66 ns/hit)                    |
-| Graph surgery (compact, prune)        | TypeScript           | Map/Set work that V8 handles efficiently                         |
-| Discovery candidate filtering         | TypeScript           | Slot allocation, weighted sampling, cache lookups                |
+| Subsystem                             | Lives in             | Reason / evidence                                           |
+| ------------------------------------- | -------------------- | ----------------------------------------------------------- |
+| Activation functions (squashes)       | Rust → WASM          | Vendored from NEAT-AI-core; see audit #2369                 |
+| Forward pass (accumulate)             | Rust → WASM          | Numerically heavy inner loop                                |
+| Topological backprop loop             | Rust → WASM only     | TS fallback removed in #2442                                |
+| Elastic error distribution            | Rust → WASM only     | Migrated #1377 (#1519/#1526); TS fallback removed in #2442  |
+| Predictive coding (inference + learn) | Rust → WASM          | `wasm_activation/src/pc_inference.rs`, `pc_learning.rs`     |
+| Score computation                     | Rust → WASM          | Cache-aware incremental scorer (#1011/#1078)                |
+| Training state                        | Rust → WASM          | `wasm_activation/src/training_state.rs`                     |
+| Topology validation, cycle detection  | Rust → WASM          | Core-owned operation per `AGENTS.md` §"No TS fallbacks"     |
+| Discovery recording (Parquet)         | Rust extension (FFI) | `recordDiscovery()` writes Parquet via Rust                 |
+| Discovery analysis (GPU-only)         | Rust extension (FFI) | `analyzeParallel()` — wgpu (Metal/Vulkan/DX12); no CPU path |
+| Discovery focus ranking               | Rust extension (FFI) | `rankFocusNeurons()`                                        |
+| NEAT loop / breeding / mutation       | TypeScript           | Orchestration; non-numerical                                |
+| Cache-dominated paths (LRU)           | TypeScript           | Already faster than any WASM path (66 ns/hit)               |
+| Graph surgery (compact, prune)        | TypeScript           | Map/Set work that V8 handles efficiently                    |
+| Discovery candidate filtering         | TypeScript           | Slot allocation, weighted sampling, cache lookups           |
 
 > [!IMPORTANT]
 > **No TS fallbacks for core-owned operations.** Once an operation moves into

--- a/docs/archive/pr-summaries/pr-summary-3692.md
+++ b/docs/archive/pr-summaries/pr-summary-3692.md
@@ -1,0 +1,113 @@
+# PR Summary — GPU docs promised a CPU fallback that does not exist
+
+## Summary
+
+`docs/GPU_ACCELERATION.md` and nine sibling documents told operators that
+discovery's synapse/neuron analysis "gracefully falls back to CPU" when no GPU
+adapter is present. It does not. Corrected every surface to state the shipped
+behaviour, removed the two unrunnable code samples and the dead environment
+variable, and exported `getGpuBackendInfo()` from `mod.ts` so the probe sample a
+reader copies actually resolves. Closes #3692.
+
+**What the code actually does** — verified, not inferred:
+
+- `RustDiscoveryOperations.ts:293` — `analyzeParallel()` returns
+  `{ success: false, error: "Rust synapse/neuron analysis unavailable (GPU adapter not available)" }`
+  whenever `requireGpu !== false` and no adapter is present.
+- Nothing in `src/` ever sets `requireGpu`, so that branch is always taken on a
+  GPU-less host. It is a field on the internal FFI payload
+  `RustParallelAnalysisInput` (`RustDiscoveryTypes.ts:335`), not a `NeatOptions`
+  key.
+- Setting it to `false` buys no CPU path either: NEAT-AI-Discovery's own
+  `ffi_internal/gpu.rs:22` states "The crate hard-requires a GPU for
+  synapse/neuron analysis", and returns `errorKind: "GpuPermanent"` (the
+  behaviour `AnalyzeParallelGpuGuard.ts` already asserts).
+- `RustAnalysisCache.ts:207-216` — on that failure the pass logs a warning and
+  returns no result, so discovery contributes no proposals. Evolution itself is
+  unaffected.
+- `NEAT_AI_DISCOVERY_GPU_DEBUG` is read nowhere in this repository **and**
+  nowhere in NEAT-AI-Discovery (grepped both trees) — deleted rather than
+  externally attributed.
+
+### Docs corrected
+
+`docs/GPU_ACCELERATION.md` (rewritten TL;DR, overview, backend matrix, pipeline
+diagram, verification methods, configuration, troubleshooting, history),
+`docs/troubleshooting/DISCOVERY.md`, `docs/DISCOVERY_DIR.md`, `AGENTS.md`, plus
+six more carrying the same claim that the issue did not list:
+`docs/TROUBLESHOOTING.md`, `docs/README.md`, `docs/DISCOVERY_ARCHITECTURE.md`,
+`docs/TS_RUST_MIGRATION.md`, `docs/comparison/IMPLEMENTED.md`,
+`docs/comparison/FUTURE_WORK.md`. Leaving those would have re-seeded the rot.
+
+### Code changes
+
+- `mod.ts` — exports `getGpuBackendInfo` and the `GpuBackendInfo` type. The doc
+  previously told readers to
+  `import { getGpuBackendInfo } from "./RustDiscovery.ts"`, a relative path that
+  resolves only inside `src/architecture/ErrorGuidedStructuralEvolution/`. Per
+  the Issue #3271 rule a sample must import from the sole published specifier,
+  so the symbol is now exported rather than the sample deleted — a GPU probe is
+  exactly what a consumer needs now that analysis is known to be GPU-gated.
+- `RustDiscoveryLibrary.ts` — the GPU probe logged
+  `ℹ️  No GPU detected — discovery will use CPU fallback` at `info`. That
+  message is the root of the wrong mental model, so it (and its three siblings)
+  now `warn` and name the real consequence. No behaviour change; assertions
+  untouched.
+- `DiscoveryRunner.ts` — one stale comment.
+- Two existing test files: names and messages only ("CPU fallback supported" →
+  "the GPU adapter is checked at analysis time"). **No test was removed,
+  disabled, or had an assertion changed** — those tests assert that
+  `isRustDiscoveryEnabled()` does not gate on GPU, which is still true; only
+  their stated rationale was wrong.
+
+## Evidence
+
+Backend-only change — no web interface to screenshot. Evidence is the test run
+below plus the source citations above.
+
+```mermaid
+flowchart LR
+    NEAT[NEAT-AI TypeScript] --> Guard{GPU adapter<br/>available?}
+    Guard -->|no| Skip[analyzeParallel returns failure<br/>warning logged, 0 proposals]
+    Guard -->|yes| Rust[NEAT-AI-Discovery<br/>wgpu kernels]
+    Rust --> Results[synapse + neuron candidates]
+    Skip --> Evo[Evolution continues either way]
+    Results --> Evo
+```
+
+`./quality.sh` — **8272 passed, 0 failed, 4 ignored (5m26s)**.
+
+The new test file was written first and fails against the unfixed tree twice
+over: on `mod.ts` with "Module ... has no exported member 'getGpuBackendInfo'",
+and on the docs with "docs/GPU_ACCELERATION.md still contains analyzeSynapses".
+Both pass after the change.
+
+## Test Plan
+
+New file `test/docs/GpuAccelerationDoc.ts` — five "what" tests, each exercising
+real code rather than grepping source:
+
+- `getGpuBackendInfo()` is reachable from `mod.ts` and returns a structured
+  result — proves the doc's Method 2 sample is runnable (fails pre-fix with a
+  type error).
+- `ensureRustCombinedAnalysis` fed the real guard failure returns
+  `{ result: undefined, cache: undefined }` and warns on both the synapse and
+  neuron scopes — the documented "no proposals, no CPU results" outcome.
+- `convertParallelAnalysisResult` puts `gpuUsed` on `converted.synapse` /
+  `converted.neuron` with nothing at the top level — the corrected Method 3
+  sample.
+- `createNeatConfig({})` has no `requireGpu` property — it is not user
+  configuration.
+- A companion guard (the `RootImportSpecifiers.ts` pattern) asserting the four
+  removed claims cannot creep back into `docs/GPU_ACCELERATION.md`,
+  `docs/troubleshooting/DISCOVERY.md`, `docs/DISCOVERY_DIR.md` and `AGENTS.md`.
+
+Existing coverage left intact and still green: `AnalyzeParallelGpuGuard.ts`,
+`CpuOnlyDiscoveryIntegration.ts`, `CrossPlatformGpuSupport.ts`,
+`GpuBackendDetection.ts`, `RustAnalysisCacheGpuGuard.ts`.
+
+## Security Self-Check
+
+No new external input, endpoints, dependencies, or injection surfaces. No
+secrets staged. The one new public export is a read-only diagnostic that cannot
+throw and reveals only a wgpu backend/adapter name already printed to the log.

--- a/docs/comparison/FUTURE_WORK.md
+++ b/docs/comparison/FUTURE_WORK.md
@@ -210,15 +210,16 @@ layer.
 
 > [!NOTE]
 > GPU acceleration uses wgpu, which automatically selects the best available
-> backend: Metal on macOS, Vulkan on Linux, and DX12 on Windows. When no
-> compatible GPU is detected, discovery gracefully falls back to CPU.
+> backend: Metal on macOS, Vulkan on Linux, and DX12 on Windows. Discovery
+> analysis is GPU-only — when no compatible GPU is detected the analysis pass is
+> refused and yields no proposals (see
+> [GPU_ACCELERATION.md](../GPU_ACCELERATION.md)).
 
 **What's implemented**:
 
 - ✅ Automatic backend selection via wgpu (Metal, Vulkan, DX12, OpenGL).
-- ✅ CPU fallback when no compatible GPU is available.
+- ✅ A graceful refusal — not a thread panic — when no GPU adapter is present.
 - ✅ GPU backend detection and reporting (`getGpuBackendInfo()`).
-- ✅ Cross-platform `requireGpu: false` — GPU accelerates but is not required.
 
 **What's missing**: native CUDA for NVIDIA GPUs (wgpu uses Vulkan on Linux),
 OpenCL for older hardware, and benchmarking across all platforms.

--- a/docs/comparison/IMPLEMENTED.md
+++ b/docs/comparison/IMPLEMENTED.md
@@ -144,8 +144,8 @@ to a dedicated guide, the contrast with standard NEAT is documented there.
   practice.
 - ✅ **GPU-Accelerated Discovery** _(NEAT-AI extension)_: Cross-platform GPU
   support via [wgpu](https://wgpu.rs/) abstraction — Metal on macOS, Vulkan on
-  Linux, DX12 on Windows — with automatic CPU fallback when no compatible GPU is
-  detected.
+  Linux, DX12 on Windows. Analysis is GPU-only: with no compatible adapter the
+  pass is refused and discovery yields no proposals.
 - ✅ **Discovery Caching** _(NEAT-AI extension)_: Success and failure caching
   for discovery candidates with age-based and size-based eviction,
   cache-informed multi-neuron removal candidates, and supplemental candidate

--- a/docs/troubleshooting/DISCOVERY.md
+++ b/docs/troubleshooting/DISCOVERY.md
@@ -6,8 +6,8 @@ Unit) accelerated structural analysis. It is **optional** — if unavailable, th
 discovery phase is skipped.
 
 This document covers building, locating, and loading the Rust library, GPU
-backend selection / fallback, and the "discovery is enabled but not finding
-improvements" diagnostic flow. See the index in
+backend selection, and the "discovery is enabled but not finding improvements"
+diagnostic flow. See the index in
 [`../TROUBLESHOOTING.md`](../TROUBLESHOOTING.md) for other categories.
 
 ## Table of contents
@@ -94,9 +94,9 @@ ldd /path/to/libneat_ai_discovery.so
 ## 💡 Discovery is always optional
 
 Discovery tests skip gracefully when the Rust library is not available — no
-environment variable is required. The library already probes for GPU
-availability internally and falls back to CPU (Central Processing Unit) when no
-GPU is present.
+environment variable is required. A host with no Graphics Processing Unit (GPU)
+adapter is equally non-fatal to evolution, but it does mean the analysis phase
+produces nothing — see [No GPU detected](#-no-gpu-detected).
 
 > [!NOTE]
 > If you want to disable discovery during training, set
@@ -114,17 +114,26 @@ deno run --allow-ffi --allow-read --allow-env your_script.ts
 
 ## 🖥️ No GPU detected
 
-**Symptom:** `ℹ️  No GPU detected — discovery will use CPU fallback`
+**Symptom:**
+`⚠️  No GPU detected (<reason>). Discovery analysis is GPU-only, so it will yield no proposals on this worker; evolution continues.`
+followed, once discovery runs, by
+`Rust synapse analysis unavailable (Rust synapse/neuron analysis unavailable (GPU adapter not available)) for focus neuron(s): …`
 
-This is a **non-fatal**, informational condition. The library loaded but no
-usable GPU was found. The GPU probe is for logging/telemetry only — it does
-**not** gate discovery, which continues to run on the CPU path handled inside
-the Rust library. GPU accelerates analysis but is not required. On macOS, ensure
-Metal is available if you want the acceleration.
+The library loaded but no usable GPU was found. This is **not fatal to
+evolution** — mutation, breeding, training and scoring all continue — but it
+**is fatal to discovery proposals**: the analysis kernels are GPU-only, so
+`analyzeParallel()` refuses the call and that pass produces no candidates.
 
-The Rust extension uses `wgpu` to negotiate Metal (macOS), Vulkan (Linux), or
-DirectX 12 (Windows). When no compatible adapter is available the library falls
-back to CPU computation automatically. See
+The GPU probe does not gate discovery _enablement_ — `isRustDiscoveryEnabled()`
+still returns `true`, so recording still runs — which is why the effect shows up
+as repeated "analysis unavailable" warnings and zero proposals rather than a
+clean skip.
+
+To fix it, provision a GPU adapter: the Rust extension uses `wgpu` to negotiate
+Metal (macOS), Vulkan (Linux), or DirectX 12 (Windows). On macOS ensure Metal is
+available; on headless Linux ensure Vulkan drivers are installed. If the host
+will never have a GPU, disable discovery with `discoverySampleRate: -1` to avoid
+paying the recording cost for nothing. See
 [`../GPU_ACCELERATION.md`](../GPU_ACCELERATION.md) for backend selection
 details.
 

--- a/mod.ts
+++ b/mod.ts
@@ -460,6 +460,21 @@ export {
 export type { DiscoveryEvaluationSummary } from "@discovery/DiscoveryRunner.ts";
 
 /**
+ * Discovery GPU probe.
+ *
+ * Issue #3692: discovery's synapse/neuron analysis is GPU-only — there is no
+ * CPU fallback. Call this before relying on discovery proposals to learn which
+ * wgpu backend was selected, or why none was. The probe never throws: without
+ * the Rust library, or without FFI permission, it reports
+ * `{ available: false, reason }`. The result is cached after the first probe.
+ *
+ * @see {@link module:docs/GPU_ACCELERATION}
+ */
+export { getGpuBackendInfo } from "@architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts";
+
+export type { GpuBackendInfo } from "@architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts";
+
+/**
  * Discovery cleanup utilities for orphaned temp directory management.
  *
  * Issue #1702: Provides functions to detect and clean up orphaned discovery

--- a/src/architecture/ErrorGuidedStructuralEvolution/RustDiscoveryLibrary.ts
+++ b/src/architecture/ErrorGuidedStructuralEvolution/RustDiscoveryLibrary.ts
@@ -624,9 +624,11 @@ export function getDiscoveryVersion(): string | undefined {
 /**
  * Checks whether the loaded Rust discovery library reports a usable GPU.
  *
- * Returns false (and logs an info message once) when the probe fails or reports
- * that no GPU is available on this worker. Discovery will still function via
- * CPU fallback — GPU accelerates analysis but is not required.
+ * Returns false (and logs a warning once) when the probe fails or reports that
+ * no GPU is available on this worker. Discovery's synapse/neuron analysis is
+ * GPU-only (Issue #3692): a false result means `analyzeParallel()` will refuse
+ * every analysis pass, so discovery yields no proposals on this host. Evolution
+ * itself is unaffected.
  */
 export function isRustGpuAvailable(): boolean {
   if (!isRustLibraryAvailable()) {
@@ -641,9 +643,9 @@ export function isRustGpuAvailable(): boolean {
       if (!rustGpuWarningEmitted) {
         rustGpuWarningEmitted = true;
         cachedGpuBackendInfo = { available: false, reason: "null pointer" };
-        getLogger().info(
-          "ℹ️  Discovery GPU probe returned a null pointer. " +
-            "Discovery will use CPU fallback on this worker.",
+        getLogger().warn(
+          "⚠️  Discovery GPU probe returned a null pointer. " +
+            "Discovery analysis is GPU-only and will yield no proposals on this worker.",
         );
       }
       return false;
@@ -659,9 +661,9 @@ export function isRustGpuAvailable(): boolean {
       if (!rustGpuWarningEmitted) {
         rustGpuWarningEmitted = true;
         cachedGpuBackendInfo = { available: false, reason: "invalid JSON" };
-        getLogger().info(
-          "ℹ️  Discovery GPU probe returned invalid JSON. " +
-            "Discovery will use CPU fallback on this worker.",
+        getLogger().warn(
+          "⚠️  Discovery GPU probe returned invalid JSON. " +
+            "Discovery analysis is GPU-only and will yield no proposals on this worker.",
         );
       }
       return false;
@@ -672,9 +674,9 @@ export function isRustGpuAvailable(): boolean {
         rustGpuWarningEmitted = true;
         const detail = parsed.error ?? "no usable GPU detected";
         cachedGpuBackendInfo = { available: false, reason: detail };
-        getLogger().info(
-          "ℹ️  No GPU detected — discovery will use CPU fallback " +
-            `(${detail}). GPU accelerates analysis but is not required.`,
+        getLogger().warn(
+          `⚠️  No GPU detected (${detail}). Discovery analysis is GPU-only, ` +
+            "so it will yield no proposals on this worker; evolution continues.",
         );
       }
       return false;
@@ -711,9 +713,9 @@ export function isRustGpuAvailable(): boolean {
         available: false,
         reason: String(error),
       };
-      getLogger().info(
-        "ℹ️  Discovery GPU probe threw an error. " +
-          "Discovery will use CPU fallback on this worker.",
+      getLogger().warn(
+        "⚠️  Discovery GPU probe threw an error. " +
+          "Discovery analysis is GPU-only and will yield no proposals on this worker.",
         error,
       );
     }
@@ -736,11 +738,12 @@ export function isRustLibraryAvailable(): boolean {
 /**
  * Checks if the Rust discovery module is enabled and available.
  *
- * Discovery requires the Rust library. GPU acceleration is optional —
- * when no GPU is detected, the Rust library falls back to CPU computation.
- * This enables cross-platform discovery on macOS (Metal), Linux (Vulkan),
- * and Windows (DX12) via the wgpu abstraction layer, with automatic CPU
- * fallback when no compatible GPU is present.
+ * Discovery requires the Rust library. This gate covers the library only — a
+ * GPU adapter is checked separately, at analysis time. Cross-platform GPU
+ * selection (Metal on macOS, Vulkan on Linux, DX12 on Windows) is handled by
+ * the wgpu abstraction layer; without an adapter the library still loads and
+ * this function still returns true, but every analysis pass is refused
+ * (Issue #3692).
  *
  * This function caches the result after the first check for low overhead.
  *
@@ -759,8 +762,9 @@ export function isRustDiscoveryEnabled(): boolean {
       return false;
     }
 
-    // Probe GPU availability for logging/telemetry — result does not gate
-    // discovery enablement. The Rust library handles CPU fallback internally.
+    // Probe GPU availability for logging/telemetry — the result does not gate
+    // discovery *enablement*. It does gate the analysis phase: without an
+    // adapter, `analyzeParallel()` refuses every pass (Issue #3692).
     isRustGpuAvailable();
 
     rustDiscoveryEnabledState = true;
@@ -788,8 +792,9 @@ export function shouldSkipRustDiscoveryTests(): boolean {
  * Returns information about the GPU backend selected by wgpu.
  *
  * Call this after `isRustDiscoveryEnabled()` to learn which GPU backend
- * (Metal, Vulkan, DX12, OpenGL) was selected, or whether CPU fallback is
- * being used. The result is cached after the first GPU probe.
+ * (Metal, Vulkan, DX12, OpenGL) was selected, or why none was. Discovery
+ * analysis is GPU-only, so an unavailable result means the analysis phase will
+ * produce no proposals. The result is cached after the first GPU probe.
  *
  * @returns GPU backend information, or a "not probed" result if the library
  *          has not been loaded yet.

--- a/src/discovery/DiscoveryRunner.ts
+++ b/src/discovery/DiscoveryRunner.ts
@@ -117,7 +117,8 @@ export class DiscoveryRunner {
   }
 
   async discoverDir(input: DiscoveryDirInput): Promise<DiscoveryDirResult> {
-    // Discovery requires the Rust library — GPU is optional (CPU fallback supported)
+    // Discovery requires the Rust library. A GPU adapter is checked separately,
+    // at analysis time — this gate covers the library only (Issue #3692).
     if (!this.#rustDiscoveryEnabled()) {
       throw new DiscoveryError(
         "Discovery requires the NEAT-AI-Discovery Rust library to be available. " +

--- a/test/ErrorGuidedStructuralEvolution/RustDiscoveryCrossPlatformGpu.ts
+++ b/test/ErrorGuidedStructuralEvolution/RustDiscoveryCrossPlatformGpu.ts
@@ -4,7 +4,7 @@
  * Validates:
  * - GPU backend detection returns a known backend name
  * - Discovery is enabled when library is available (regardless of GPU)
- * - CPU fallback behaviour when GPU is unavailable
+ * - Graceful behaviour when no GPU adapter is present
  * - RustCheckGpuResult type includes backend field
  */
 import { assert, assertEquals, assertNotEquals } from "@std/assert";
@@ -20,13 +20,14 @@ import {
 const KNOWN_BACKENDS = ["metal", "vulkan", "dx12", "gl"];
 
 Deno.test({
-  name: "discovery enabled with library available (CPU fallback supported)",
+  name: "discovery enabled with library available (GPU checked separately)",
   ignore: shouldSkipRustDiscoveryTests(),
   sanitizeResources: false,
   fn: () => {
     try {
       // When the Rust library is available, discovery should be enabled
-      // regardless of whether GPU is available (CPU fallback is supported)
+      // regardless of whether a GPU is present — the adapter is checked later,
+      // at analysis time (Issue #3692).
       const libraryAvailable = isRustLibraryAvailable();
       assert(libraryAvailable, "Rust library should be available");
 
@@ -34,7 +35,7 @@ Deno.test({
       assert(
         discoveryEnabled,
         "Discovery should be enabled when library is available " +
-          "(GPU is optional — CPU fallback supported)",
+          "(the GPU adapter is checked at analysis time, not here)",
       );
     } finally {
       closeRustLibrary();
@@ -117,14 +118,15 @@ Deno.test({
     try {
       // The key behaviour change from Issue #1864:
       // isRustDiscoveryEnabled() should return true when the library is
-      // available, even if GPU is not available (CPU fallback is supported).
+      // available, even if no GPU is present — analysis will then refuse each
+      // pass, but enablement itself does not depend on the adapter.
       const libraryAvailable = isRustLibraryAvailable();
       if (libraryAvailable) {
         const discoveryEnabled = isRustDiscoveryEnabled();
         assert(
           discoveryEnabled,
           "Discovery must be enabled when library is available. " +
-            "GPU is optional — the Rust library supports CPU fallback.",
+            "The GPU adapter is checked at analysis time, not by this gate.",
         );
       }
     } finally {

--- a/test/discovery/CrossPlatformGpuSupport.ts
+++ b/test/discovery/CrossPlatformGpuSupport.ts
@@ -1,7 +1,7 @@
 /**
  * Tests for cross-platform GPU support via wgpu abstraction.
  *
- * Issue #1864: Verify GPU backend detection, CPU fallback behaviour,
+ * Issue #1864: Verify GPU backend detection, graceful degradation,
  * and cross-platform requireGpu logic.
  */
 import { assertEquals, assertExists, assertThrows } from "@std/assert";
@@ -94,7 +94,7 @@ Deno.test("requireGpu is omitted in ensureRustCombinedAnalysis so GPU guard is a
   assertExists(result.result, "Result should be returned");
 });
 
-Deno.test("CPU fallback: analysis succeeds with gpuUsed=false", () => {
+Deno.test("gpuUsed=false is still a successful, candidate-bearing result", () => {
   const parallelResult: RustParallelAnalysisResult = {
     success: true,
     synapseGpuUsed: false,
@@ -122,12 +122,12 @@ Deno.test("CPU fallback: analysis succeeds with gpuUsed=false", () => {
   assertEquals(
     converted.synapse!.gpuUsed,
     false,
-    "gpuUsed should be false for CPU fallback",
+    "gpuUsed should mirror what the library reported",
   );
   assertEquals(
     converted.synapse!.helpfulSynapses?.length,
     1,
-    "Helpful synapse candidates should still be returned on CPU",
+    "Helpful synapse candidates should be returned regardless of gpuUsed",
   );
 });
 

--- a/test/docs/GpuAccelerationDoc.ts
+++ b/test/docs/GpuAccelerationDoc.ts
@@ -1,0 +1,239 @@
+/**
+ * Issue #3692 — fact-check guard for docs/GPU_ACCELERATION.md and the three
+ * sibling docs that repeated its CPU-fallback claim.
+ *
+ * Four documents told operators that discovery analysis "falls back to CPU"
+ * when no GPU adapter is present. It does not: `analyzeParallel()` refuses the
+ * call with "GPU adapter not available", and NEAT-AI-Discovery itself
+ * hard-requires a GPU for synapse/neuron analysis. These are "what" tests —
+ * each documented claim is exercised against the real code path, so the docs
+ * cannot silently drift back.
+ */
+
+import { assert, assertEquals } from "@std/assert";
+import { createNeatConfig, getGpuBackendInfo } from "../../mod.ts";
+import {
+  convertParallelAnalysisResult,
+  ensureRustCombinedAnalysis,
+} from "@architecture/ErrorGuidedStructuralEvolution/RustAnalysisCache.ts";
+import type { RustParallelAnalysisInput } from "@architecture/ErrorGuidedStructuralEvolution/RustDiscovery.ts";
+import { buildWireToRuntimeIdMap } from "@architecture/ErrorGuidedStructuralEvolution/DiscoveryWireIdentity.ts";
+import { Creature } from "@creature";
+import { CreatureUtil } from "@architecture/CreatureUtils.ts";
+import { initWasmForTests } from "../_initWasm.ts";
+
+/** The exact refusal `analyzeParallel()` returns on a GPU-less host. */
+const GPU_GUARD_ERROR =
+  "Rust synapse/neuron analysis unavailable (GPU adapter not available)";
+
+/** Builds a creature with a hidden neuron suitable for discovery analysis. */
+function makeTestCreature(): Creature {
+  const creature = Creature.fromJSON({
+    input: 2,
+    output: 1,
+    neurons: [
+      { type: "hidden", uuid: "hidden-1", squash: "IDENTITY", bias: 0 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-1", weight: 0.5 },
+      { fromUUID: "hidden-1", toUUID: "output-0", weight: 0.5 },
+      { fromUUID: "input-1", toUUID: "output-0", weight: -0.25 },
+    ],
+  });
+  creature.validate();
+  CreatureUtil.makeUUID(creature);
+  return creature;
+}
+
+Deno.test({
+  name:
+    "GPU doc — getGpuBackendInfo() is reachable from the package entry point",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn() {
+    // The doc's "Query Backend Info" sample must be runnable by a consumer,
+    // who can only import from the root specifier (@stsoftware/neat-ai).
+    const info = getGpuBackendInfo();
+    assertEquals(typeof info.available, "boolean");
+    if (info.available) {
+      if (info.backendName) {
+        assert(
+          ["metal", "vulkan", "dx12", "gl"].includes(
+            info.backendName.toLowerCase(),
+          ),
+          `Unexpected wgpu backend name: ${info.backendName}`,
+        );
+      }
+    } else {
+      assertEquals(
+        typeof info.reason,
+        "string",
+        "an unavailable GPU must report why",
+      );
+    }
+  },
+});
+
+Deno.test(
+  "GPU doc — a GPU-less analysis yields no candidates, not CPU results",
+  async () => {
+    await initWasmForTests();
+    const creature = makeTestCreature();
+    const focusId = buildWireToRuntimeIdMap(creature).get("output-0");
+    assert(focusId !== undefined, "output-0 should have a runtime id");
+
+    const warnings: Array<{ scope: string; reason: string }> = [];
+    const { result, cache } = ensureRustCombinedAnalysis(
+      creature,
+      "/tmp/gpu-doc.parquet",
+      {
+        isRustDiscoveryEnabled: () => true,
+        isRustLibraryAvailable: () => true,
+        recordDiscovery: () => ({ success: true, file: "chunk.parquet" }),
+        mergeDiscoveryParquet: () => ({
+          success: true,
+          outputFile: "merged.parquet",
+        }),
+        // Exactly what the shipped GPU guard returns on a GPU-less host.
+        analyzeParallel: ((_input: RustParallelAnalysisInput) => ({
+          success: false,
+          error: GPU_GUARD_ERROR,
+        })) as Parameters<typeof ensureRustCombinedAnalysis>[2][
+          "analyzeParallel"
+        ],
+        readDiscoveryRecords: () => ({ success: true, records: [] }),
+      },
+      undefined,
+      undefined,
+      [focusId],
+      true,
+      true,
+      (scope, _focusList, reason) => warnings.push({ scope, reason }),
+    );
+
+    assertEquals(
+      result,
+      undefined,
+      "no CPU path exists — the analysis produces no candidates at all",
+    );
+    assertEquals(cache, undefined, "a refused analysis must not be cached");
+    assertEquals(
+      warnings.map((w) => w.scope).sort(),
+      ["neuron", "synapse"],
+      "both analysis scopes must report the unavailability",
+    );
+    for (const warning of warnings) {
+      assert(
+        warning.reason.includes("GPU adapter not available"),
+        `warning should name the GPU adapter, got: ${warning.reason}`,
+      );
+    }
+  },
+);
+
+Deno.test("GPU doc — gpuUsed lives on the nested synapse/neuron results", () => {
+  const converted = convertParallelAnalysisResult({
+    success: true,
+    synapseGpuUsed: true,
+    neuronGpuUsed: true,
+    helpfulSynapses: [
+      {
+        fromNeuronUuid: "input-0",
+        toNeuronUuid: "output-0",
+        weight: 0.25,
+        targetNeuronImpact: 1,
+        expectedCreatureErrorReduction: 0.05,
+        expectedCreatureScoreGain: 0.1,
+        improvedCount: 8,
+        totalCount: 10,
+      },
+    ],
+    helpfulNeurons: [
+      {
+        sourceNeuronUuid: "input-0",
+        targetNeuronUuid: "output-0",
+        incomingWeight: 0.5,
+        outgoingWeight: 0.5,
+        squash: "IDENTITY",
+        bias: 0,
+        targetNeuronImpact: 1,
+        expectedCreatureErrorReduction: 0.05,
+        expectedCreatureScoreGain: 0.1,
+        improvedCount: 8,
+        totalCount: 10,
+      },
+    ],
+  });
+
+  assertEquals(converted.synapse?.gpuUsed, true);
+  assertEquals(converted.neuron?.gpuUsed, true);
+  assertEquals(
+    (converted as unknown as Record<string, unknown>).gpuUsed,
+    undefined,
+    "there is no top-level gpuUsed field to read",
+  );
+});
+
+Deno.test("GPU doc — requireGpu is not a NeatOptions key", () => {
+  const config = createNeatConfig({});
+  assert(
+    !("requireGpu" in config),
+    "requireGpu is an internal FFI payload field, not user configuration",
+  );
+});
+
+Deno.test("GPU doc — the corrected docs keep the false claims out", async () => {
+  const forbidden: Array<{ file: string; text: string; why: string }> = [
+    {
+      file: "docs/GPU_ACCELERATION.md",
+      text: "analyzeSynapses",
+      why: "no such function exists; the entry point is analyzeParallel()",
+    },
+    {
+      file: "docs/GPU_ACCELERATION.md",
+      text: 'from "./RustDiscovery.ts"',
+      why: "a relative path no consumer can resolve",
+    },
+    {
+      file: "docs/GPU_ACCELERATION.md",
+      text: "NEAT_AI_DISCOVERY_GPU_DEBUG",
+      why: "read nowhere in NEAT-AI or NEAT-AI-Discovery",
+    },
+    {
+      file: "docs/GPU_ACCELERATION.md",
+      text: "requireGpu: false;",
+      why: "presented as a configuration default that no caller can set",
+    },
+    {
+      file: "docs/troubleshooting/DISCOVERY.md",
+      text: "continues to run on the CPU path",
+      why: "analysis is refused on a GPU-less host",
+    },
+    {
+      file: "docs/DISCOVERY_DIR.md",
+      text: "the Rust library handles CPU fallback internally",
+      why: "the Rust crate hard-requires a GPU for analysis",
+    },
+    {
+      file: "AGENTS.md",
+      text: "with CPU (Central Processing Unit)\n  fallback",
+      why: "there is no CPU fallback for discovery analysis",
+    },
+  ];
+
+  const paths = [...new Set(forbidden.map((f) => f.file))];
+  const texts = await Promise.all(
+    paths.map((file) =>
+      Deno.readTextFile(new URL(`../../${file}`, import.meta.url))
+    ),
+  );
+  const cache = new Map(paths.map((file, i) => [file, texts[i]]));
+
+  for (const { file, text, why } of forbidden) {
+    assert(
+      !cache.get(file)!.includes(text),
+      `${file} still contains "${text}" — ${why}`,
+    );
+  }
+});


### PR DESCRIPTION
# PR Summary — GPU docs promised a CPU fallback that does not exist

## Summary

`docs/GPU_ACCELERATION.md` and nine sibling documents told operators that
discovery's synapse/neuron analysis "gracefully falls back to CPU" when no GPU
adapter is present. It does not. Corrected every surface to state the shipped
behaviour, removed the two unrunnable code samples and the dead environment
variable, and exported `getGpuBackendInfo()` from `mod.ts` so the probe sample a
reader copies actually resolves. Closes #3692.

**What the code actually does** — verified, not inferred:

- `RustDiscoveryOperations.ts:293` — `analyzeParallel()` returns
  `{ success: false, error: "Rust synapse/neuron analysis unavailable (GPU adapter not available)" }`
  whenever `requireGpu !== false` and no adapter is present.
- Nothing in `src/` ever sets `requireGpu`, so that branch is always taken on a
  GPU-less host. It is a field on the internal FFI payload
  `RustParallelAnalysisInput` (`RustDiscoveryTypes.ts:335`), not a `NeatOptions`
  key.
- Setting it to `false` buys no CPU path either: NEAT-AI-Discovery's own
  `ffi_internal/gpu.rs:22` states "The crate hard-requires a GPU for
  synapse/neuron analysis", and returns `errorKind: "GpuPermanent"` (the
  behaviour `AnalyzeParallelGpuGuard.ts` already asserts).
- `RustAnalysisCache.ts:207-216` — on that failure the pass logs a warning and
  returns no result, so discovery contributes no proposals. Evolution itself is
  unaffected.
- `NEAT_AI_DISCOVERY_GPU_DEBUG` is read nowhere in this repository **and**
  nowhere in NEAT-AI-Discovery (grepped both trees) — deleted rather than
  externally attributed.

### Docs corrected

`docs/GPU_ACCELERATION.md` (rewritten TL;DR, overview, backend matrix, pipeline
diagram, verification methods, configuration, troubleshooting, history),
`docs/troubleshooting/DISCOVERY.md`, `docs/DISCOVERY_DIR.md`, `AGENTS.md`, plus
six more carrying the same claim that the issue did not list:
`docs/TROUBLESHOOTING.md`, `docs/README.md`, `docs/DISCOVERY_ARCHITECTURE.md`,
`docs/TS_RUST_MIGRATION.md`, `docs/comparison/IMPLEMENTED.md`,
`docs/comparison/FUTURE_WORK.md`. Leaving those would have re-seeded the rot.

### Code changes

- `mod.ts` — exports `getGpuBackendInfo` and the `GpuBackendInfo` type. The doc
  previously told readers to
  `import { getGpuBackendInfo } from "./RustDiscovery.ts"`, a relative path that
  resolves only inside `src/architecture/ErrorGuidedStructuralEvolution/`. Per
  the Issue #3271 rule a sample must import from the sole published specifier,
  so the symbol is now exported rather than the sample deleted — a GPU probe is
  exactly what a consumer needs now that analysis is known to be GPU-gated.
- `RustDiscoveryLibrary.ts` — the GPU probe logged
  `ℹ️  No GPU detected — discovery will use CPU fallback` at `info`. That
  message is the root of the wrong mental model, so it (and its three siblings)
  now `warn` and name the real consequence. No behaviour change; assertions
  untouched.
- `DiscoveryRunner.ts` — one stale comment.
- Two existing test files: names and messages only ("CPU fallback supported" →
  "the GPU adapter is checked at analysis time"). **No test was removed,
  disabled, or had an assertion changed** — those tests assert that
  `isRustDiscoveryEnabled()` does not gate on GPU, which is still true; only
  their stated rationale was wrong.

## Evidence

Backend-only change — no web interface to screenshot. Evidence is the test run
below plus the source citations above.

```mermaid
flowchart LR
    NEAT[NEAT-AI TypeScript] --> Guard{GPU adapter<br/>available?}
    Guard -->|no| Skip[analyzeParallel returns failure<br/>warning logged, 0 proposals]
    Guard -->|yes| Rust[NEAT-AI-Discovery<br/>wgpu kernels]
    Rust --> Results[synapse + neuron candidates]
    Skip --> Evo[Evolution continues either way]
    Results --> Evo
```

`./quality.sh` — **8272 passed, 0 failed, 4 ignored (5m26s)**.

The new test file was written first and fails against the unfixed tree twice
over: on `mod.ts` with "Module ... has no exported member 'getGpuBackendInfo'",
and on the docs with "docs/GPU_ACCELERATION.md still contains analyzeSynapses".
Both pass after the change.

## Test Plan

New file `test/docs/GpuAccelerationDoc.ts` — five "what" tests, each exercising
real code rather than grepping source:

- `getGpuBackendInfo()` is reachable from `mod.ts` and returns a structured
  result — proves the doc's Method 2 sample is runnable (fails pre-fix with a
  type error).
- `ensureRustCombinedAnalysis` fed the real guard failure returns
  `{ result: undefined, cache: undefined }` and warns on both the synapse and
  neuron scopes — the documented "no proposals, no CPU results" outcome.
- `convertParallelAnalysisResult` puts `gpuUsed` on `converted.synapse` /
  `converted.neuron` with nothing at the top level — the corrected Method 3
  sample.
- `createNeatConfig({})` has no `requireGpu` property — it is not user
  configuration.
- A companion guard (the `RootImportSpecifiers.ts` pattern) asserting the four
  removed claims cannot creep back into `docs/GPU_ACCELERATION.md`,
  `docs/troubleshooting/DISCOVERY.md`, `docs/DISCOVERY_DIR.md` and `AGENTS.md`.

Existing coverage left intact and still green: `AnalyzeParallelGpuGuard.ts`,
`CpuOnlyDiscoveryIntegration.ts`, `CrossPlatformGpuSupport.ts`,
`GpuBackendDetection.ts`, `RustAnalysisCacheGpuGuard.ts`.

## Security Self-Check

No new external input, endpoints, dependencies, or injection surfaces. No
secrets staged. The one new public export is a read-only diagnostic that cannot
throw and reveals only a wgpu backend/adapter name already printed to the log.



## Milestone
This PR is part of the **Scan 20260807** milestone and targets the `milestone/scan-20260807` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-msl5j7ob-894d36`<!-- vibe-worker-issue-3692 -->