### PR TITLE
🟠 Training docs put syntheticSynapses on the wrong option surface and quote stale backprop defaults (Issue #3694)

### DIFF
--- a/docs/api/TRAINING.md
+++ b/docs/api/TRAINING.md
@@ -8,17 +8,24 @@ densification step.
 > Collection).
 
 NEAT-AI uses elastic backpropagation to train creatures within each generation.
-Training is typically invoked internally by `evolveDir()`, but the configuration
-types are documented here for fine-grained control and for callers wiring their
-own training loop.
+Training is invoked internally by `evolveDir()`; the configuration types below
+are documented so you can see which defaults that training runs with, and how
+the synthetic-synapse step fits into the pipeline.
 
-## 📦 Exports referenced here
+## 📦 Types referenced here
 
-These types are consumed via `NeatOptions` and (when training is invoked
-directly) via `Creature.propagate()` / `Creature.propagateUpdate()`.
+> [!IMPORTANT]
+> None of the types below are re-exported from `mod.ts`, so consumers **cannot**
+> import them. They are documented here for architectural reference and for the
+> defaults they resolve to. The public way to configure training is
+> [`NeatOptions`](CONFIGURATION.md), which `evolveDir()` accepts.
 
-- `BackPropagationOptions` (interface; configures elastic backprop)
-- `TrainOptions` (extends `BackPropagationOptions`)
+- `BackPropagationOptions` (internal; `Partial<BackPropagationArguments>` — the
+  input to `createBackPropagationConfig()`, which the training pipeline calls
+  for every training run)
+- `TrainOptions` (internal; `Partial<TrainArguments>`, which extends
+  `BackPropagationArguments` — the options the internal `trainDir()` entry point
+  accepts)
 - Synthetic synapse helpers (internal — documented here for architectural
   reference)
 
@@ -26,8 +33,8 @@ directly) via `Creature.propagate()` / `Creature.propagateUpdate()`.
 
 ```typescript
 interface BackPropagationOptions {
-  generations?: number; // Training iterations (default: random 1–100)
-  learningRate?: number; // 0–1 (default: random low value)
+  generations?: number; // Dampening generations (default: random 1–10, MAX_RANDOM_GENERATIONS)
+  learningRate?: number; // 0–1 (default: 0.01)
   batchSize?: number; // Samples per batch (default: 64)
   sparseRatio?: number; // Neuron selection ratio (default: 1.0)
   trainingMutationRate?: number; // Gene change probability (default: random)
@@ -39,7 +46,7 @@ interface BackPropagationOptions {
   disableBiasAdjustment?: boolean; // Skip bias updates (default: false)
   disableWeightAdjustment?: boolean; // Skip weight updates (default: false)
   disableRandomSamples?: boolean; // Use sequential sampling (default: false)
-  learningRateStrategy?: "fixed" | "decay" | "adaptive"; // Default: random
+  learningRateStrategy?: "fixed" | "decay" | "adaptive" | "warm_restart"; // Default: random
   initialLearningRate?: number; // For decay/adaptive (default: 0.01)
   learningRateDecay?: number; // Decay factor (default: 0.95)
 }
@@ -106,15 +113,29 @@ The synthetic synapse lifecycle has three phases, all handled automatically when
 
 ### Enabling synthetic synapses
 
-Synthetic synapses are opt-in. Set `syntheticSynapses: true` in the training
-options passed to `evolveDir()`:
+Synthetic synapses are opt-in, and the switch lives on `TrainOptions` — the
+options the internal `trainDir()` entry point accepts
+(`src/config/TrainOptions.ts`).
+
+> [!WARNING]
+> `syntheticSynapses` is **not** a `NeatOptions` field, so it cannot be enabled
+> through `evolveDir()`, `evolveDataSet()`, or `createNeatConfig()`. Passing it
+> in those options is a type error, and the train options the evolution loop
+> builds internally (`src/NEAT/NeatScheduling.ts`) do not forward it. There is
+> currently no public API that turns synthetic synapses on.
+
+Internally — and in the repository's own tests — the flag is set on the options
+handed to `trainDir()`:
 
 ```typescript
-const result = await creature.evolveDir(dataDir, {
-  costName: "MSE",
+// Internal: `trainDir` is not exported from `mod.ts`. Shown for reference.
+import { trainDir } from "@architecture/Training.ts";
+import { Costs } from "@costs";
+
+const result = trainDir(creature, dataDir, {
   iterations: 100,
   syntheticSynapses: true, // Enable synthetic synapse generation
-});
+}, Costs.find("MSE"));
 ```
 
 ### Internal functions

--- a/docs/archive/pr-summaries/pr-summary-3694.md
+++ b/docs/archive/pr-summaries/pr-summary-3694.md
@@ -1,0 +1,86 @@
+# Training docs: correct the `syntheticSynapses` surface and the backprop defaults
+
+## Summary
+
+`docs/api/TRAINING.md` and `docs/config/TRAINING.md` documented
+`syntheticSynapses` as an evolution-level option and quoted three stale
+`BackPropagationOptions` facts. Both docs now match the source. Closes #3694.
+
+**`syntheticSynapses` is a `TrainOptions` key, not a `NeatOptions` key**
+
+- It is declared only on `TrainArguments` (`src/config/TrainOptions.ts:116`) and
+  read only by `prepareTraining()`
+  (`src/architecture/training/TrainingSetup.ts:201`).
+- It is not a `NeatOptions`/`NeatArguments` field, so `createNeatConfig()` never
+  reads it, and the train options the evolution loop builds internally
+  (`src/NEAT/NeatScheduling.ts:360-380`) do not forward it — `evolveDir()`
+  cannot enable it.
+- There is also no public `Creature.train()`: `trainDir()`
+  (`src/architecture/Training.ts:41`) is internal and is not re-exported from
+  `mod.ts`, so the flag is currently unreachable from the public API. Both docs
+  now say so plainly rather than showing a sample that cannot work.
+
+**Stale backprop facts corrected in `docs/api/TRAINING.md`**
+
+| Doc claim (before)                        | Source (after)                                                   |
+| ----------------------------------------- | ---------------------------------------------------------------- |
+| `generations` default "random 1–100"      | random 1–10 — `MAX_RANDOM_GENERATIONS` (`BackPropagation.ts:13`) |
+| `learningRate` default "random low value" | fixed `0.01` (`BackPropagation.ts:54`, Issue #1437)              |
+| `learningRateStrategy` union of three     | adds `"warm_restart"` (`BackPropagation.ts:96`)                  |
+
+**Exports list (Issue #3271 rule)** — `BackPropagationOptions` and
+`TrainOptions` are not re-exported from `mod.ts`, so the "Exports referenced
+here" section is now "Types referenced here" and states that consumers cannot
+import them; `NeatOptions` is named as the public configuration surface. No new
+re-exports were added, because no public function accepts either type.
+
+## Evidence
+
+Documentation-only change to a Deno library — no web interface to screenshot.
+The evidence is the new fact-check test suite, which drives the real factories
+and the real training entry point:
+
+```
+deno test --allow-all test/docs/TrainingDocsFacts.ts
+running 6 tests from ./test/docs/TrainingDocsFacts.ts
+docs/api/TRAINING.md: BackPropagationOptions defaults are as published ... ok
+docs/api/TRAINING.md: generations defaults to a random 1–MAX_RANDOM_GENERATIONS ... ok
+docs/api/TRAINING.md: learningRateStrategy accepts every documented value ... ok
+docs/api/TRAINING.md: the random default strategy can select warm_restart ... ok
+docs/config/TRAINING.md: syntheticSynapses is not a NeatOptions field ... ok
+docs/api/TRAINING.md: syntheticSynapses is opt-in on the training options ... ok
+ok | 6 passed | 0 failed
+```
+
+Where the flag can and cannot travel:
+
+```mermaid
+flowchart LR
+    N["NeatOptions / createNeatConfig()"] -->|"syntheticSynapses dropped"| X["not in NeatConfig"]
+    N --> S["NeatScheduling builds TrainOptions"]
+    S -->|"key never forwarded"| T["trainDir(creature, dir, TrainOptions, cost)"]
+    D["direct trainDir() call (internal)"] -->|"syntheticSynapses: true"| T
+    T --> P["prepareTraining() → generateSyntheticSynapses()"]
+```
+
+## Test Plan
+
+Added `test/docs/TrainingDocsFacts.ts` (6 tests, all "what" tests — no source or
+doc grepping):
+
+- `BackPropagationOptions defaults are as published` — asserts every default the
+  doc's code block quotes against `createBackPropagationConfig()`.
+- `generations defaults to a random 1–MAX_RANDOM_GENERATIONS` — pins
+  `MAX_RANDOM_GENERATIONS === 10` and the resolved range across stubbed RNG
+  draws; an explicit value is honoured unchanged.
+- `learningRateStrategy accepts every documented value` — round-trips all four
+  union members, including `"warm_restart"`.
+- `the random default strategy can select warm_restart` — a constant RNG at 0.6
+  pins the documented `[0.55, 0.75)` branch.
+- `syntheticSynapses is not a NeatOptions field` — the old doc sample's key is
+  dropped by `createNeatConfig()`, so it can never reach training.
+- `syntheticSynapses is opt-in on the training options` — trains through
+  `trainDir()` with the flag set and asserts a finite error, verifying the
+  surface the doc now points at.
+
+Full `./quality.sh` run passes (fmt, lint, type-check, all tests).

--- a/docs/config/TRAINING.md
+++ b/docs/config/TRAINING.md
@@ -2,9 +2,9 @@
 
 Training parameters control backpropagation within each NEAT (NeuroEvolution of
 Augmenting Topologies) generation: how much data is used, how aggressively
-weights/biases are updated, how dense layers become, and how the data is fuzzed
-and validated. These options sit on the top-level `NeatOptions` object or on
-dedicated nested configs (`dataFuzzing`, `crossValidation`).
+weights/biases are updated, and how the data is fuzzed and validated. These
+options sit on the top-level `NeatOptions` object or on dedicated nested configs
+(`dataFuzzing`, `crossValidation`).
 
 ```ts
 import { createNeatConfig } from "@stsoftware/neat-ai";
@@ -15,7 +15,6 @@ const config = createNeatConfig({
   trainPerGen: 10,
   trainingBatchSize: 100,
   trainingSampleRate: 1,
-  syntheticSynapses: false,
 });
 ```
 
@@ -28,7 +27,6 @@ const config = createNeatConfig({
 | `trainingBatchSize`            | `integer` | `100`                      | Observations per training batch (min: 1)                  |
 | `trainingSampleRate`           | `number`  | `1`                        | Fraction of data used for training (0.0001–1)             |
 | `dataSetPartitionBreak`        | `integer` | `2000`                     | Records per dataset file (min: 1)                         |
-| `syntheticSynapses`            | `boolean` | `false`                    | Generate dense inter-layer synapses before backprop       |
 | `maximumBiasAdjustmentScale`   | `number`  | `1`                        | Maximum bias adjustment per training iteration (min: 0)   |
 | `maximumWeightAdjustmentScale` | `number`  | `1`                        | Maximum weight adjustment per training iteration (min: 0) |
 
@@ -158,28 +156,17 @@ values allow more aggressive bias updates.
 Maximum amount by which a weight can be adjusted in one training iteration.
 Higher values allow more aggressive weight updates.
 
-## 🧪 Synthetic synapses
+## 🧪 Synthetic synapses — not a `NeatOptions` option
 
-### `syntheticSynapses`
+`syntheticSynapses` is **not** part of `NeatOptions`. It lives on the internal
+`TrainOptions` surface (`src/config/TrainOptions.ts`), which only the internal
+`trainDir()` entry point accepts. `createNeatConfig()` never reads the key, and
+the train options the evolution loop builds internally
+(`src/NEAT/NeatScheduling.ts`) do not forward it — so passing it here is a type
+error, and there is no public API that turns synthetic synapses on.
 
-**Default: false** | Type: boolean
-
-When enabled, dense zero-weight synapses are generated between adjacent
-topological layers before backpropagation begins. After training, synthetic
-synapses whose weights remain near zero are pruned, and any that have been
-trained to meaningful weights are retained as permanent connections. This allows
-backpropagation to discover useful connections that NEAT's evolutionary process
-may not have found.
-
-A per-target cap of 50 connections per target neuron per layer pair prevents
-combinatorial explosion on wide networks. Orphaned neurons are cleaned up
-automatically after pruning.
-
-> [!TIP]
-> Synthetic synapses are most beneficial for networks with sparse inter-layer
-> connectivity — typically early in evolution when NEAT has not yet built dense
-> connections between layers. For already-dense networks, the overhead may
-> outweigh the benefit.
+See [Training API — Synthetic Synapses](../api/TRAINING.md#-synthetic-synapses)
+for what the feature does and where the flag is read.
 
 ## 🎲 Data fuzzing
 

--- a/test/docs/TrainingDocsFacts.ts
+++ b/test/docs/TrainingDocsFacts.ts
@@ -1,0 +1,176 @@
+/**
+ * Issue #3694 — fact-check guard for the training docs.
+ *
+ * `docs/api/TRAINING.md` and `docs/config/TRAINING.md` describe the surface a
+ * caller programs against when training a creature. These tests pin the facts
+ * those docs publish:
+ *
+ * - the `BackPropagationOptions` defaults (`generations`, `learningRate`, …),
+ * - the full `learningRateStrategy` union, including `"warm_restart"`,
+ * - that `syntheticSynapses` lives on `TrainOptions` only — it is not a
+ *   `NeatOptions` field, so `createNeatConfig()` drops it.
+ *
+ * These are "what" tests: every assertion comes from calling the real factory
+ * or the real training entry point — not from grepping source or docs.
+ */
+
+import { assert, assertEquals, assertFalse } from "@std/assert";
+import {
+  type BackPropagationOptions,
+  createBackPropagationConfig,
+  MAX_RANDOM_GENERATIONS,
+} from "@propagate/BackPropagation.ts";
+import { Creature } from "@creature";
+import type { DataRecordInterface } from "@architecture/DataSet.ts";
+import type { CreatureExport } from "@architecture/CreatureInterfaces.ts";
+import type { TrainOptions } from "@config/TrainOptions.ts";
+import { createNeatConfig, type NeatOptions } from "../../mod.ts";
+import {
+  getRandomNumberGenerator,
+  type RandomNumberGenerator,
+  setRandomNumberGenerator,
+} from "@utils/RandomNumberGenerator.ts";
+import { train } from "../TrainTestOnlyUtil.ts";
+import { initWasmForTests } from "../_initWasm.ts";
+
+await initWasmForTests();
+
+/** RNG that always returns `value`, so a documented random branch is pinned. */
+function constantRng(value: number): RandomNumberGenerator {
+  return {
+    random: () => value,
+    randomInt: (min: number, max: number) =>
+      Math.min(max, min + Math.floor(value * (max - min + 1))),
+    choice: <T>(array: readonly T[]): T => {
+      assert(array.length > 0, "choice() needs a non-empty array");
+      return array[
+        Math.min(array.length - 1, Math.floor(value * array.length))
+      ];
+    },
+    seeded: true,
+    seed: null,
+  };
+}
+
+function withGlobalRng(rng: RandomNumberGenerator, fn: () => void): void {
+  const previous = getRandomNumberGenerator();
+  try {
+    setRandomNumberGenerator(rng);
+    fn();
+  } finally {
+    setRandomNumberGenerator(previous);
+  }
+}
+
+Deno.test("docs/api/TRAINING.md: BackPropagationOptions defaults are as published", () => {
+  const config = createBackPropagationConfig();
+
+  // Issue #1437 replaced the random learning rate with a fixed 0.01.
+  assertEquals(config.learningRate, 0.01);
+  assertEquals(config.initialLearningRate, 0.01);
+  assertEquals(config.learningRateDecay, 0.95);
+  assertEquals(config.batchSize, 64);
+  assertEquals(config.sparseRatio, 1);
+  assertEquals(config.plankConstant, 0.000_000_1);
+  assertEquals(config.maximumBiasAdjustmentScale, 1);
+  assertEquals(config.maximumWeightAdjustmentScale, 1);
+  assertEquals(config.limitBiasScale, 10_000);
+  assertEquals(config.limitWeightScale, 100_000);
+  assertFalse(config.disableBiasAdjustment);
+  assertFalse(config.disableWeightAdjustment);
+  assertFalse(config.disableRandomSamples);
+});
+
+Deno.test("docs/api/TRAINING.md: generations defaults to a random 1–MAX_RANDOM_GENERATIONS", () => {
+  // Issue #1436 reduced the published range from 1–100 to 1–10.
+  assertEquals(MAX_RANDOM_GENERATIONS, 10);
+
+  for (const draw of [0, 0.25, 0.5, 0.75, 0.999]) {
+    withGlobalRng(constantRng(draw), () => {
+      const config = createBackPropagationConfig();
+      assert(
+        config.generations >= 1 &&
+          config.generations <= MAX_RANDOM_GENERATIONS,
+        `generations ${config.generations} outside 1–${MAX_RANDOM_GENERATIONS}`,
+      );
+    });
+  }
+
+  // An explicit value is honoured unchanged.
+  assertEquals(createBackPropagationConfig({ generations: 3 }).generations, 3);
+});
+
+Deno.test("docs/api/TRAINING.md: learningRateStrategy accepts every documented value", () => {
+  const strategies: NonNullable<
+    BackPropagationOptions["learningRateStrategy"]
+  >[] = ["fixed", "decay", "adaptive", "warm_restart"];
+
+  for (const strategy of strategies) {
+    const config = createBackPropagationConfig({
+      learningRateStrategy: strategy,
+    });
+    assertEquals(config.learningRateStrategy, strategy);
+  }
+});
+
+Deno.test("docs/api/TRAINING.md: the random default strategy can select warm_restart", () => {
+  // The default selector maps [0.55, 0.75) to "warm_restart".
+  withGlobalRng(constantRng(0.6), () => {
+    assertEquals(
+      createBackPropagationConfig().learningRateStrategy,
+      "warm_restart",
+    );
+  });
+});
+
+Deno.test("docs/config/TRAINING.md: syntheticSynapses is not a NeatOptions field", () => {
+  const requested = {
+    trainPerGen: 10,
+    trainingBatchSize: 100,
+    trainingSampleRate: 1,
+    // A caller following the old doc sample passed this key; it is not part of
+    // NeatOptions, so createNeatConfig() never carries it into the config.
+    syntheticSynapses: false,
+  } as unknown as NeatOptions;
+
+  const config = createNeatConfig(requested);
+
+  assertEquals(config.trainPerGen, 10);
+  assertEquals(config.trainingBatchSize, 100);
+  assertFalse(
+    "syntheticSynapses" in config,
+    "syntheticSynapses must not appear on a resolved NeatConfig",
+  );
+});
+
+Deno.test("docs/api/TRAINING.md: syntheticSynapses is opt-in on the training options", () => {
+  const json: CreatureExport = {
+    neurons: [
+      { type: "hidden", uuid: "hidden-0", squash: "LOGISTIC", bias: 0 },
+      { type: "output", uuid: "output-0", squash: "IDENTITY", bias: 0 },
+    ],
+    synapses: [
+      { fromUUID: "input-0", toUUID: "hidden-0", weight: 0.5 },
+      { fromUUID: "hidden-0", toUUID: "output-0", weight: 0.5 },
+    ],
+    input: 2,
+    output: 1,
+  };
+  const creature = Creature.fromJSON(json);
+
+  const dataSet: DataRecordInterface[] = [
+    { input: new Float32Array([0, 0]), output: new Float32Array([0]) },
+    { input: new Float32Array([1, 0]), output: new Float32Array([1]) },
+    { input: new Float32Array([0, 1]), output: new Float32Array([1]) },
+    { input: new Float32Array([1, 1]), output: new Float32Array([0]) },
+  ];
+
+  const options: TrainOptions = {
+    iterations: 2,
+    disableRandomSamples: true,
+    syntheticSynapses: true,
+  };
+
+  const result = train(creature, dataSet, options);
+  assert(Number.isFinite(result.error), "training error should be finite");
+});


### PR DESCRIPTION
# Training docs: correct the `syntheticSynapses` surface and the backprop defaults

## Summary

`docs/api/TRAINING.md` and `docs/config/TRAINING.md` documented
`syntheticSynapses` as an evolution-level option and quoted three stale
`BackPropagationOptions` facts. Both docs now match the source. Closes #3694.

**`syntheticSynapses` is a `TrainOptions` key, not a `NeatOptions` key**

- It is declared only on `TrainArguments` (`src/config/TrainOptions.ts:116`) and
  read only by `prepareTraining()`
  (`src/architecture/training/TrainingSetup.ts:201`).
- It is not a `NeatOptions`/`NeatArguments` field, so `createNeatConfig()` never
  reads it, and the train options the evolution loop builds internally
  (`src/NEAT/NeatScheduling.ts:360-380`) do not forward it — `evolveDir()`
  cannot enable it.
- There is also no public `Creature.train()`: `trainDir()`
  (`src/architecture/Training.ts:41`) is internal and is not re-exported from
  `mod.ts`, so the flag is currently unreachable from the public API. Both docs
  now say so plainly rather than showing a sample that cannot work.

**Stale backprop facts corrected in `docs/api/TRAINING.md`**

| Doc claim (before)                        | Source (after)                                                   |
| ----------------------------------------- | ---------------------------------------------------------------- |
| `generations` default "random 1–100"      | random 1–10 — `MAX_RANDOM_GENERATIONS` (`BackPropagation.ts:13`) |
| `learningRate` default "random low value" | fixed `0.01` (`BackPropagation.ts:54`, Issue #1437)              |
| `learningRateStrategy` union of three     | adds `"warm_restart"` (`BackPropagation.ts:96`)                  |

**Exports list (Issue #3271 rule)** — `BackPropagationOptions` and
`TrainOptions` are not re-exported from `mod.ts`, so the "Exports referenced
here" section is now "Types referenced here" and states that consumers cannot
import them; `NeatOptions` is named as the public configuration surface. No new
re-exports were added, because no public function accepts either type.

## Evidence

Documentation-only change to a Deno library — no web interface to screenshot.
The evidence is the new fact-check test suite, which drives the real factories
and the real training entry point:

```
deno test --allow-all test/docs/TrainingDocsFacts.ts
running 6 tests from ./test/docs/TrainingDocsFacts.ts
docs/api/TRAINING.md: BackPropagationOptions defaults are as published ... ok
docs/api/TRAINING.md: generations defaults to a random 1–MAX_RANDOM_GENERATIONS ... ok
docs/api/TRAINING.md: learningRateStrategy accepts every documented value ... ok
docs/api/TRAINING.md: the random default strategy can select warm_restart ... ok
docs/config/TRAINING.md: syntheticSynapses is not a NeatOptions field ... ok
docs/api/TRAINING.md: syntheticSynapses is opt-in on the training options ... ok
ok | 6 passed | 0 failed
```

Where the flag can and cannot travel:

```mermaid
flowchart LR
    N["NeatOptions / createNeatConfig()"] -->|"syntheticSynapses dropped"| X["not in NeatConfig"]
    N --> S["NeatScheduling builds TrainOptions"]
    S -->|"key never forwarded"| T["trainDir(creature, dir, TrainOptions, cost)"]
    D["direct trainDir() call (internal)"] -->|"syntheticSynapses: true"| T
    T --> P["prepareTraining() → generateSyntheticSynapses()"]
```

## Test Plan

Added `test/docs/TrainingDocsFacts.ts` (6 tests, all "what" tests — no source or
doc grepping):

- `BackPropagationOptions defaults are as published` — asserts every default the
  doc's code block quotes against `createBackPropagationConfig()`.
- `generations defaults to a random 1–MAX_RANDOM_GENERATIONS` — pins
  `MAX_RANDOM_GENERATIONS === 10` and the resolved range across stubbed RNG
  draws; an explicit value is honoured unchanged.
- `learningRateStrategy accepts every documented value` — round-trips all four
  union members, including `"warm_restart"`.
- `the random default strategy can select warm_restart` — a constant RNG at 0.6
  pins the documented `[0.55, 0.75)` branch.
- `syntheticSynapses is not a NeatOptions field` — the old doc sample's key is
  dropped by `createNeatConfig()`, so it can never reach training.
- `syntheticSynapses is opt-in on the training options` — trains through
  `trainDir()` with the flag set and asserts a finite error, verifying the
  surface the doc now points at.

Full `./quality.sh` run passes (fmt, lint, type-check, all tests).



## Milestone
This PR is part of the **Scan 20260807** milestone and targets the `milestone/scan-20260807` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-mslex393-71425e`<!-- vibe-worker-issue-3694 -->