### PR TITLE
Docs: fix AGENTS.md logging example to use the public API (#3697)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -384,20 +384,22 @@ project deliberately does **not** depend on `@std/log`.
    call `setLogger()` directly:
 
    ```typescript
-   import { Neat, setLogger } from "@stsoftware/neat-ai";
+   import { Creature, type Logger, setLogger } from "@stsoftware/neat-ai";
 
-   // Option A — inject via NeatOptions
-   const neat = new Neat(input, output, fitness, {
-     logger: {
-       debug: (...a) => myPino.debug({ args: a }),
-       info: (...a) => myPino.info({ args: a }),
-       warn: (...a) => myPino.warn({ args: a }),
-       error: (...a) => myPino.error({ args: a }),
-     },
-   });
+   const myLogger: Logger = {
+     debug: (...a) => myPino.debug({ args: a }),
+     info: (...a) => myPino.info({ args: a }),
+     warn: (...a) => myPino.warn({ args: a }),
+     error: (...a) => myPino.error({ args: a }),
+   };
 
-   // Option B — set globally
-   setLogger(myCustomLogger);
+   // Option A — inject via NeatOptions on any public evolve call
+   const creature = new Creature(2, 1);
+   await creature.evolveDataSet(dataSet, { logger: myLogger, iterations: 100 });
+   // …or creature.evolveDir(dataSetDir, { logger: myLogger, iterations: 100 });
+
+   // Option B — set globally, before any evolve call
+   setLogger(myLogger);
    ```
 
    > **One entry point.** `deno.json` declares `"exports": "./mod.ts"`, so the

--- a/docs/archive/pr-summaries/pr-summary-3697.md
+++ b/docs/archive/pr-summaries/pr-summary-3697.md
@@ -1,0 +1,48 @@
+## Summary
+
+The AGENTS.md Logging Policy sample (rule 3) could not run: it imported `Neat`,
+which is internal and not re-exported from `mod.ts`, and called a
+`new Neat(input, output, fitness, options)` constructor that never existed (the
+real one is `(input, output, options, workers, fastWorkers?)`). Both breaches
+sat directly above the note forbidding them and above `docs/DOC_STYLE.md`
+rule 4.
+
+Option A is now written around the public `Creature.evolveDataSet()` /
+`evolveDir()` entry points, which take `NeatOptions` — where `logger` really
+lives (`src/config/NeatOptions.ts:203`, consumed at
+`src/config/NeatConfig.ts:753-762`). Option B (`setLogger`) is unchanged; both
+now share one `myLogger: Logger` object so the sample is copy-pasteable. Only
+the vehicle changed — no source or API change was needed. Closes #3697.
+
+## Evidence
+
+Documentation-only change; no web surface to screenshot. Verified by tests:
+
+- `test/docs/AgentsLoggingExample.ts` "AGENTS.md imports only symbols mod.ts
+  actually re-exports" fails against the old doc (`Neat`) and passes after the
+  rewrite.
+- Full gate: `./quality.sh` →
+  `ok | 8303 passed (5 steps) | 0 failed | 4 ignored`.
+
+```mermaid
+flowchart LR
+    Consumer["Consumer code"] -->|"logger in NeatOptions"| Evolve["Creature.evolveDataSet()<br/>Creature.evolveDir()"]
+    Evolve --> Config["createNeatConfig()<br/>src/config/NeatConfig.ts"]
+    Config -->|setLogger| Global["global getLogger()"]
+    Consumer -->|"Option B: setLogger()"| Global
+    Global --> Internal["all internal src/ logging"]
+```
+
+## Test Plan
+
+New `test/docs/AgentsLoggingExample.ts`:
+
+- `collectRootImportedSymbols extracts named symbols and skips type-only ones` —
+  unit test for the helper (happy path, type-only clause, other-package import).
+- `AGENTS.md imports only symbols mod.ts actually re-exports` — regression test
+  for this issue; walks every `@stsoftware/neat-ai` import in AGENTS.md and
+  checks each value symbol against the real `mod.ts` namespace (general check,
+  not a grep for `Neat`), so any future non-exported symbol is caught too.
+- `NeatOptions.logger routes NEAT-AI log output to the injected logger` — runs
+  the corrected Option A through `Creature.evolveDataSet()` and asserts the
+  injected logger becomes the active logger and receives log output.

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -389,6 +389,7 @@
     "parsable",
     "parseable",
     "passthrough",
+    "pasteable",
     "pathlib",
     "pathspecs",
     "pathx",

--- a/test/docs/AgentsLoggingExample.ts
+++ b/test/docs/AgentsLoggingExample.ts
@@ -1,0 +1,111 @@
+/**
+ * Issue #3697 — fact-check guard for the AGENTS.md Logging Policy example.
+ *
+ * The sample used to `import { Neat, … } from "@stsoftware/neat-ai"` and call a
+ * `new Neat(input, output, fitness, options)` constructor that never existed:
+ * `Neat` is internal (not re-exported from `mod.ts`) and its real signature is
+ * `(input, output, options, workers)`. Both breaches sit directly above the note
+ * that forbids them, so the doc contradicted itself.
+ *
+ * These are "what" tests: the first walks every `@stsoftware/neat-ai` import in
+ * AGENTS.md and asserts each named value symbol really is exported from the
+ * public entry point (a general check, not a grep for `Neat`); the second runs
+ * the corrected Option A through the public `Creature.evolveDataSet()` path and
+ * asserts the injected logger actually receives the log output.
+ */
+
+import { assert, assertEquals, assertGreater } from "@std/assert";
+import { Creature, getLogger, type Logger, setLogger } from "../../mod.ts";
+import * as publicApi from "../../mod.ts";
+
+/** Named symbols imported from the package root in a markdown doc. */
+export function collectRootImportedSymbols(markdown: string): string[] {
+  const importRe =
+    /import\s*\{([^}]*)\}\s*from\s*["']@stsoftware\/neat-ai["']/g;
+  const symbols: string[] = [];
+  for (const match of markdown.matchAll(importRe)) {
+    for (const clause of match[1].split(",")) {
+      const name = clause.trim().replace(/^type\s+/, "").split(/\s+as\s+/)[0]
+        .trim();
+      // Skip `import { type Foo }` — type-only symbols have no runtime binding.
+      if (name && !/^type\s/.test(clause.trim())) symbols.push(name);
+    }
+  }
+  return symbols;
+}
+
+Deno.test("collectRootImportedSymbols extracts named symbols and skips type-only ones", () => {
+  const markdown = [
+    '```ts\nimport { Creature, setLogger } from "@stsoftware/neat-ai";\n```',
+    '```ts\nimport { type Logger, getLogger } from "@stsoftware/neat-ai";\n```',
+    '```ts\nimport { Foo } from "some-other-package";\n```',
+  ].join("\n");
+
+  assertEquals(collectRootImportedSymbols(markdown), [
+    "Creature",
+    "setLogger",
+    "getLogger",
+  ]);
+});
+
+Deno.test("AGENTS.md imports only symbols mod.ts actually re-exports", async () => {
+  const markdown = await Deno.readTextFile(
+    new URL("../../AGENTS.md", import.meta.url),
+  );
+  const symbols = collectRootImportedSymbols(markdown);
+  assertGreater(
+    symbols.length,
+    0,
+    "AGENTS.md should contain an import example",
+  );
+
+  const missing = symbols.filter((name) => !(name in publicApi));
+  assertEquals(
+    missing,
+    [],
+    `AGENTS.md imports symbols not re-exported from mod.ts: ${
+      missing.join(", ")
+    }`,
+  );
+});
+
+Deno.test("NeatOptions.logger routes NEAT-AI log output to the injected logger", async () => {
+  const original = getLogger();
+  try {
+    const calls: string[] = [];
+    const myLogger: Logger = {
+      debug: (...a: unknown[]) => calls.push(`debug:${a.length}`),
+      info: (...a: unknown[]) => calls.push(`info:${a.length}`),
+      warn: (...a: unknown[]) => calls.push(`warn:${a.length}`),
+      error: (...a: unknown[]) => calls.push(`error:${a.length}`),
+    };
+
+    const trainingSet = [
+      { input: new Float32Array([0, 0]), output: new Float32Array([0]) },
+      { input: new Float32Array([0, 1]), output: new Float32Array([1]) },
+      { input: new Float32Array([1, 0]), output: new Float32Array([1]) },
+      { input: new Float32Array([1, 1]), output: new Float32Array([0]) },
+    ];
+
+    // Option A exactly as AGENTS.md now shows it.
+    const creature = new Creature(2, 1);
+    await creature.evolveDataSet(trainingSet, {
+      logger: myLogger,
+      iterations: 2,
+      populationSize: 10,
+      threads: 1,
+    });
+
+    assert(
+      getLogger() === myLogger,
+      "options.logger should become the active logger",
+    );
+    assertGreater(
+      calls.length,
+      0,
+      "the injected logger should receive NEAT-AI log output",
+    );
+  } finally {
+    setLogger(original);
+  }
+});


### PR DESCRIPTION
## Summary

The AGENTS.md Logging Policy sample (rule 3) could not run: it imported `Neat`,
which is internal and not re-exported from `mod.ts`, and called a
`new Neat(input, output, fitness, options)` constructor that never existed (the
real one is `(input, output, options, workers, fastWorkers?)`). Both breaches
sat directly above the note forbidding them and above `docs/DOC_STYLE.md`
rule 4.

Option A is now written around the public `Creature.evolveDataSet()` /
`evolveDir()` entry points, which take `NeatOptions` — where `logger` really
lives (`src/config/NeatOptions.ts:203`, consumed at
`src/config/NeatConfig.ts:753-762`). Option B (`setLogger`) is unchanged; both
now share one `myLogger: Logger` object so the sample is copy-pasteable. Only
the vehicle changed — no source or API change was needed. Closes #3697.

## Evidence

Documentation-only change; no web surface to screenshot. Verified by tests:

- `test/docs/AgentsLoggingExample.ts` "AGENTS.md imports only symbols mod.ts
  actually re-exports" fails against the old doc (`Neat`) and passes after the
  rewrite.
- Full gate: `./quality.sh` →
  `ok | 8303 passed (5 steps) | 0 failed | 4 ignored`.

```mermaid
flowchart LR
    Consumer["Consumer code"] -->|"logger in NeatOptions"| Evolve["Creature.evolveDataSet()<br/>Creature.evolveDir()"]
    Evolve --> Config["createNeatConfig()<br/>src/config/NeatConfig.ts"]
    Config -->|setLogger| Global["global getLogger()"]
    Consumer -->|"Option B: setLogger()"| Global
    Global --> Internal["all internal src/ logging"]
```

## Test Plan

New `test/docs/AgentsLoggingExample.ts`:

- `collectRootImportedSymbols extracts named symbols and skips type-only ones` —
  unit test for the helper (happy path, type-only clause, other-package import).
- `AGENTS.md imports only symbols mod.ts actually re-exports` — regression test
  for this issue; walks every `@stsoftware/neat-ai` import in AGENTS.md and
  checks each value symbol against the real `mod.ts` namespace (general check,
  not a grep for `Neat`), so any future non-exported symbol is caught too.
- `NeatOptions.logger routes NEAT-AI log output to the injected logger` — runs
  the corrected Option A through `Creature.evolveDataSet()` and asserts the
  injected logger becomes the active logger and receives log output.



## Milestone
This PR is part of the **Scan 20260807** milestone and targets the `milestone/scan-20260807` feature branch.

---

🤖 Processed by: stservice
🏷️ Run id: `vibe-msm155k2-30c236`<!-- vibe-worker-issue-3697 -->